### PR TITLE
Fix buffer overflow in GameConnection message formatting

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -638,6 +638,31 @@ TEST(StringUtilsTest, sortingNumericPrefixAlphaSuffix)
 }
 
 
+TEST(StringUtilsTest, formatMessage)
+{
+   Vector<StringTableEntry> e;
+   e.push_back("entry0");
+   e.push_back("entry1");
+
+   Vector<StringPtr> s;
+   s.push_back("ptr0");
+
+   Vector<S32> i;
+   i.push_back(42);
+
+   EXPECT_EQ("entry0 and entry1", formatMessage("%e0 and %e1", e, s, i));
+   EXPECT_EQ("ptr0 is 42", formatMessage("%s0 is %i0", e, s, i));
+   EXPECT_EQ("plain text", formatMessage("plain text", e, s, i));
+   EXPECT_EQ("invalid %x9 tokens", formatMessage("invalid %x9 tokens", e, s, i));
+   EXPECT_EQ("out of range ", formatMessage("out of range %e9", e, s, i));
+
+   // Long string test to ensure no overflow
+   std::string longStr(500, 'a');
+   e.push_back(longStr.c_str());
+   EXPECT_EQ(longStr, formatMessage("%e2", e, s, i));
+}
+
+
 TEST(StringUtilsTest, s_fprintf)
 {
    string testFile = "test_fprintf.txt";

--- a/zap/gameConnection.cpp
+++ b/zap/gameConnection.cpp
@@ -1118,39 +1118,8 @@ TNL_IMPLEMENT_RPC(GameConnection, s2cDisplayMessageESI,
                   (color, sfx, formatString, e, s, i),
                   NetClassGroupGameMask, RPCGuaranteedOrdered, RPCDirServerToClient, 0)
 {
-   char outputBuffer[256];
-   S32 pos = 0;
-   const char *src = formatString.getString();
-   while(*src)
-   {
-      if(src[0] == '%' && (src[1] == 'e' || src[1] == 's' || src[1] == 'i') && isDigit(src[2]))
-      {
-         S32 index = src[2] - '0';
-         switch(src[1])
-         {
-            case 'e':
-               if(index < e.size())
-                  pos += dSprintf(outputBuffer + pos, 256 - pos, "%s", e[index].getString());
-               break;
-            case 's':
-               if(index < s.size())
-                  pos += dSprintf(outputBuffer + pos, 256 - pos, "%s", s[index].getString());
-               break;
-            case 'i':
-               if(index < i.size())
-                  pos += dSprintf(outputBuffer + pos, 256 - pos, "%d", i[index]);
-               break;
-         }
-         src += 3;
-      }
-      else
-         outputBuffer[pos++] = *src++;
-
-      if(pos >= 255)
-         break;
-   }
-   outputBuffer[pos] = 0;
-   displayMessage(color, sfx, outputBuffer);
+   string formatted = formatMessage(formatString.getString(), e, s, i);
+   displayMessage(color, sfx, formatted.c_str());
 }
 
 
@@ -1184,31 +1153,8 @@ TNL_IMPLEMENT_RPC(GameConnection, s2cTouchdownScored,
 
 void GameConnection::displayMessageE(U32 color, U32 sfx, StringTableEntry formatString, Vector<StringTableEntry> e)
 {
-   char outputBuffer[256];
-   S32 pos = 0;
-   const char *src = formatString.getString();
-   while(*src)
-   {
-      if(src[0] == '%' && (src[1] == 'e') && isDigit(src[2]))
-      {
-         S32 index = src[2] - '0';
-         switch(src[1])
-         {
-            case 'e':
-               if(index < e.size())
-                  pos += dSprintf(outputBuffer + pos, 256 - pos, "%s", e[index].getString());
-               break;
-         }
-         src += 3;
-      }
-      else
-         outputBuffer[pos++] = *src++;
-
-      if(pos >= 255)
-         break;
-   }
-   outputBuffer[pos] = 0;
-   displayMessage(color, sfx, outputBuffer);
+   string formatted = formatMessage(formatString.getString(), e);
+   displayMessage(color, sfx, formatted.c_str());
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -320,6 +320,42 @@ string sanitizeForSql(const string &value)
 }
 
 
+string formatMessage(const char *format, const Vector<StringTableEntry> &e, const Vector<StringPtr> &s, const Vector<S32> &i)
+{
+   string result;
+   if(!format)
+      return result;
+
+   const char *src = format;
+   while(*src)
+   {
+      if(src[0] == '%' && (src[1] == 'e' || src[1] == 's' || src[1] == 'i') && isDigit(src[2]))
+      {
+         S32 index = src[2] - '0';
+         switch(src[1])
+         {
+            case 'e':
+               if(index < e.size())
+                  result += e[index].getString();
+               break;
+            case 's':
+               if(index < s.size())
+                  result += s[index].getString();
+               break;
+            case 'i':
+               if(index < i.size())
+                  result += itos(i[index]);
+               break;
+         }
+         src += 3;
+      }
+      else
+         result += *src++;
+   }
+   return result;
+}
+
+
 bool isControlCharacter(char ch)
 {
    return ch > 0 && ch <= 0x1F;

--- a/zap/stringUtils.h
+++ b/zap/stringUtils.h
@@ -14,6 +14,8 @@
 #include "ConfigEnum.h"
 #include "tnlVector.h"     // For Vector
 #include "tnlTypes.h"
+#include "tnlNetStringTable.h"
+#include "tnlString.h"
 
 #include <string>
 #include <map>
@@ -78,6 +80,9 @@ bool isAlNum(char c);
 
 string sanitizeForJson(const char *value);
 string sanitizeForSql(const string &value);
+
+string formatMessage(const char *format, const Vector<StringTableEntry> &e = Vector<StringTableEntry>(),
+                     const Vector<StringPtr> &s = Vector<StringPtr>(), const Vector<S32> &i = Vector<S32>());
 
 bool isControlCharacter(char ch);
 bool containsControlCharacter(const char* str);


### PR DESCRIPTION
I am an AI agent. I have identified and fixed a buffer overflow vulnerability in `GameConnection.cpp` where `dSprintf` was used to accumulate strings into a fixed-size buffer without properly handling the return value of `vsnprintf`. This could lead to out-of-bounds writes if the formatted message exceeded 256 characters.

I have:
1. Refactored the problematic formatting logic into a centralized utility function `formatMessage` in `zap/stringUtils.cpp`.
2. This new utility uses `std::string` and its `operator+=` to safely build the message, avoiding fixed-size buffer issues.
3. Updated `zap/gameConnection.cpp` to use `formatMessage` in `s2cDisplayMessageESI` and `displayMessageE`.
4. Added comprehensive unit tests for `formatMessage` in `bitfighter_test/TestStringUtils.cpp`, including tests with long strings that would have triggered the original overflow.
5. Ensured all new and existing tests pass.

The changes improve the security and robustness of the network message handling.

---
*PR created automatically by Jules for task [18402349617011179582](https://jules.google.com/task/18402349617011179582) started by @eykamp*