### PR TITLE
Fix silent word truncation in parseString utility

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -304,6 +304,21 @@ TEST(StringUtilsTest, parseString)
 }
 
 
+TEST(StringUtilsTest, parseStringTruncation)
+{
+   // Create a word longer than 126 characters (original buffer size was 126)
+   string longWord(130, 'a');
+   string input = longWord + ";short";
+
+   Vector<string> words;
+   parseString(input.c_str(), words, ';');
+
+   ASSERT_EQ(2, words.size());
+   EXPECT_EQ(longWord, words[0]);
+   EXPECT_EQ("short", words[1]);
+}
+
+
 TEST(StringUtilsTest, parseStringAndStripLeadingSlash)
 {
    Vector<string> result = parseStringAndStripLeadingSlash("/cmd arg1 arg2");

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -414,35 +414,25 @@ void parseString(const string &inputString, Vector<string> &words, char seperato
 // Splits inputString into a series of words using the specified separator; does not consider quotes; trims words
 void parseString(const char *inputString, Vector<string> &words, char seperator)
 {
-   const S32 maxlen = 126;
-   char word[maxlen + 2];
-   S32 wn = 0;       // Where we are in the word we're creating
+   string word;
    S32 isn = 0;      // Where we are in the inputString we're parsing
 
    words.clear();
 
    while(inputString[isn] != 0)
    {
-      if(inputString[isn] == seperator) 
+      if(inputString[isn] == seperator)
       {
-         word[wn] = 0;    // Add terminating NULL
-
          words.push_back(trim(word));
-
-         wn = 0;
+         word.clear();
       }
       else
       {
-         if(wn < maxlen)   // Avoid overflows
-         {
-            word[wn] = inputString[isn]; 
-            wn++; 
-         }
+         word += inputString[isn];
       }
       isn++;
    }
-   
-   word[wn] = 0;     // Add terminator
+
    words.push_back(trim(word));
 }
 


### PR DESCRIPTION
This PR fixes a bug in the `parseString(const char*, Vector<string>&, char)` utility function where words exceeding 126 characters were being silently truncated due to a fixed-size stack buffer. I replaced the buffer with `std::string` for dynamic accumulation, ensuring that words of any length are parsed correctly. I also added a unit test in `bitfighter_test/TestStringUtils.cpp` to verify the fix and prevent regressions. I am an AI agent.

---
*PR created automatically by Jules for task [15415086252452265480](https://jules.google.com/task/15415086252452265480) started by @eykamp*