### PR TITLE
Fix precision issues and boundary bugs in geometry utilities

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -1127,6 +1127,34 @@ TEST(GeomUtilsTest, removeCollinearPointsDuplicates)
    EXPECT_LT(pts.size(), 4);
 }
 
+TEST(GeomUtilsTest, removeCollinearPointsDuplicatesAtEnd)
+{
+   Vector<Point> pts;
+   pts.push_back(Point(0, 0));
+   pts.push_back(Point(1, 1));
+   pts.push_back(Point(1, 1));
+
+   removeCollinearPoints(pts, false);
+
+   ASSERT_EQ(2, pts.size());
+   EXPECT_EQ(Point(0, 0), pts[0]);
+   EXPECT_EQ(Point(1, 1), pts[1]);
+}
+
+TEST(GeomUtilsTest, removeCollinearPointsDegenerate)
+{
+   Vector<Point> pts;
+   pts.push_back(Point(0, 0));
+   removeCollinearPoints(pts, true);
+   ASSERT_EQ(1, pts.size());
+
+   pts.clear();
+   pts.push_back(Point(0, 0));
+   pts.push_back(Point(0, 0));
+   removeCollinearPoints(pts, true);
+   ASSERT_EQ(1, pts.size());
+}
+
 
 // ============================================================
 // createPolygon / calcPolygonVerts
@@ -1189,6 +1217,22 @@ TEST(GeomUtilsTest, isWoundClockwiseCCW)
    ccw.push_back(Point(10, 10));
    ccw.push_back(Point(0, 10));
    EXPECT_FALSE(isWoundClockwise(ccw));
+}
+
+TEST(GeomUtilsTest, isWoundClockwiseLargeCoordinates)
+{
+   F32 offset = 1e7;
+   Vector<Point> ccw;
+   ccw.push_back(Point(offset, offset));
+   ccw.push_back(Point(offset + 10, offset));
+   ccw.push_back(Point(offset, offset + 10));
+   EXPECT_FALSE(isWoundClockwise(ccw));
+
+   Vector<Point> cw;
+   cw.push_back(Point(offset, offset));
+   cw.push_back(Point(offset, offset + 10));
+   cw.push_back(Point(offset + 10, offset));
+   EXPECT_TRUE(isWoundClockwise(cw));
 }
 
 TEST(GeomUtilsTest, isWoundClockwiseTriangleCW)

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -154,29 +154,33 @@ static bool PolygonContains2p2t(p2t::Point **vertices, int vertexCount, const p2
 void removeCollinearPoints(Vector<Point> &points, bool isPolygon)
 {
    // Check for duplicate points
-   for(S32 i = 1; i < points.size() - 1; i++)
+   for(S32 i = 1; i < points.size(); i++)
       if(points[i-1] == points[i])
       {
          points.erase(i);
          i--;
       }
 
+   if(points.size() < 3)
+      return;
 
    for(S32 i = 1; i < points.size() - 1; i++)
    {
-      S32 j = i;
-      while(i < points.size() - 1 && (points[j] - points[j-1]).ATAN2() == (points[i+1] - points[i]).ATAN2())
+      if((points[i] - points[i-1]).ATAN2() == (points[i+1] - points[i]).ATAN2())
+      {
          points.erase(i);
+         i--;
+      }
    }
 
-   if(isPolygon)
+   if(isPolygon && points.size() >= 3)
    {
       // Handle wrap-around, where second-to-last, last, and first are collinear
-      while((points[points.size() - 2] - points[points.size() - 1]).ATAN2() == (points[points.size() - 1] - points[0]).ATAN2())
+      while(points.size() >= 3 && (points[points.size() - 2] - points[points.size() - 1]).ATAN2() == (points[points.size() - 1] - points[0]).ATAN2())
          points.erase(points.size() - 1);
 
       // Handle wrap-around, where last, first, and second are collinear
-      while((points[points.size() - 1] - points[0]).ATAN2() == (points[0] - points[1]).ATAN2())
+      while(points.size() >= 3 && (points[points.size() - 1] - points[0]).ATAN2() == (points[0] - points[1]).ATAN2())
          points.erase(0);
    }
 }
@@ -1501,13 +1505,13 @@ Vector<Point> floatsToPoints(const Vector<F32> floats)
 // http://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-points-are-in-clockwise-order/1165943#1165943
 bool isWoundClockwise(const Vector<Point>& inputPoly)
 {
-   F32 finalSum = 0;
+   F64 finalSum = 0;
    S32 i_prev = inputPoly.size() - 1;
 
    for(S32 i = 0; i < inputPoly.size(); i++)
    {
       // (x2-x1)(y2+y1)
-      finalSum += (inputPoly[i].x - inputPoly[i_prev].x) * (inputPoly[i].y + inputPoly[i_prev].y);
+      finalSum += (F64(inputPoly[i].x) - inputPoly[i_prev].x) * (F64(inputPoly[i].y) + inputPoly[i_prev].y);
       i_prev = i;
    }
 

--- a/zap/Point.cpp
+++ b/zap/Point.cpp
@@ -136,9 +136,9 @@ void Point::setPolar(const F32 l, const F32 ang)
    y = sin(ang) * l;
 }
 
-F32 Point::determinant(const Point &p)
+F64 Point::determinant(const Point &p) const
 {
-   return (x * p.y - y * p.x);
+   return (F64(x) * p.y - F64(y) * p.x);
 }
 
 void Point::scaleFloorDiv(float scaleFactor, float divFactor)

--- a/zap/Point.h
+++ b/zap/Point.h
@@ -60,7 +60,7 @@ public:
    void setAngle(const F32 ang);
    void setPolar(const F32 l, const F32 ang);
 
-   F32 determinant(const Point &p);
+   F64 determinant(const Point &p) const;
 
    void scaleFloorDiv(float scaleFactor, float divFactor);
 


### PR DESCRIPTION
This submission addresses several bugs and precision issues in the geometry utility functions of the Bitfighter codebase.

### Changes:
- **`removeCollinearPoints`**: Fixed a loop boundary bug that caused duplicate points at the end of the vector to be skipped. Added safety checks to prevent crashes or underflows on degenerate point sets (fewer than 3 vertices).
- **`isWoundClockwise`**: Updated to use `F64` (double precision) for its accumulation sum and intermediate products. This fixes a bug where large coordinates (e.g., > 10^7) caused precision loss that could lead to incorrect winding results.
- **`Point::determinant`**: Upgraded to return `F64` and perform internal calculations with double precision to ensure more robust orientation tests. Also marked the method as `const`.
- **Unit Tests**: Added new test cases to `bitfighter_test/TestGeomUtils.cpp` covering duplicate points at the end of a vector, degenerate sets, and winding order with large coordinates.

These fixes improve the overall stability and accuracy of geometric calculations within the engine.

I am Jules, an AI software engineer assisting with these changes.

---
*PR created automatically by Jules for task [17529089905053926137](https://jules.google.com/task/17529089905053926137) started by @eykamp*