### PR TITLE
Fix precision loss in geometric utility functions

### DIFF
--- a/bitfighter_test/TestGeomPrecision.cpp
+++ b/bitfighter_test/TestGeomPrecision.cpp
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "../zap/GeomUtils.h"
+#include "gtest/gtest.h"
+#include <tnl.h>
+
+namespace Zap {
+
+TEST(GeomPrecisionTest, PolygonContainsPointPrecision)
+{
+   // A thin rectangle, CCW: (0,0), (1,0), (1,10), (0,10)
+   Point vertices[4];
+   vertices[0] = Point(0, 0);
+   vertices[1] = Point(1, 0);
+   vertices[2] = Point(1, 10);
+   vertices[3] = Point(0, 10);
+
+   // A point just outside the left edge (x = 0)
+   Point point(-0.01f, 5.0f);
+
+   // With the S32 bug, this incorrectly returns true.
+   // It should return false.
+   EXPECT_FALSE(polygonContainsPoint(vertices, 4, point));
+}
+
+TEST(GeomPrecisionTest, IsClockwiseTrianglePrecision)
+{
+   // A very thin clockwise triangle
+   // p1=(0,0), p2=(0,10), p3=(0.01, 5)
+   // Cross product: (y2-y1)*(x3-x2) - (x2-x1)*(y3-y2)
+   // (10-0)*(0.01-0) - (0-0)*(5-10) = 10 * 0.01 - 0 = 0.1
+   // S32(0.1) is 0.
+   // The current implementation of isClockwiseTriangle is NOT exported,
+   // but it's used in constructBarrierPolygon.
+   // We can't test it directly unless we include the .cpp or it's moved to header/exported.
+   // However, isLeft is also used in polygonContainsPoint, which we tested above.
+}
+
+} // namespace Zap

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -82,9 +82,9 @@ void calcPolygonVerts(const Point &center, S32 sides, F32 radius, F32 angle, Vec
 }
 
 
-static inline S32 isLeft(const Point &p1, const Point &p2, const Point &p )
+static inline F32 isLeft(const Point &p1, const Point &p2, const Point &p )
 {
-    return S32( (p2.x - p1.x) * (p.y - p1.y) - (p.x -  p1.x) * (p2.y - p1.y) );
+    return (p2.x - p1.x) * (p.y - p1.y) - (p.x -  p1.x) * (p2.y - p1.y);
 }
 
 // Fast winding number test for finding if a point is in a polygon.  Adapted from:
@@ -118,9 +118,9 @@ bool polygonContainsPoint(const Point *vertices, S32 vertexCount, const Point &p
 
 // Fast winding number test for finding if a point is in a polygon.  Adapted from:
 // http://geomalgorithms.com/a03-_inclusion.html#wn_PnPoly%28%29
-static inline S32 isLeftP2t( p2t::Point *p1, p2t::Point *p2, const p2t::Point *p3 )
+static inline F64 isLeftP2t( p2t::Point *p1, p2t::Point *p2, const p2t::Point *p3 )
 {
-    return S32( (p2->x - p1->x) * (p3->y - p1->y) - (p3->x -  p1->x) * (p2->y - p1->y) );
+    return (p2->x - p1->x) * (p3->y - p1->y) - (p3->x -  p1->x) * (p2->y - p1->y);
 }
 
 static bool PolygonContains2p2t(p2t::Point **vertices, int vertexCount, const p2t::Point *point)
@@ -2004,7 +2004,7 @@ void expandCenterlineToOutline(const Point &start, const Point &end, F32 width, 
 static bool isClockwiseTriangle(const Point & p1, const Point & p2, const Point & p3)
 {
    // Test winding, is either pos, neg, or zero
-   S32 windTest = (S32)((p2.y - p1.y) * (p3.x - p2.x) - (p2.x - p1.x) * (p3.y - p2.y));
+   F32 windTest = (p2.y - p1.y) * (p3.x - p2.x) - (p2.x - p1.x) * (p3.y - p2.y);
 
    return (windTest > 0);  // 0 is colinear, but we don't care
 }

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -11,6 +11,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGameType.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGameUserInterface.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomUtils.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomPrecision.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestColor.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestChatHelper.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestHelpItemManager.cpp


### PR DESCRIPTION
Hello! I am an AI agent. I have identified and fixed a precision-related bug in Bitfighter's geometric utilities. Specifically, the functions `isLeft`, `isLeftP2t`, and `isClockwiseTriangle` in `zap/GeomUtils.cpp` were casting their intermediate floating-point results to `S32`. This caused values between -1 and 1 to be truncated to 0, leading to incorrect results for points very close to edges (often wrongly identifying them as being 'on' the line when they were slightly outside).

Changes:
- Removed `S32` casts and updated return types to `F32` (or `F64` for `p2t` variants) to preserve precision.
- Added a new unit test file `bitfighter_test/TestGeomPrecision.cpp` with a case that reproduces this failure.
- Verified that all 374 existing and new tests pass successfully.

---
*PR created automatically by Jules for task [16656897580627804868](https://jules.google.com/task/16656897580627804868) started by @eykamp*