### PR TITLE
Asteroid teams

### DIFF
--- a/zap/Spawn.cpp
+++ b/zap/Spawn.cpp
@@ -492,7 +492,7 @@ void AsteroidSpawn::spawn()
    F32 ang = TNL::Random::readF() * Float2Pi;
 
    asteroid->setPosAng(getPos(), ang);
-
+   asteroid->setTeam(getTeam());
    asteroid->addToGame(game, game->getGameObjDatabase());              // And add it to the list of game objects
    s2cSetTimeUntilSpawn(mTimer.getCurrent());
 }

--- a/zap/Spawn.cpp
+++ b/zap/Spawn.cpp
@@ -504,6 +504,8 @@ U32 AsteroidSpawn::packUpdate(GhostConnection *connection, U32 updateMask, BitSt
 
    if(stream->writeFlag(updateMask & InitialMask))
       ((GameConnection *) connection)->writeCompressedPoint(getPos(), stream);
+   if (updateMask & InitialMask)
+      writeThisTeam(stream);
 
    return 0; // retMask;
 }
@@ -517,7 +519,9 @@ void AsteroidSpawn::unpackUpdate(GhostConnection *connection, BitStream *stream)
       ((GameConnection *) connection)->readCompressedPoint(pos, stream);
 
       setPos(pos);      // Also sets object extent
+      readThisTeam(stream);
    }
+   
 }
 
 
@@ -528,7 +532,7 @@ void AsteroidSpawn::renderLayer(S32 layerIndex)
    if(layerIndex != -1)
       return;
 
-   renderAsteroidSpawn(getPos(), mTimer.getCurrent());
+   renderAsteroidSpawn(getPos(), mTimer.getCurrent(), getColor());
 #endif
 }
 
@@ -536,7 +540,7 @@ void AsteroidSpawn::renderLayer(S32 layerIndex)
 void AsteroidSpawn::renderEditor(F32 currentScale, bool snappingToWallCornersEnabled, bool renderVertices)
 {
 #ifndef ZAP_DEDICATED
-   renderAsteroidSpawnEditor(getPos(), 1/currentScale);
+   renderAsteroidSpawnEditor(getPos(), getColor(), 1/currentScale);
 #endif
 }
 
@@ -544,8 +548,42 @@ void AsteroidSpawn::renderEditor(F32 currentScale, bool snappingToWallCornersEna
 void AsteroidSpawn::renderDock()
 {
 #ifndef ZAP_DEDICATED
-   renderAsteroidSpawnEditor(getPos());
+   renderAsteroidSpawnEditor(getPos(), getColor());
 #endif
+}
+
+bool AsteroidSpawn::processArguments(S32 argc, const char** argv, Game* game)
+{
+   if (argc < 2)
+      return false;
+
+   Point pos;
+   pos.read(argv);
+   pos *= game->getLegacyGridSize();
+   for (S32 i = 0; i < argc; i++) 
+   {
+      char firstChar = argv[i][0];    // First character of arg
+
+      if ((firstChar >= 'a' && firstChar <= 'z') || (firstChar >= 'A' && firstChar <= 'Z')) //if argument doesn't just start with a number
+      {
+         if (!strnicmp(argv[i], "Team=", 5))
+            setTeam(atoi(&argv[i][5])); //set team to character 5 on this argument, indexed at 0 (Team=4)
+      }
+   }
+
+   setPos(pos);
+
+   S32 time = (argc > 2) ? atoi(argv[2]) : getDefaultRespawnTime();
+
+   setRespawnTime(time);
+
+   updateExtentInDatabase();
+
+   return true;
+}
+string AsteroidSpawn::toLevelCode() const
+{
+   return Parent::toLevelCode() + " Team=" + itos(getTeam());
 }
 
 
@@ -637,6 +675,7 @@ bool FlagSpawn::processArguments(S32 argc, const char **argv, Game *game)
       return false;
 
    setTeam(atoi(argv[0]));
+
    
    return Parent::processArguments(argc - 1, argv + 1, game);     // then read the rest of the args
 }

--- a/zap/Spawn.h
+++ b/zap/Spawn.h
@@ -183,6 +183,9 @@ public:
    void renderEditor(F32 currentScale, bool snappingToWallCornersEnabled, bool renderVertices = false);
    void renderDock();
 
+   bool processArguments(S32 argc, const char** argv, Game* game);
+   string toLevelCode() const;
+
    TNL_DECLARE_CLASS(AsteroidSpawn);
    TNL_DECLARE_RPC(s2cSetTimeUntilSpawn, (S32 millis));
 

