### PR TITLE
Fix string utility bugs and add unit tests

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -386,6 +386,13 @@ TEST(StringUtilsTest, countCharInString)
    EXPECT_EQ(3, countCharInString("banana", 'a'));
    EXPECT_EQ(0, countCharInString("banana", 'z'));
    EXPECT_EQ(1, countCharInString("banana", 'b'));
+
+   // Test with embedded null characters
+   string s = "abc";
+   s += '\0';
+   s += "abc";
+   // s is "abc\0abc", length is 7
+   EXPECT_EQ(2, countCharInString(s, 'a'));
 }
 
 
@@ -408,6 +415,7 @@ TEST(StringUtilsTest, sanitizeForJson)
    EXPECT_EQ("\\\\backslash\\\\", sanitizeForJson("\\backslash\\"));
    EXPECT_EQ("\\n\\r\\t", sanitizeForJson("\n\r\t"));
    EXPECT_EQ("&amp;&lt;&gt;", sanitizeForJson("&<>"));
+   EXPECT_EQ("", sanitizeForJson(NULL));
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -252,6 +252,9 @@ bool isPositiveInteger(const char *str)
 // Sanitize strings before inclusion into JSON
 string sanitizeForJson(const char *value)
 {
+   if(!value)
+      return "";
+
    size_t maxsize = strlen(value) * 2 + 3; // allescaped+quotes+NULL
    std::string result;
    result.reserve(maxsize);  // memory management
@@ -786,13 +789,12 @@ void trim_in_place(string& source, const string &t)
 // count the occurrence of a specific character in a string
 S32 countCharInString(const string &source, char search)
 {
-    S32 count = 0, c = 0;
+    S32 count = 0;
 
-    while(source[c] != '\0')
+    for(size_t i = 0; i < source.length(); i++)
     {
-      if (source[c] == search)
+      if (source[i] == search)
          count++;
-      c++;
     }
     return count;
 }


### PR DESCRIPTION
I identified and fixed two bugs in the `stringUtils.cpp` file:
- `countCharInString` was incorrectly using a null-terminator check to iterate through a `std::string`, which meant it would stop prematurely if it encountered an embedded null character. I updated it to use the string's `length()` method.
- `sanitizeForJson` was missing a check for `NULL` input, which could lead to a crash when `strlen()` was called. I added a safety check at the beginning of the function.

I also added regression tests in `bitfighter_test/TestStringUtils.cpp` to ensure these cases are handled correctly and to prevent future regressions. All tests, including the new ones, pass successfully.

I am an AI agent assisting with this task.

---
*PR created automatically by Jules for task [7729318331353695262](https://jules.google.com/task/7729318331353695262) started by @eykamp*