### PR TITLE
Fix integer overflow in alphaNumberSort

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -645,6 +645,17 @@ TEST(StringUtilsTest, sorting)
    EXPECT_TRUE(alphaNumberSort("1abc", "2abc"));    // 1 < 2
    EXPECT_FALSE(alphaNumberSort("10foo", "9foo"));  // 10 > 9
    EXPECT_FALSE(alphaNumberSort("2xyz", "2xyz"));   // equal -> alphaSort tie-break (false: not strictly less)
+
+   // Test for overflow with large integers
+   EXPECT_TRUE(alphaNumberSort("2147483647", "2147483648"));
+   EXPECT_TRUE(alphaNumberSort("2147483648", "2147483649"));
+   EXPECT_TRUE(alphaNumberSort("10000000000", "10000000001"));
+
+   // Test leading zeros
+   EXPECT_TRUE(alphaNumberSort("001", "02"));
+   EXPECT_TRUE(alphaNumberSort("01", "1"));      // Equal numerically -> alphaSort
+   EXPECT_FALSE(alphaNumberSort("1", "01"));     // Equal numerically -> alphaSort
+   EXPECT_TRUE(alphaNumberSort("0", "00"));      // Equal numerically -> alphaSort
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -1067,13 +1067,24 @@ bool alphaNumberSort(const string &a, const string &b)
 
    if(aIsNum && bIsNum)
    {
-      int aNum = atoi(a.c_str());
-      int bNum = atoi(b.c_str());
+      const char *aPtr = a.c_str();
+      const char *bPtr = b.c_str();
 
-      if(aNum == bNum)
-         return alphaSort(a, b);
+      // Skip leading zeros for numeric comparison, but keep at least one digit
+      while(*aPtr == '0' && isDigit(aPtr[1])) aPtr++;
+      while(*bPtr == '0' && isDigit(bPtr[1])) bPtr++;
 
-      return aNum < bNum;
+      size_t aLen = strlen(aPtr);
+      size_t bLen = strlen(bPtr);
+
+      if(aLen != bLen)
+         return aLen < bLen;
+
+      int cmp = strcmp(aPtr, bPtr);
+      if(cmp != 0)
+         return cmp < 0;
+
+      return alphaSort(a, b);
    }
 
    if(aIsNum)
@@ -1083,18 +1094,29 @@ bool alphaNumberSort(const string &a, const string &b)
       return false;
 
    // Both strings start with a digit but are not purely numeric (e.g. "2xyz" vs "11xyz").
-   // Compare the leading numeric portions numerically; atoi stops at the first non-digit,
-   // which is exactly the behavior we want here. Fall back to alphabetical on a tie.
+   // Compare the leading numeric portions numerically. Fall back to alphabetical on a tie.
    bool aStartsWithDigit = !a.empty() && isDigit(a[0]);
    bool bStartsWithDigit = !b.empty() && isDigit(b[0]);
 
    if(aStartsWithDigit && bStartsWithDigit)
    {
-      int aNum = atoi(a.c_str());
-      int bNum = atoi(b.c_str());
+      const char *aPtr = a.c_str();
+      const char *bPtr = b.c_str();
 
-      if(aNum != bNum)
-         return aNum < bNum;
+      while(*aPtr == '0' && isDigit(aPtr[1])) aPtr++;
+      while(*bPtr == '0' && isDigit(bPtr[1])) bPtr++;
+
+      size_t aDigits = 0;
+      while(isDigit(aPtr[aDigits])) aDigits++;
+      size_t bDigits = 0;
+      while(isDigit(bPtr[bDigits])) bDigits++;
+
+      if(aDigits != bDigits)
+         return aDigits < bDigits;
+
+      int cmp = strncmp(aPtr, bPtr, aDigits);
+      if(cmp != 0)
+         return cmp < 0;
    }
 
    return alphaSort(a, b);


### PR DESCRIPTION
I am an AI agent. I have identified and fixed a bug in the `alphaNumberSort` function within `zap/stringUtils.cpp`.

### Problem
The original implementation of `alphaNumberSort` used `atoi()` to convert numeric strings or leading numeric portions of strings into integers for comparison. This approach is susceptible to integer overflow when the numeric value exceeds `INT_MAX` (2147483647). For example, comparing "2147483647" and "2147483648" would yield an incorrect result.

### Solution
I have replaced the `atoi()`-based comparison with a more robust logic that:
1. Skips leading zeros (while ensuring at least one digit remains).
2. Compares the lengths of the numeric segments. A longer numeric segment is always greater.
3. If lengths are equal, it performs a lexicographical comparison (using `strcmp` or `strncmp`).
4. Falls back to the standard `alphaSort` if the numeric portions are equal.

This "natural sort" approach handles arbitrarily large numbers without the risk of overflow.

### Testing
I added new test cases to `bitfighter_test/TestStringUtils.cpp` that specifically check:
- Comparison of numeric strings larger than `INT_MAX`.
- Correct handling of leading zeros in numeric strings.
- Consistency with existing alphanumeric sorting behavior.

All 45 tests in `StringUtilsTest` now pass.

---
*PR created automatically by Jules for task [157687295544209039](https://jules.google.com/task/157687295544209039) started by @eykamp*