--- a/zap/gameObjectRender.cpp
+++ b/zap/gameObjectRender.cpp
@@ -2309,14 +2309,14 @@ void renderAsteroid(const Point &pos, S32 design, F32 scaleFact)
 }
 
 
-void renderAsteroidSpawn(const Point &pos, S32 time)
+void renderAsteroidSpawn(const Point &pos, S32 time, const Color* color)
 {
    static const S32 period = 4096;  // Power of 2 please
    static const F32 invPeriod = 1 / F32(period);
 
    F32 alpha = max(0.0f, 1.0f - time * invPeriod);
 
-   renderAsteroid(pos, 2, 0.1f, &Colors::green, alpha);
+   renderAsteroid(pos, 2, 0.1f, color, alpha);
 
 //   static const F32 lines[] = {
 //         // Inner
@@ -2345,7 +2345,7 @@ void renderAsteroidSpawn(const Point &pos, S32 time)
 }
 
 
-void renderAsteroidSpawnEditor(const Point &pos, F32 scale)
+void renderAsteroidSpawnEditor(const Point &pos, const Color* color, F32 scale)
 {
    scale *= 0.8f;
    static const Point p(0,0);
@@ -2353,7 +2353,7 @@ void renderAsteroidSpawnEditor(const Point &pos, F32 scale)
    glPushMatrix();
       glTranslatef(pos.x, pos.y, 0);
       glScalef(scale, scale, 1);
-      renderAsteroid(p, 2, .1f);
+      renderAsteroid(p, 2, .1f, color, .7);
 
       drawCircle(p, 13, &Colors::white);
    glPopMatrix();

--- a/zap/gameObjectRender.h
+++ b/zap/gameObjectRender.h
@@ -232,8 +232,8 @@ void renderTestItem(const Vector<Point> &points, F32 alpha = 1);
 void renderAsteroid(const Point &pos, S32 design, F32 scaleFact);
 void renderAsteroid(const Point &pos, S32 design, F32 scaleFact, const Color *color, F32 alpha = 1);
 
-void renderAsteroidSpawn(const Point &pos, S32 time);
-void renderAsteroidSpawnEditor(const Point &pos, F32 scale = 1.0);
+void renderAsteroidSpawn(const Point &pos, S32 time, const Color* color);
+void renderAsteroidSpawnEditor(const Point &pos, const Color* color, F32 scale = 1.0);
 
 void renderResourceItem(const Vector<Point> &points, F32 alpha = 1);
 //void renderResourceItem(const Point &pos, F32 scaleFactor, const Color *color, F32 alpha);

--- a/zap/moveObject.cpp
+++ b/zap/moveObject.cpp
@@ -741,6 +741,7 @@ void MoveObject::computeCollisionResponseMoveObject(U32 stateIndex, MoveObject *
          damageInfo.damageType = DamageTypePoint;
          damageInfo.damagingObject = asteroid;
          damageInfo.impulseVector = getActualVel();
+
          if (ship->getTeam() != asteroid->getTeam())
          {
             ship->damageObject(&damageInfo);
@@ -1555,6 +1556,7 @@ void Asteroid::renderItem(const Point &pos)
 {
    if(shouldRender())
       renderAsteroid(pos, mDesign, mRadius / 89.f, getColor(), .7);
+   renderAsteroid(pos, mDesign, mRadius / 88.f, &Colors::white, .2); //since this is outside the if statement, it makes a "ghost" effect when the last asteroid is killed
 }
 
 

--- a/zap/moveObject.h
+++ b/zap/moveObject.h
@@ -317,6 +317,7 @@ private:
    S32 mSizeLeft;
    bool hasExploded;
    S32 mDesign;
+   S32 mTeam;
 
 protected:
    enum MaskBits {


### PR DESCRIPTION
https://bitfighter.org/forums/viewtopic.php?f=4&t=3107

-Asteroid spawns and asteroids now write teams to .level files as an appended "team={teamIndex}" value
-Asteroid Spawns spawn asteroids for their team, and render in that color
-Asteroids display as team's color, black team render as dark grey
-Asteroids are shootable regardless of team, but only damage ships of other teams
-Asteroids collide with ships
-Destroyed size 1 asteroids leave a momentary "shadow", it makes destroying them deeply satisfying
-You can keep a size 1 asteroid with you because it is cute, you can push it around and it won't die unless caught in crossfire, which is ok because asteroids are tribbles
-First foray into a lot of essential code
-Probably needs some cleanup, but is definitely fun
-bobdaduck was here

[teamAsteroidsTestLevel.zip](https://github.com/bitfighter/bitfighter/files/4762985/teamAsteroidsTestLevel.zip)
