### PR TITLE
Fix bugs in string utility functions isHex and extractDirectory

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -60,6 +60,7 @@ TEST(StringUtilsTest, isHex)
    EXPECT_FALSE(isHex("12:345"));   // ':' comes just after '9'
    EXPECT_FALSE(isHex("@bcdef"));   // '@' comes just before 'A'
    EXPECT_FALSE(isHex("c01`"));     // '`' comes just before 'a'
+   EXPECT_FALSE(isHex(""));
 }
 
 
@@ -120,6 +121,9 @@ TEST(StringUtilsTest, extractDirectory)
    EXPECT_EQ("", extractDirectory("file.txt"));
    EXPECT_EQ("path/to", extractDirectory("path/to/"));
    EXPECT_EQ("path/to", extractDirectory("path/to/this"));
+#if !defined(TNL_OS_WIN32)
+   EXPECT_EQ("/", extractDirectory("/file.txt"));
+#endif
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -65,6 +65,9 @@ string extractDirectory(const string &path )
   if (pos == string::npos)
      return "";
 
+  if (pos == 0)
+     return path.substr(0, 1);
+
   return path.substr( 0, pos ); // Paths should never end with the slash
 }
 
@@ -1006,6 +1009,9 @@ bool isAlNum(char c)
 // Return true if str contains only hex chars
 bool isHex(const string &str)
 {
+   if(str.empty())
+      return false;
+
    for(string::size_type i = 0; i < str.length(); i++)
       if(!isHex(str[i]))
          return false;


### PR DESCRIPTION
I am an AI agent assisting with codebase maintenance.

I have identified and fixed two bugs in the string utility library `zap/stringUtils.cpp`:

1.  **isHex bug**: The function `isHex(const string &str)` incorrectly returned `true` for empty strings because the internal validation loop was skipped. It now explicitly returns `false` for empty inputs to ensure consistent behavior.
2.  **extractDirectory bug**: The function `extractDirectory(const string &path)` returned an empty string when given a path to a file in the root directory (e.g., `/file.txt`). This prevented proper path reconstruction. I updated it to return the root separator in these cases.

I have also added unit tests for both scenarios in `bitfighter_test/TestStringUtils.cpp` and verified that all string utility tests pass.

Note: I have ensured that no build artifacts were included in this submission after a code review highlighted their presence in a previous draft.

---
*PR created automatically by Jules for task [916694329944383347](https://jules.google.com/task/916694329944383347) started by @eykamp*