### PR TITLE
Fix bugs and add regression tests in string and geometry utilities

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -1306,6 +1306,12 @@ TEST(GeomUtilsTest, isWoundClockwiseCCW)
    EXPECT_FALSE(isWoundClockwise(ccw));
 }
 
+TEST(GeomUtilsTest, isWoundClockwiseEmpty)
+{
+   Vector<Point> empty;
+   EXPECT_TRUE(isWoundClockwise(empty));
+}
+
 TEST(GeomUtilsTest, isWoundClockwiseLargeCoordinates)
 {
    F32 offset = 1e7;

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -360,6 +360,10 @@ TEST(StringUtilsTest, parseStringAndStripLeadingSlash)
    EXPECT_EQ("cmd", result[0]);
    EXPECT_EQ("arg1", result[1]);
    EXPECT_EQ("arg2", result[2]);
+
+   // Bug fix: NULL input
+   result = parseStringAndStripLeadingSlash(NULL);
+   EXPECT_TRUE(result.empty());
 }
 
 
@@ -373,6 +377,9 @@ TEST(StringUtilsTest, findPointerOfArg)
    EXPECT_STREQ("", findPointerOfArg(msg, 4));
    EXPECT_STREQ("", findPointerOfArg(msg, 40));
    EXPECT_STREQ("", findPointerOfArg(msg, -1));
+
+   // Bug fix: NULL input
+   EXPECT_STREQ("", findPointerOfArg(NULL, 0));
 }
 
 
@@ -382,6 +389,9 @@ TEST(StringUtilsTest, concatenate)
    Vector<string> words(wordArry, ARRAYSIZE(wordArry));
    EXPECT_EQ("one two three", concatenate(words));
    EXPECT_EQ("two three", concatenate(words, 1));
+
+   // Bug fix: negative startingWith
+   EXPECT_EQ("one two three", concatenate(words, -1));
 }
 
 
@@ -572,6 +582,9 @@ TEST(StringUtilsTest, safeFilename)
    EXPECT_TRUE(safeFilename("file.txt"));
    EXPECT_FALSE(safeFilename("path/file.txt"));
    EXPECT_FALSE(safeFilename("path\\file.txt"));
+
+   // Bug fix: NULL input
+   EXPECT_FALSE(safeFilename(NULL));
 }
 
 

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -1513,6 +1513,9 @@ Vector<Point> floatsToPoints(const Vector<F32> floats)
 // http://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-points-are-in-clockwise-order/1165943#1165943
 bool isWoundClockwise(const Vector<Point>& inputPoly)
 {
+   if(inputPoly.size() < 2)
+      return true;
+
    F64 finalSum = 0;
    S32 i_prev = inputPoly.size() - 1;
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -221,7 +221,7 @@ bool caseInsensitiveStringCompare(const string &str1, const string &str2) {
 string lcase(string strToConvert)      // Note that strToConvert is a copy of whatever was passed
 {
    for(U32 i = 0; i < strToConvert.length(); i++)
-      strToConvert[i] = tolower(strToConvert[i]);
+      strToConvert[i] = (char)tolower((unsigned char)strToConvert[i]);
    return strToConvert;
 }
 
@@ -230,12 +230,13 @@ string lcase(string strToConvert)      // Note that strToConvert is a copy of wh
 string ucase(string strToConvert)
 {
    for(U32 i = 0; i < strToConvert.length(); i++)
-      strToConvert[i] = toupper(strToConvert[i]);
+      strToConvert[i] = (char)toupper((unsigned char)strToConvert[i]);
    return strToConvert;
 }
 
 
 // Return true if str looks like a non-negative int
+// Returns false if str is NULL or empty
 bool isPositiveInteger(const char *str)
 {
    if(!str || str[0] == 0)
@@ -491,6 +492,9 @@ void parseString(const char *inputString, Vector<string> &words, char seperator)
 
 Vector<string> parseStringAndStripLeadingSlash(const char *str)
 {
+   if(!str)
+      return Vector<string>();
+
    Vector<string> words = parseString(str);
 
    if(words.size() > 0 && words[0][0] == '/')
@@ -503,6 +507,9 @@ Vector<string> parseStringAndStripLeadingSlash(const char *str)
 // Returns a pointer of string of chars, after "count" number of args
 const char *findPointerOfArg(const char *message, S32 count)
 {
+   if(!message)
+      return "";
+
    S32 spacecount = 0;
    S32 cur = 0;
    char prevchar = 0;
@@ -523,6 +530,9 @@ const char *findPointerOfArg(const char *message, S32 count)
 // TODO: Merge with listToString below
 string concatenate(const Vector<string> &words, S32 startingWith)
 {
+   if(startingWith < 0)
+      startingWith = 0;
+
    string concatenated = "";
    for(S32 i = startingWith; i < words.size(); i++)
       concatenated += (i == startingWith ? "" : " ") + words[i];
@@ -644,6 +654,9 @@ bool getFilesFromFolder(const string &dir, Vector<string> &files, const string e
 // Make sure a file name is 'safe', i.e. not having a path component
 bool safeFilename(const char *str)
 {
+   if(!str)
+      return false;
+
    char chr = str[0];
    S32 i = 0;
    while(chr != 0)


### PR DESCRIPTION
I have identified and fixed several bugs in the core utility functions of Bitfighter. Specifically:

1.  **Null Pointer Safety**: Added checks to `safeFilename`, `findPointerOfArg`, and `parseStringAndStripLeadingSlash` in `zap/stringUtils.cpp` to prevent crashes when passed NULL pointers.
2.  **Bounds Checking**: Fixed an issue in `concatenate` where a negative starting index could cause out-of-bounds access.
3.  **Winding Order Safety**: Updated `isWoundClockwise` in `zap/GeomUtils.cpp` to handle empty or small polygons gracefully instead of accessing invalid memory.
4.  **Character Portability**: Modified `lcase` and `ucase` to use `unsigned char` casts, avoiding undefined behavior when processing signed characters with `tolower` or `toupper`.

To ensure these fixes work as intended, I have added corresponding unit tests to the project's test suite in `bitfighter_test/TestStringUtils.cpp` and `bitfighter_test/TestGeomUtils.cpp`. These tests cover the identified edge cases and verify that the functions now behave correctly.

I am an AI agent assisting with codebase maintenance.

---
*PR created automatically by Jules for task [12681509629105166393](https://jules.google.com/task/12681509629105166393) started by @eykamp*