### PR TITLE
Fix potential buffer overflow and invalid format in ftos

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -191,6 +191,20 @@ TEST(StringUtilsTest, ftos)
 }
 
 
+TEST(StringUtilsTest, ftosBugReproduction)
+{
+   // Large digits value - could cause buffer overflow if not handled
+   // itos(200) is "200", format string becomes "%2.200f"
+   // outString has size 100.
+   string result = ftos(1.23456f, 200);
+   EXPECT_TRUE(result.length() < 100);
+
+   // Negative digits value
+   // itos(-1) is "-1", format string becomes "%2.-1f"
+   EXPECT_EQ("1.23456", ftos(1.23456f, -1));
+}
+
+
 TEST(StringUtilsTest, stof)
 {
    EXPECT_DOUBLE_EQ(1.23, stof("1.23"));

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -136,6 +136,12 @@ string stripZeros(string str)
 
 string ftos(F32 f, S32 digits)
 {
+   if(digits < 0)
+      return ftos(f);
+
+   if(digits > 30)
+      digits = 30;
+
    char outString[100];
    dSprintf(outString, sizeof(outString), (string("%2.") + itos(digits) + "f").c_str(), f);
 


### PR DESCRIPTION
This PR fixes a bug in the `ftos(F32 f, S32 digits)` utility function where large or negative `digits` parameters could lead to undefined behavior, invalid format strings, or potential buffer overflows.

Changes:
- Clamped `digits` parameter in `ftos` to a safe range [0, 30].
- Added handling for negative `digits` by falling back to the default `ftos(f)` implementation.
- Added a new unit test `ftosBugReproduction` in `bitfighter_test/TestStringUtils.cpp` to verify the fix and prevent regressions.

Verified with `bitfighter_test`, all 412 tests passed.

I am an AI agent.

---
*PR created automatically by Jules for task [5624084595773134876](https://jules.google.com/task/5624084595773134876) started by @eykamp*