### PR TITLE
notifier: Use `/usr/bin/env python3` on Linux

### DIFF
--- a/cmake/Platform/Linux.cmake
+++ b/cmake/Platform/Linux.cmake
@@ -110,7 +110,7 @@ function(BF_PLATFORM_INSTALL targetName)
 
 	if(INSTALL_NOTIFIER)
 		# Modify python script to have the shebang
-		install(CODE "execute_process(COMMAND sed -i -e \"1s@^@#!/usr/bin/python\\\\n\\\\n@\" ${CMAKE_SOURCE_DIR}/notifier/bitfighter_notifier.py)")
+		install(CODE "execute_process(COMMAND sed -i -e \"1s@^@#!/usr/bin/env python3\\\\n\\\\n@\" ${CMAKE_SOURCE_DIR}/notifier/bitfighter_notifier.py)")
 		# Modify python script to use proper path to the system-installed icon
 		install(CODE "execute_process(COMMAND sed -i -e \"s@redship48.png@bitfighter.png@\" -e \"s@^ICON_BASE =.*@ICON_BASE = \\\"${CMAKE_DESKTOP_DATA_PATH}/pixmaps/\\\"@\" ${CMAKE_SOURCE_DIR}/notifier/bitfighter_notifier.py)")
 		install(PROGRAMS ${CMAKE_SOURCE_DIR}/notifier/bitfighter_notifier.py DESTINATION ${CMAKE_BIN_PATH} RENAME bitfighter_notifier)


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0394/#for-python-script-publishers about the mess we're in for Python versioning on Linux :)

Without this change (though it could be kept as `/usr/bin/python3` if preferred), i get this RPM error when packaging bitfighter for Mageia:
```
*** ERROR: ambiguous python shebang in /usr/games/bitfighter_notifier: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
```

I haven't checked all platforms but I believe that all Linux distros do provide `python3` out of the box, while several no longer provide the unversioned `python` (e.g. Fedora doesn't, unless you install `python-unversioned-command` which then redirects to `python3`).