### PR TITLE
Fix integer overflow in alphaNumberSort

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -677,6 +677,21 @@ TEST(StringUtilsTest, sortingNumericPrefixAlphaSuffix)
 }
 
 
+// Verify that alphaNumberSort handles numbers larger than S32_MAX correctly.
+TEST(StringUtilsTest, sortingLargeNumbers)
+{
+   EXPECT_TRUE(alphaNumberSort("2147483647", "2147483648"));
+   EXPECT_FALSE(alphaNumberSort("2147483648", "2147483647"));
+   EXPECT_TRUE(alphaNumberSort("10000000000000000000", "10000000000000000001"));
+   EXPECT_FALSE(alphaNumberSort("10000000000000000000", "2"));
+   EXPECT_TRUE(alphaNumberSort("2", "10000000000000000000"));
+
+   // Mixed strings with large numbers
+   EXPECT_TRUE(alphaNumberSort("2abc", "2147483648abc"));
+   EXPECT_FALSE(alphaNumberSort("2147483648abc", "2abc"));
+}
+
+
 TEST(StringUtilsTest, formatMessage)
 {
    Vector<StringTableEntry> e;

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -1065,15 +1065,37 @@ bool alphaNumberSort(const string &a, const string &b)
    bool aIsNum = isPositiveInteger(a.c_str());
    bool bIsNum = isPositiveInteger(b.c_str());
 
+   // Helper to find the numeric part of a string, skipping leading zeros
+   auto getNumericPart = [](const string &s, size_t &start, size_t &len) {
+      start = 0;
+      while(start < s.length() && s[start] == '0')
+         start++;
+      len = 0;
+      while(start + len < s.length() && isDigit(s[start + len]))
+         len++;
+      if (len == 0 && start > 0 && (start == s.length() || !isDigit(s[start]))) // It was all zeros or zeros followed by non-digits
+      {
+          start--; // Keep one zero
+          len = 1;
+      }
+   };
+
    if(aIsNum && bIsNum)
    {
-      int aNum = atoi(a.c_str());
-      int bNum = atoi(b.c_str());
+      size_t aStart, aLen, bStart, bLen;
+      getNumericPart(a, aStart, aLen);
+      getNumericPart(b, bStart, bLen);
 
-      if(aNum == bNum)
-         return alphaSort(a, b);
+      if(aLen != bLen)
+         return aLen < bLen;
 
-      return aNum < bNum;
+      for(size_t i = 0; i < aLen; i++)
+      {
+         if(a[aStart + i] != b[bStart + i])
+            return a[aStart + i] < b[bStart + i];
+      }
+
+      return alphaSort(a, b);
    }
 
    if(aIsNum)
@@ -1083,18 +1105,24 @@ bool alphaNumberSort(const string &a, const string &b)
       return false;
 
    // Both strings start with a digit but are not purely numeric (e.g. "2xyz" vs "11xyz").
-   // Compare the leading numeric portions numerically; atoi stops at the first non-digit,
-   // which is exactly the behavior we want here. Fall back to alphabetical on a tie.
+   // Compare the leading numeric portions numerically. Fall back to alphabetical on a tie.
    bool aStartsWithDigit = !a.empty() && isDigit(a[0]);
    bool bStartsWithDigit = !b.empty() && isDigit(b[0]);
 
    if(aStartsWithDigit && bStartsWithDigit)
    {
-      int aNum = atoi(a.c_str());
-      int bNum = atoi(b.c_str());
+      size_t aStart, aLen, bStart, bLen;
+      getNumericPart(a, aStart, aLen);
+      getNumericPart(b, bStart, bLen);
 
-      if(aNum != bNum)
-         return aNum < bNum;
+      if(aLen != bLen)
+         return aLen < bLen;
+
+      for(size_t i = 0; i < aLen; i++)
+      {
+         if(a[aStart + i] != b[bStart + i])
+            return a[aStart + i] < b[bStart + i];
+      }
    }
 
    return alphaSort(a, b);


### PR DESCRIPTION
This PR fixes a bug in alphaNumberSort where numeric strings exceeding INT_MAX would cause integer overflow, leading to incorrect sorting results. The fix implements a robust string-based numeric comparison that handles arbitrarily large numbers by first comparing lengths (after stripping leading zeros) and then comparing lexicographically. Unit tests covering large numbers and mixed cases have been added to bitfighter_test/TestStringUtils.cpp.

As an AI agent, I have identified this bug and provided the fix with unit tests.

---
*PR created automatically by Jules for task [1808417624798905656](https://jules.google.com/task/1808417624798905656) started by @eykamp*