### PR TITLE
Fix floating-point precision bugs in geometric functions

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -958,6 +958,18 @@ TEST(GeomUtilsTest, areaSignDependsOnWinding)
    EXPECT_TRUE(area(cw) * area(ccw) < 0.0f);
 }
 
+TEST(GeomUtilsTest, areaLargeCoordinates)
+{
+   F32 offset = 1e6f;
+   Vector<Point> square;
+   square.push_back(Point(offset, offset));
+   square.push_back(Point(offset + 10, offset));
+   square.push_back(Point(offset + 10, offset + 10));
+   square.push_back(Point(offset, offset + 10));
+
+   EXPECT_NEAR(100.0f, fabs(area(square)), 0.001f);
+}
+
 
 // ============================================================
 // mean2d
@@ -1010,6 +1022,20 @@ TEST(GeomUtilsTest, findCentroidSquare)
    Point c = findCentroid(square);
    EXPECT_NEAR(5.0f, c.x, 0.01f);
    EXPECT_NEAR(5.0f, c.y, 0.01f);
+}
+
+TEST(GeomUtilsTest, findCentroidLargeCoordinates)
+{
+   F32 offset = 1e6f;
+   Vector<Point> square;
+   square.push_back(Point(offset, offset));
+   square.push_back(Point(offset + 10, offset));
+   square.push_back(Point(offset + 10, offset + 10));
+   square.push_back(Point(offset, offset + 10));
+
+   Point c = findCentroid(square);
+   EXPECT_NEAR(offset + 5.0f, c.x, 0.01f);
+   EXPECT_NEAR(offset + 5.0f, c.y, 0.01f);
 }
 
 TEST(GeomUtilsTest, findCentroidSmallPolygon)
@@ -1713,6 +1739,18 @@ TEST(GeomUtilsTest, isConvexPoint)
 {
    Vector<Point> poly;
    poly.push_back(Point(0, 0));
+   EXPECT_TRUE(isConvex(&poly));
+}
+
+TEST(GeomUtilsTest, isConvexLargeCoordinates)
+{
+   F32 offset = 1e6f;
+   Vector<Point> poly;
+   poly.push_back(Point(offset, offset));
+   poly.push_back(Point(offset + 10, offset));
+   poly.push_back(Point(offset + 10, offset + 10));
+   poly.push_back(Point(offset, offset + 10));
+
    EXPECT_TRUE(isConvex(&poly));
 }
 

--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -1815,4 +1815,87 @@ TEST(GeomUtilsTest, segmentsColinearPerpendicular)
                                   Point(5, 5), Point(5, -5), 1.0f));
 }
 
