### PR TITLE
Support linux snap packages.

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -1,0 +1,59 @@
+name: bitfighter
+base: core18
+version: '21'
+summary: Fast team-based space multiplayer arcade game.
+description: |
+  The fast-paced team-based outer-space multi-player arcade game.
+  Blast your friends, zap your enemies. Steal their flags and nuke their cores.
+  Customize your ship to be sneaky, or overwhelm with superior firepower.
+  It's fast, fun, and frenetic.
+
+grade: stable
+confinement: strict
+
+parts:
+  bitfighter:
+    source: .
+    plugin: cmake
+    configflags:
+      - "-DLINUX_DATA_DIR='/snap/bitfighter/current/share'"
+    build-packages:
+      - build-essential
+      - libphysfs-dev
+      - libsdl2-dev
+      - libopenal-dev
+      - libvorbis-dev
+      - libmodplug-dev
+      - libspeex-dev
+      - libpng-dev
+    stage-packages:
+      - libglu1-mesa
+      - libphysfs1
+      - libsdl2-2.0-0
+      - libopenal1
+      - libvorbis0a
+      - libvorbisfile3
+      - libmodplug1
+      - libspeex1
+      - libpng16-16
+      - libgl1
+      - libglx0
+      - libmpg123-0
+    override-pull: |
+      snapcraftctl pull
+      sed -i 's_Icon=bitfighter_Icon=share/pixmaps/bitfighter.png_g' packaging/linux/bitfighter.desktop
+apps:
+  bitfighter:
+    command: bin/bitfighter
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-gl:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xorg:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio/
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri 
+    desktop: share/applications/bitfighter.desktop
+    plugs:
+      - x11 # To create a window.
+      - opengl # To draw accelerated graphics.
+      - network # To play online.
+      - network-bind # To host a game on LAN.
+      - audio-record # To capture voice.
+      - audio-playback # To play sound effects.
+      - joystick # To allow gamepad usage.

--- a/cmake/Platform/Linux.cmake
+++ b/cmake/Platform/Linux.cmake
@@ -25,9 +25,15 @@ endif()
 
 message(STATUS "CMAKE_DATA_PATH: ${CMAKE_DATA_PATH}.  Change this by invoking cmake with -DCMAKE_DATA_PATH=<SOME_DIRECTORY>")
 
-# Quotes need to be a part of the definition or the compiler won't understand
-add_definitions(-DLINUX_DATA_DIR="${CMAKE_DATA_PATH}")
-
+# The executable will look for game assets in LINUX_DATA_DIR, hardcoded.
+# The default here is fine, but we are overridable in case a packager needs to move these after the fact.
+if (NOT LINUX_DATA_DIR)
+	# Quotes need to be a part of the definition or the compiler won't understand
+	add_definitions(-DLINUX_DATA_DIR="${CMAKE_DATA_PATH}")
+else()
+	# Yes, this is tautological. No, it does not work without it.
+	add_definitions(-DLINUX_DATA_DIR="${LINUX_DATA_DIR}")
+endif()
 
 if(NOT CMAKE_BIN_PATH)
 	set(CMAKE_BIN_PATH "${CMAKE_INSTALL_PREFIX}/bin")


### PR DESCRIPTION
Well, I kinda prefer Flatpaks or AppImages in my day to day, but if you want it, here's working Snap builds for linux. A maintainer will need to to follow the instructions over at https://snapcraft.io/build to get it listed after this merges.

The general workflow is that every time `master` moves, a webhook hits the snap store which kicks off a new `latest` build. Then, maintainers can promote particular builds to stable/release/current/whatever the "default" channel is. Feel free to decline, I'm going to try the same thing with flatpak and appimage in the coming days.

Have not tested with discord, might need an extra hole in the confinement. Verified voice and netplay work, voice requires users to give permission to record audio.