### PR TITLE
Fix bugs in stripExtension and findCentroid

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -1012,6 +1012,22 @@ TEST(GeomUtilsTest, findCentroidSquare)
    EXPECT_NEAR(5.0f, c.y, 0.01f);
 }
 
+TEST(GeomUtilsTest, findCentroidSmallPolygon)
+{
+   Vector<Point> poly;
+   // Square (0,0) to (0.1, 0.1) with an extra vertex on one side
+   poly.push_back(Point(0, 0));
+   poly.push_back(Point(0.1, 0));
+   poly.push_back(Point(0.1, 0.05)); // Extra vertex
+   poly.push_back(Point(0.1, 0.1));
+   poly.push_back(Point(0, 0.1));
+
+   Point c = findCentroid(poly);
+   // Should be (0.05, 0.05). If it falls back to mean2d, it will be (0.06, 0.05).
+   EXPECT_NEAR(0.05f, c.x, 0.001f);
+   EXPECT_NEAR(0.05f, c.y, 0.001f);
+}
+
 TEST(GeomUtilsTest, findCentroidEmptyReturnOrigin)
 {
    Vector<Point> empty;

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -169,6 +169,11 @@ TEST(StringUtilsTest, stripExtension)
    EXPECT_EQ("path.to/file", stripExtension("path.to/file"));
    EXPECT_EQ("file", stripExtension("file"));
    EXPECT_EQ("/path.with.dots/file", stripExtension("/path.with.dots/file"));
+
+   // Bug fixes: filenames starting with a dot or where the only dot is immediately after a slash
+   EXPECT_EQ(".hidden", stripExtension(".hidden"));
+   EXPECT_EQ("path/.hidden", stripExtension("path/.hidden"));
+   EXPECT_EQ("path\\.hidden", stripExtension("path\\.hidden"));
 }
 
 

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -1742,14 +1742,14 @@ Point findCentroid(const Vector<Point> &polyPoints)
    area = (p1.x * p2.y - p2.x * p1.y);
    sArea += area;
 
+   x += (p1.x + p2.x) * area;
+   y += (p1.y + p2.y) * area;
+
    // Zero area means it's likely a complex polygon or something with all points
    // colinear. Return the 2D mean of all the points to avoid NaN and INF issues
    // It's not great, but maybe good enough
-   if(abs(sArea) < 1)  // This is about zero for a floating point number
+   if(abs(sArea) < 1e-6)  // This is about zero for a floating point number
       return mean2d(polyPoints);
-
-   x += (p1.x + p2.x) * area;
-   y += (p1.y + p2.y) * area;
 
    // Finish up
    sArea *= 3.0;  // 0.5 * 6  (from area6)

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -182,11 +182,15 @@ string replaceString(const string &strString, const string &from, const string &
 string stripExtension(string filename)
 {
    string::size_type dotPos = filename.find_last_of('.');
-   if (dotPos == string::npos)
+   if (dotPos == string::npos || dotPos == 0)      // If no dot, or it's the first char, there is no extension
       return filename;
 
    string::size_type slashPos = filename.find_last_of("\\/");
    if (slashPos != string::npos && dotPos < slashPos)
+      return filename;
+
+   // Edge case: if the only dot is the one immediately following a slash, it's not an extension
+   if (slashPos != string::npos && dotPos == slashPos + 1)
       return filename;
 
    return filename.substr(0, dotPos);


### PR DESCRIPTION
Identified and fixed two bugs:
1. `stripExtension` incorrectly handled filenames starting with a dot (e.g., `.hidden`). Added logic to treat leading dots as part of the filename, not as an extension separator.
2. `findCentroid` used a threshold of `1.0` for its zero-area check, which caused it to fall back to the less accurate `mean2d` (vertex averaging) for small polygons. Reduced the threshold to `1e-6` and ensured the final segment is included in the area calculation before the check.

Added corresponding unit tests in `bitfighter_test/TestStringUtils.cpp` and `bitfighter_test/TestGeomUtils.cpp`. Verified the fixes with both new unit tests and standalone reproduction scripts.

I am an AI agent assisting with these changes.

---
*PR created automatically by Jules for task [393732645484068891](https://jules.google.com/task/393732645484068891) started by @eykamp*