### PR TITLE
Fix Vector use-after-free and Point const-correctness

### DIFF
--- a/bitfighter_test/TestPoint.cpp
+++ b/bitfighter_test/TestPoint.cpp
@@ -47,8 +47,8 @@ TEST(PointTest, SetMethods)
 
 TEST(PointTest, ArithmeticOperators)
 {
-   Point p1(1.0f, 2.0f);
-   Point p2(3.0f, 4.0f);
+   const Point p1(1.0f, 2.0f);
+   const Point p2(3.0f, 4.0f);
 
    Point p3 = p1 + p2;
    EXPECT_FLOAT_EQ(4.0f, p3.x);

--- a/bitfighter_test/TestTnlVector.cpp
+++ b/bitfighter_test/TestTnlVector.cpp
@@ -1,0 +1,30 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "tnlVector.h"
+#include "gtest/gtest.h"
+
+namespace Zap {
+
+TEST(TnlVectorTest, PopMethods)
+{
+   TNL::Vector<int> v;
+   v.push_back(1);
+   v.push_back(2);
+   v.push_back(3);
+
+   ASSERT_EQ(3, v.size());
+   EXPECT_EQ(3, v.last());
+
+   v.pop_back();
+   ASSERT_EQ(2, v.size());
+   EXPECT_EQ(2, v.last());
+
+   v.pop_front();
+   ASSERT_EQ(1, v.size());
+   EXPECT_EQ(2, v.first());
+}
+
+} // namespace Zap

--- a/tnl/tnlVector.h
+++ b/tnl/tnlVector.h
@@ -92,8 +92,8 @@ public:
 
    void push_front(const T&);
    void push_back(const T&);
-   T& pop_front();
-   T& pop_back();
+   void pop_front();
+   void pop_back();
 
    T& operator[](U32 index);
    const T& operator[](U32 index) const;
@@ -347,20 +347,16 @@ template<class T> inline void Vector<T>::push_back(const T &x)
    this->innerVector.push_back(x);
 }
 
-template<class T> inline T& Vector<T>::pop_front()
+template<class T> inline void Vector<T>::pop_front()
 {
    TNLAssert(this->innerVector.size() != 0, "Vector is empty");
-   T& t = (T&)this->innerVector[0];
    this->innerVector.erase(this->innerVector.begin());
-   return t;
 }
 
-template<class T> inline T& Vector<T>::pop_back()
+template<class T> inline void Vector<T>::pop_back()
 {
    TNLAssert(this->innerVector.size() != 0, "Vector is empty");
-   T& t = (T&)*(this->innerVector.end() - 1);
    this->innerVector.pop_back();
-   return t;
 }
 
 template<class T> inline T& Vector<T>::operator[](U32 index)

--- a/zap/Point.h
+++ b/zap/Point.h
@@ -110,7 +110,7 @@ public:
       return Point (x * f, y * f);
    }
 
-   inline Point operator/(const F32 f)
+   inline Point operator/(const F32 f) const
    {
       return Point (x / f, y / f);
    }
@@ -129,12 +129,12 @@ public:
       return *this;
    }
 
-   inline Point operator*(const Point &pt)
+   inline Point operator*(const Point &pt) const
    {
       return Point(x * pt.x, y * pt.y);
    }
 
-   inline Point operator/(const Point &pt)
+   inline Point operator/(const Point &pt) const
    {
       return Point(x / pt.x, y / pt.y);
    }

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -42,6 +42,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestStatistics.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestStringUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/main_test.cpp


### PR DESCRIPTION
Hello! I am an AI agent, and I've identified and fixed a few issues in the codebase:

1.  **Memory Safety Fix in `TNL::Vector`**: The `pop_front()` and `pop_back()` methods were returning a reference to the element just removed from the vector. This is dangerous as the reference becomes dangling immediately after the pop operation. I've changed these methods to return `void`, matching the behavior of `std::vector` and ensuring safety.
2.  **`const` Correctness in `Zap::Point`**: Several operators (`operator/` with float, and point-wise `operator*` and `operator/`) were missing the `const` qualifier. This prevented them from being used on `const Point` objects. I've added the missing qualifiers.
3.  **New Unit Tests**: I've added a new test file `bitfighter_test/TestTnlVector.cpp` to verify the `Vector` changes and updated `bitfighter_test/TestPoint.cpp` to ensure arithmetic operators work correctly on `const` objects.

All relevant tests passed successfully. I have not merged these changes into the main line codebase.

---
*PR created automatically by Jules for task [5901949462837860644](https://jules.google.com/task/5901949462837860644) started by @eykamp*