### PR TITLE
Github Actions: build Linux

### DIFF
--- a/.github/workflows/BuildPackages.yml
+++ b/.github/workflows/BuildPackages.yml
@@ -1,0 +1,21 @@
+name: Build Packages
+on:
+  push:
+    branches:
+      - master
+    tags:
+  release:
+  pull_request:
+jobs:
+  Build-Linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt-get install -y cmake libphysfs-dev libsdl2-dev libopenal-dev libvorbis-dev libmodplug-dev libspeex-dev
+      - run: cd build && cmake .. && make
+      - run: cp -R resource/* exe/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Bitfighter-Linux
+          path: |
+            exe/


### PR DESCRIPTION
This proposal spawned out of #669.
The Linux build is probably less interesting than the actual implicit rest of the wire-up, so I think we should try to separate the two when considering what this changeset does.
Let's talk through what this file does, line-by-line.

### Preamble
GitHub will treat any .yml files in .github/workflows/ as the spec for a workflow. This creates a workflow Build Packages. The "name:" block controls what the workflow's displayed name is.

This does not "fully" specify the workflow's identity, as sometimes the filename is used too. For an example, I changed the .yml file name from `PR-Builds.yml` to `BuildPackages.yml` while iterating, and now I have the same named workflow under different URLs on my personal fork of Bitfighter: [PR-Builds](https://github.com/elementc/bitfighter/actions/workflows/PR-Builds.yml) vs [BuildPackages](https://github.com/elementc/bitfighter/actions/workflows/BuildPackages.yml). This is annoying but [the GitHub team has promised to improve this story eventually](https://github.com/orgs/community/discussions/26256#discussioncomment-3250998) and [users have some manual operations maintainers can run to manually clean this up](https://github.com/orgs/community/discussions/26256#discussioncomment-3642295) if things get bad. Still I think we definitely shouldn't change a workflow's filename or pretty-name once we've settled on one, unless we really need to.

### `on` block
This controls what triggers the workflow. Here we specify that we should run these jobs when someone pushes specifically to the `master` branch, or any new tag is created. We also specify that we should run these jobs when a pull request is updated, or a Release is created.

You may wish to consult [the Events documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) for the nuances of this particular section.

### `jobs` block
This is the list of things to do when this workflow is triggered. I suspect we'll end up with one job entry in this section per supported platform. Linux might actually be the hairiest, for reasons I'll get into in a bit.

### `Build-Linux` job
Let's start by walking through what the job does.
It `runs-on` a specific kind of computer. There are a lot of Linuxes out there in the world, but the only one GitHub is hosting on our behalf is a few specific versions of Ubuntu, so I just specify the most recent Long Term Support release here. GitHub has good documentation on [the available set of provided-for-you runners](https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job) and it is possible to "host your own" if someone really wants to run a build server in a closet or something.

The actual procedure to build for Linux is then encoded in the `steps` block. We `checkout` the source code, install our build dependencies, use `cmake` to generate makefiles in the build/ directory, run `make` to compile it all, copy the contents of the resources/ directory into the exe/ directory, and then upload an artifact named `Bitfighter-Linux` to the record of the job for us to be able to download and inspect.

Two general notes about this section:
1. The `checkouts` and `upload-artifact` steps are provided by GitHub, [there are a lot of others available](https://github.com/actions) but we only really need these two.
2. Each `run` step is run relative to the root of the repository, so a `cd` command is only "effective" for the scope of that specific line.

### Nuances of building and packaging for Linux
Okay, well, this binary works but it's kinda silly because all the resources it coexists with aren't going to be where it expects. [We've personally talked in circles about this.](https://github.com/bitfighter/bitfighter/pull/638/files#diff-746c2224e110830428505a90125f4dbbaabf4ab9172fe13f255cf9367aafb9e7)
- [ ] We should make the LINUX_DATA_DIR more robust, by searching for a number of possible locations. I owe a ticket for this so it doesn't get lost.

We added support for Flatpak recently, which is great! Huge thanks to @Mailaender for that effort! I've played Bitfighter on my Steam Deck via this package and it's _awesome_. I added support for Snap, a competing format, a few years back. That format is still relevant, but Flatpak is really taking off and our Snap formatting never got into the Snap Store anyways.
- [ ] I should put up a PR to delete the Snap configs. We're in Flathub, no need to keep both around.
- [ ] I should ticket additionally building a Flatpak image directly in our Actions so that we don't accidentally regress Flathub. I may need @Mailaender 's help with "what is the entry point" for that.
- [ ] On the topic of Steam Deck, we should probably add support for the Deck's built-in controller. I owe a ticket for this.

We are _also_ building for several Linux distros via the [Open Build Service](https://build.opensuse.org/package/show/games/bitfighter). We can't really replicate that trivially for all the different distros it gives us, but the one we pitch on the website, the AppImage,  we should probably make sure we aren't regressing.
- [ ] I owe a ticket for switching this "special additional different" Linux build this creates from being what we have here to just building an AppImage since that seems like the most atomic possible result we could get.

### Conclusions
I think, in light of the above todo-list, this isn't what I'd say is capital-D Done, but I suggest this is still an excellent first step and the follow-ons are all pretty orthogonal to just "setting up any Linux build at all" so I am really thinking there's not much additional worth pursuing on this PR.

I'm a desktop Linux user, so I do not have a lot of Windows/Mac build intuition, but I am still going to also take stabs at those efforts before the end of this arc.

If you think this was a high-value contribution, please consider applying the `hacktoberfest-accepted` label so I can get credit in this year's Hacktoberfest.

Thanks for your eyes!