### PR TITLE
CMake: Fix build against system luajit

### DIFF
--- a/zap/bitfighter_client.cmake
+++ b/zap/bitfighter_client.cmake
@@ -26,10 +26,12 @@ endif()
 if(NOT POLY2TRI_FOUND)
 	list(APPEND CLIENT_EXTRA_DEPS poly2tri)
 endif()
+if(NOT LUAJIT_FOUND)
+	list(APPEND CLIENT_EXTRA_DEPS ${LUA_LIB})
+endif()
 
 
 add_dependencies(bitfighter_client
-	${LUA_LIB}
 	tnl
 	${CLIENT_EXTRA_DEPS}
 )

--- a/zap/bitfighterd.cmake
+++ b/zap/bitfighterd.cmake
@@ -19,10 +19,12 @@ endif()
 if(NOT POLY2TRI_FOUND)
 	list(APPEND DEDICATED_EXTRA_DEPS poly2tri)
 endif()
+if(NOT LUAJIT_FOUND)
+	list(APPEND DEDICATED_EXTRA_DEPS ${LUA_LIB})
+endif()
 
 add_dependencies(bitfighterd
 	tnl
-	${LUA_LIB}
 	${DEDICATED_EXTRA_DEPS}
 )
 


### PR DESCRIPTION
Follow-up to 53a325c3b40616bcbe76990f5b3dfd94e78b87cd using the same approach.

---

To be clear, I don't think this is *correct* CMake, but I don't like CMake enough to try to figure out what's correct when they add and deprecate features all the time. The problem here is likely that you use `add_dependencies` which registers things that need to be built, when you should use `target_link_libraries` (or any of the 3 to 5 other ways to add linker flags...) to add linker flags. Seems like there's already code that register the libraries to link so it works with your fix (and this one as follow-up).