+TEST(GeomUtilsTest, areaRightTriangle)
+{
+   Vector<Point> tri;
+   tri.push_back(Point(0, 0));
+   tri.push_back(Point(10, 0));
+   tri.push_back(Point(0, 10));
+   // Area = 0.5 * 10 * 10 = 50
+   EXPECT_NEAR(50.0f, fabs(area(tri)), 0.001f);
+}
+
+TEST(GeomUtilsTest, areaTinyPolygonLargeCoords)
+{
+   F32 offset = 1e7f;
+   Vector<Point> square;
+   square.push_back(Point(offset, offset));
+   square.push_back(Point(offset + 1, offset));
+   square.push_back(Point(offset + 1, offset + 1));
+   square.push_back(Point(offset, offset + 1));
+
+   // Area = 1 * 1 = 1
+   // With float, 1e7 * 1e7 = 1e14, float has ~7 digits, 1e14 + 1 is lost.
+   EXPECT_NEAR(1.0f, fabs(area(square)), 0.001f);
+}
+
+TEST(GeomUtilsTest, findCentroidLShape)
+{
+   // L-shape from (0,0) to (10,10) with width 5
+   Vector<Point> lshape;
+   lshape.push_back(Point(0, 0));
+   lshape.push_back(Point(10, 0));
+   lshape.push_back(Point(10, 5));
+   lshape.push_back(Point(5, 5));
+   lshape.push_back(Point(5, 10));
+   lshape.push_back(Point(0, 10));
+
+   // Area = (10*5) + (5*5) = 75
+   // Centroid of (10x5) rect at (5, 2.5), weighted by area 50
+   // Centroid of (5x5) rect at (2.5, 7.5), weighted by area 25
+   // x = (50*5 + 25*2.5) / 75 = (250 + 62.5) / 75 = 312.5 / 75 = 4.1666
+   // y = (50*2.5 + 25*7.5) / 75 = (125 + 187.5) / 75 = 312.5 / 75 = 4.1666
+   Point c = findCentroid(lshape);
+   EXPECT_NEAR(4.1666f, c.x, 0.01f);
+   EXPECT_NEAR(4.1666f, c.y, 0.01f);
+}
+
+TEST(GeomUtilsTest, findCentroidDegenerateLine)
+{
+   Vector<Point> line;
+   line.push_back(Point(0, 0));
+   line.push_back(Point(10, 0));
+   line.push_back(Point(20, 0));
+
+   // Area is 0, should fall back to mean2d
+   Point c = findCentroid(line);
+   EXPECT_NEAR(10.0f, c.x, 0.01f);
+   EXPECT_NEAR(0.0f, c.y, 0.01f);
+}
+
+TEST(GeomUtilsTest, isConvexVeryThinTriangle)
+{
+   Vector<Point> tri;
+   tri.push_back(Point(0, 0));
+   tri.push_back(Point(1000, 0));
+   tri.push_back(Point(500, 0.01)); // Very thin
+
+   EXPECT_TRUE(isConvex(&tri));
+}
+
+TEST(GeomUtilsTest, isConvexConcaveC)
+{
+   // C-shape
+   Vector<Point> cshape;
+   cshape.push_back(Point(0, 0));
+   cshape.push_back(Point(10, 0));
+   cshape.push_back(Point(10, 10));
+   cshape.push_back(Point(0, 10));
+   cshape.push_back(Point(0, 8));
+   cshape.push_back(Point(8, 8));
+   cshape.push_back(Point(8, 2));
+   cshape.push_back(Point(0, 2));
+
+   EXPECT_FALSE(isConvex(&cshape));
+}
 }; // namespace Zap

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -252,9 +252,17 @@ bool isConvex(const Vector<Point> *verts)
    double sign = 0;
    for(int i = 0; i < n; i++)
    {
-      Point v1 = verts->get((i + 1) % n) - verts->get(i);
-      Point v2 = verts->get((i + 2) % n) - verts->get((i + 1) % n);
-      double det = v1.determinant(v2);
+      const Point &p1 = verts->get(i);
+      const Point &p2 = verts->get((i + 1) % n);
+      const Point &p3 = verts->get((i + 2) % n);
+
+      // Perform subtraction in F64 to maintain precision
+      F64 v1x = F64(p2.x) - p1.x;
+      F64 v1y = F64(p2.y) - p1.y;
+      F64 v2x = F64(p3.x) - p2.x;
+      F64 v2y = F64(p3.y) - p2.y;
+
+      double det = v1x * v2y - v1y * v2x;
       if(det != 0)
       {
          if(sign == 0)
@@ -771,12 +779,12 @@ F32 area(const Vector<Point> &contour)
 {
   int n = contour.size();
 
-  float A = 0.0f;
+  F64 A = 0.0;
 
   for(int p = n-1, q = 0; q < n; p = q++)
-    A += contour[p].x * contour[q].y - contour[q].x * contour[p].y;
+    A += F64(contour[p].x) * contour[q].y - F64(contour[q].x) * contour[p].y;
 
-  return A * 0.5f;
+  return (F32)(A * 0.5);
 }
 
    /*
@@ -1718,10 +1726,10 @@ Point findCentroid(const Vector<Point> &polyPoints)
    if(size == 0)
       return Point(0,0);
 
-   F32 x = 0;
-   F32 y = 0;
-   F32 sArea = 0;  // Signed area
-   F32 area = 0;   // Partial signed area
+   F64 x = 0;
+   F64 y = 0;
+   F64 sArea = 0;  // Signed area
+   F64 area = 0;   // Partial signed area
 
    Point p1;
    Point p2;
@@ -1732,27 +1740,27 @@ Point findCentroid(const Vector<Point> &polyPoints)
       p1 = polyPoints[i];
       p2 = polyPoints[i+1];
 
-      area = (p1.x * p2.y - p2.x * p1.y);
+      area = (F64(p1.x) * p2.y - F64(p2.x) * p1.y);
       sArea += area;
 
-      x += (p1.x + p2.x) * area;
-      y += (p1.y + p2.y) * area;
+      x += F64(p1.x + p2.x) * area;
+      y += F64(p1.y + p2.y) * area;
    }
 
    // Do last segment
    p1 = polyPoints[size - 1];
    p2 = polyPoints[0];
 
-   area = (p1.x * p2.y - p2.x * p1.y);
+   area = (F64(p1.x) * p2.y - F64(p2.x) * p1.y);
    sArea += area;
 
-   x += (p1.x + p2.x) * area;
-   y += (p1.y + p2.y) * area;
+   x += F64(p1.x + p2.x) * area;
+   y += F64(p1.y + p2.y) * area;
 
    // Zero area means it's likely a complex polygon or something with all points
    // colinear. Return the 2D mean of all the points to avoid NaN and INF issues
    // It's not great, but maybe good enough
-   if(abs(sArea) < 1e-6)  // This is about zero for a floating point number
+   if(fabs(sArea) < 1e-6)  // This is about zero for a floating point number
       return mean2d(polyPoints);
 
    // Finish up
@@ -2532,8 +2540,8 @@ bool pointInHexagon(const Point &pos, const Point &center, F32 radius)
 {
    const F32 d = 2 * radius;
 
-   const F32 dx = abs(pos.x - center.x) / d;    // Transform the test point locally and to quadrant 2
-   const F32 dy = abs(pos.y - center.y) / d;    // Transform the test point locally and to quadrant 2
+   const F32 dx = fabs(pos.x - center.x) / d;    // Transform the test point locally and to quadrant 2
+   const F32 dy = fabs(pos.y - center.y) / d;    // Transform the test point locally and to quadrant 2
 
    //if(dx / 2 > radius || dy / 2 > radius * FloatSqrt3Half)     // Bounding test (since q2 is in quadrant 2 only 2 tests are needed)
    //   return false;

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -1743,8 +1743,8 @@ Point findCentroid(const Vector<Point> &polyPoints)
       area = (F64(p1.x) * p2.y - F64(p2.x) * p1.y);
       sArea += area;
 
-      x += F64(p1.x + p2.x) * area;
-      y += F64(p1.y + p2.y) * area;
+      x += (F64(p1.x) + p2.x) * area;
+      y += (F64(p1.y) + p2.y) * area;
    }
 
    // Do last segment
@@ -1754,8 +1754,8 @@ Point findCentroid(const Vector<Point> &polyPoints)
    area = (F64(p1.x) * p2.y - F64(p2.x) * p1.y);
    sArea += area;
 
-   x += F64(p1.x + p2.x) * area;
-   y += F64(p1.y + p2.y) * area;
+   x += (F64(p1.x) + p2.x) * area;
+   y += (F64(p1.y) + p2.y) * area;
 
    // Zero area means it's likely a complex polygon or something with all points
    // colinear. Return the 2D mean of all the points to avoid NaN and INF issues


### PR DESCRIPTION
I have identified and fixed precision bugs in several geometric functions within `zap/GeomUtils.cpp`. These functions (`area`, `findCentroid`, and `isConvex`) were using `float` (F32) for intermediate calculations, leading to significant errors or incorrect results when processing polygons with coordinates far from the origin (e.g., $10^6$). 

I have updated these functions to use `F64` (double) for accumulation and intermediate products in the Shoelace formula and vector subtractions. I also replaced uses of `abs()` with `fabs()` for floating-point calculations to ensure accuracy.

Additionally, I have added unit tests to `bitfighter_test/TestGeomUtils.cpp` that specifically target these large-coordinate scenarios to ensure the functions remain accurate and robust.

This work was performed by an AI agent.

---
*PR created automatically by Jules for task [16712072620788578938](https://jules.google.com/task/16712072620788578938) started by @eykamp*