### PR TITLE
Fix bugs in Color class

### DIFF
--- a/bitfighter_test/TestColor.cpp
+++ b/bitfighter_test/TestColor.cpp
@@ -64,6 +64,11 @@ TEST(ColorTest, IntegerAndHexConstructors)
    EXPECT_FLOAT_EQ(0x34 / 255.0f, fromHex.g);
    EXPECT_FLOAT_EQ(0x56 / 255.0f, fromHex.b);
 
+   Color fromHexWithHash("#123456");
+   EXPECT_FLOAT_EQ(0x12 / 255.0f, fromHexWithHash.r);
+   EXPECT_FLOAT_EQ(0x34 / 255.0f, fromHexWithHash.g);
+   EXPECT_FLOAT_EQ(0x56 / 255.0f, fromHexWithHash.b);
+
    Color invalidHex("12345");
    EXPECT_FLOAT_EQ(0.0f, invalidHex.r);
    EXPECT_FLOAT_EQ(0.0f, invalidHex.g);
@@ -91,7 +96,13 @@ TEST(ColorTest, ReadAndSet)
    EXPECT_FLOAT_EQ(0.4f, c.g);
    EXPECT_FLOAT_EQ(0.6f, c.b);
 
+   c.set(static_cast<const Color *>(NULL));
+   EXPECT_FLOAT_EQ(0.0f, c.r);
+   EXPECT_FLOAT_EQ(0.0f, c.g);
+   EXPECT_FLOAT_EQ(0.0f, c.b);
+
    // Invalid strings should not overwrite an existing valid color.
+   c.set("0.2,0.4,0.6");
    c.set("broken");
    EXPECT_FLOAT_EQ(0.2f, c.r);
    EXPECT_FLOAT_EQ(0.4f, c.g);
@@ -125,8 +136,8 @@ TEST(ColorTest, Interpolation)
 TEST(ColorTest, ConversionHelpers)
 {
    Color c(1.0f, 0.5f, 0.0f);
-   EXPECT_EQ(0x007FFFu, c.toU32());
-   EXPECT_EQ("FF7F00", c.toHexString());
+   EXPECT_EQ(0x0080FFu, c.toU32());      // 0.5 * 255 = 127.5, rounded to 128 (0x80)
+   EXPECT_EQ("FF8000", c.toHexString());
    EXPECT_EQ("1 0.5 0", c.toRGBString());
 }
 

--- a/zap/Color.cpp
+++ b/zap/Color.cpp
@@ -63,7 +63,11 @@ Color::Color(U32 rgbInt)
 
 Color::Color(const string &hex)
 {
-   if(hex.length() != 6)
+   string hexStr = hex;
+   if(hexStr.length() > 0 && hexStr[0] == '#')
+      hexStr = hexStr.substr(1);
+
+   if(hexStr.length() != 6)
    {
       r = 0;
       g = 0;
@@ -72,9 +76,9 @@ Color::Color(const string &hex)
       return;
    }
 
-   r = strtol(hex.substr(0,2).c_str(), NULL, 16) / 255.0f;
-   g = strtol(hex.substr(2,2).c_str(), NULL, 16) / 255.0f;
-   b = strtol(hex.substr(4,2).c_str(), NULL, 16) / 255.0f;
+   r = strtol(hexStr.substr(0, 2).c_str(), NULL, 16) / 255.0f;
+   g = strtol(hexStr.substr(2, 2).c_str(), NULL, 16) / 255.0f;
+   b = strtol(hexStr.substr(4, 2).c_str(), NULL, 16) / 255.0f;
 }
 
 
@@ -96,7 +100,21 @@ void Color::interp(float t, const Color &c1, const Color &c2)
 }
 
 void Color::set(const Color &c) { r = c.r;  g = c.g;  b = c.b;  }
-void Color::set(const Color *c) { r = c->r; g = c->g; b = c->b; }
+void Color::set(const Color *c)
+{
+   if(c)
+   {
+      r = c->r;
+      g = c->g;
+      b = c->b;
+   }
+   else
+   {
+      r = 0;
+      g = 0;
+      b = 0;
+   }
+}
 
 void Color::set(const string &s)
 {
@@ -124,9 +142,9 @@ string Color::toRGBString() const
 string Color::toHexString() const
 {
    char c[7];
-   U32 ir = (U32)(CLAMP(r, 0.0f, 1.0f) * 255.0f);
-   U32 ig = (U32)(CLAMP(g, 0.0f, 1.0f) * 255.0f);
-   U32 ib = (U32)(CLAMP(b, 0.0f, 1.0f) * 255.0f);
+   U32 ir = (U32)(CLAMP(r, 0.0f, 1.0f) * 255.0f + 0.5f);
+   U32 ig = (U32)(CLAMP(g, 0.0f, 1.0f) * 255.0f + 0.5f);
+   U32 ib = (U32)(CLAMP(b, 0.0f, 1.0f) * 255.0f + 0.5f);
 
    dSprintf(c, sizeof(c), "%.2X%.2X%.2X", ir, ig, ib);
    return c;
@@ -135,9 +153,9 @@ string Color::toHexString() const
 
 U32 Color::toU32() const
 {
-   U32 ir = (U32)(CLAMP(r, 0.0f, 1.0f) * 255.0f);
-   U32 ig = (U32)(CLAMP(g, 0.0f, 1.0f) * 255.0f);
-   U32 ib = (U32)(CLAMP(b, 0.0f, 1.0f) * 255.0f);
+   U32 ir = (U32)(CLAMP(r, 0.0f, 1.0f) * 255.0f + 0.5f);
+   U32 ig = (U32)(CLAMP(g, 0.0f, 1.0f) * 255.0f + 0.5f);
+   U32 ib = (U32)(CLAMP(b, 0.0f, 1.0f) * 255.0f + 0.5f);
 
    return ir | ig << 8 | ib << 16;
 }


### PR DESCRIPTION
Hello, I am Jules, an AI software engineer. I have identified and fixed several bugs in the `Color` class:

1. **Precision Loss in Color Conversion:** The `toU32()` and `toHexString()` methods were using truncation when converting floating-point color components to integers. This caused values like `0.5f` to be converted to `127` instead of `128`. I've updated these methods to use rounding (adding `0.5f` before truncation).
2. **Missing Null Safety:** I added a null pointer check to `Color::set(const Color *c)` to prevent potential crashes.
3. **Hex String Support:** The `Color` constructor for hex strings now handles an optional `#` prefix.

I've updated the `ConversionHelpers` test case and added new tests to `bitfighter_test/TestColor.cpp` to verify these fixes. All 369 relevant tests in the `bitfighter_test` suite passed.

---
*PR created automatically by Jules for task [13897181707495405809](https://jules.google.com/task/13897181707495405809) started by @eykamp*