### PR TITLE
Fix precision bug in geometric orientation tests

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -455,6 +455,39 @@ TEST(GeomUtilsTest, polygonContainsPoint)
    EXPECT_FALSE(polygonContainsPoint(square.address(), square.size(), Point(10.1f, 10.1f)));
 }
 
+TEST(GeomUtilsTest, polygonContainsPointPrecisionBug)
+{
+   // Square polygon
+   Vector<Point> square;
+   square.push_back(Point(0, 0));
+   square.push_back(Point(10, 0));
+   square.push_back(Point(10, 10));
+   square.push_back(Point(0, 10));
+
+   // Point slightly outside on the left
+   // isLeft should be -0.01, but truncated to 0, causing polygonContainsPoint to return true incorrectly
+   EXPECT_FALSE(polygonContainsPoint(square.address(), square.size(), Point(-0.001f, 5.0f)));
+
+   // Point slightly inside on the left
+   // isLeft should be 0.01, but truncated to 0, causing polygonContainsPoint to return false incorrectly
+   // Actually, for (0.001, 5), edge (0,10)->(0,0) is a downward crossing.
+   // isLeft is (0-0)*(5-10) - (0.001-0)*(0-10) = 0.01
+   // Counter starts at 1 from edge (10,0)->(10,10)
+   // Downward crossing edge (0,10)->(0,0) should NOT decrement counter if point is left of it (inside)
+   // 0.01 > 0, so it's not < 0. Counter remains 1. Correct.
+   EXPECT_TRUE(polygonContainsPoint(square.address(), square.size(), Point(0.001f, 5.0f)));
+
+   // Point slightly outside on the right
+   // Edge (10,0) -> (10,10) is upward crossing.
+   // isLeft((10,0), (10,10), (10.001, 5)) = (10-10)*(5-0) - (10.001-10)*(10-0) = -0.01
+   // Truncated to 0. 0 > 0 is false. Counter remains 0. Correct (outside).
+
+   // Point slightly inside on the right
+   // isLeft((10,0), (10,10), (9.999, 5)) = (10-10)*(5-0) - (9.999-10)*(10-0) = 0.01
+   // Truncated to 0. 0 > 0 is false. Counter remains 0. WRONG (inside).
+   EXPECT_TRUE(polygonContainsPoint(square.address(), square.size(), Point(9.999f, 5.0f)));
+}
+
 TEST(GeomUtilsTest, polygonContainsPointTriangle)
 {
    Vector<Point> tri;

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -82,9 +82,9 @@ void calcPolygonVerts(const Point &center, S32 sides, F32 radius, F32 angle, Vec
 }
 
 
-static inline S32 isLeft(const Point &p1, const Point &p2, const Point &p )
+static inline F64 isLeft(const Point &p1, const Point &p2, const Point &p )
 {
-    return S32( (p2.x - p1.x) * (p.y - p1.y) - (p.x -  p1.x) * (p2.y - p1.y) );
+    return ( (F64(p2.x) - p1.x) * (F64(p.y) - p1.y) - (F64(p.x) -  p1.x) * (F64(p2.y) - p1.y) );
 }
 
 // Fast winding number test for finding if a point is in a polygon.  Adapted from:
@@ -118,9 +118,9 @@ bool polygonContainsPoint(const Point *vertices, S32 vertexCount, const Point &p
 
 // Fast winding number test for finding if a point is in a polygon.  Adapted from:
 // http://geomalgorithms.com/a03-_inclusion.html#wn_PnPoly%28%29
-static inline S32 isLeftP2t( p2t::Point *p1, p2t::Point *p2, const p2t::Point *p3 )
+static inline F64 isLeftP2t( p2t::Point *p1, p2t::Point *p2, const p2t::Point *p3 )
 {
-    return S32( (p2->x - p1->x) * (p3->y - p1->y) - (p3->x -  p1->x) * (p2->y - p1->y) );
+    return ( (p2->x - p1->x) * (p3->y - p1->y) - (p3->x -  p1->x) * (p2->y - p1->y) );
 }
 
 static bool PolygonContains2p2t(p2t::Point **vertices, int vertexCount, const p2t::Point *point)
@@ -2004,7 +2004,7 @@ void expandCenterlineToOutline(const Point &start, const Point &end, F32 width, 
 static bool isClockwiseTriangle(const Point & p1, const Point & p2, const Point & p3)
 {
    // Test winding, is either pos, neg, or zero
-   S32 windTest = (S32)((p2.y - p1.y) * (p3.x - p2.x) - (p2.x - p1.x) * (p3.y - p2.y));
+   F64 windTest = (F64(p2.y) - p1.y) * (F64(p3.x) - p2.x) - (F64(p2.x) - p1.x) * (F64(p3.y) - p2.y);
 
    return (windTest > 0);  // 0 is colinear, but we don't care
 }


### PR DESCRIPTION
This PR fixes a precision bug in `zap/GeomUtils.cpp` where the results of cross-product calculations used for orientation tests (winding number) were being truncated to 32-bit integers (`S32`). This truncation caused points very close to polygon edges to be incorrectly classified. The fix involves using 64-bit floating-point numbers (`F64`) for these calculations and return types. A new unit test has been added to `bitfighter_test/TestGeomUtils.cpp` to verify the fix and prevent regressions.

I am an AI agent. I have verified these changes by running the full test suite (373 tests), all of which passed.

---
*PR created automatically by Jules for task [1326004260764712975](https://jules.google.com/task/1326004260764712975) started by @eykamp*