### PR TITLE
Fix findPointerOfArg whitespace handling and add unit tests

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -380,6 +380,13 @@ TEST(StringUtilsTest, findPointerOfArg)
 
    // Bug fix: NULL input
    EXPECT_STREQ("", findPointerOfArg(NULL, 0));
+
+   // New tests for leading and multiple spaces
+   EXPECT_STREQ("word1 word2", findPointerOfArg("  word1 word2", 0));
+   EXPECT_STREQ("word2", findPointerOfArg("  word1 word2", 1));
+   EXPECT_STREQ("word2", findPointerOfArg("word1  word2", 1));
+   EXPECT_STREQ("word2", findPointerOfArg("word1\tword2", 1));
+   EXPECT_STREQ("word2   ", findPointerOfArg("   word1   word2   ", 1));
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -512,16 +512,20 @@ const char *findPointerOfArg(const char *message, S32 count)
 
    S32 spacecount = 0;
    S32 cur = 0;
-   char prevchar = 0;
+   char prevchar = ' ';
 
    // Message needs to include everything including multiple spaces.  Message starts after second space.
    while(message[cur] != '\0' && spacecount != count)
    {
-      if(message[cur] == ' ' && prevchar != ' ')
+      if(isspace((unsigned char)message[cur]) && !isspace((unsigned char)prevchar))
          spacecount++;        // Double space does not count as a seperate parameter
       prevchar = message[cur];
       cur++;
    }
+
+   while(message[cur] != '\0' && isspace((unsigned char)message[cur]))
+      cur++;
+
    return &message[cur];
 }
 


### PR DESCRIPTION
This PR fixes a bug in the `findPointerOfArg` utility function where leading whitespace or multiple consecutive spaces would cause incorrect argument indexing and return pointers to whitespace characters instead of the argument itself.

**Changes:**
- **Logic Fix:** Initialized the tracking of the previous character to a space, ensuring leading whitespace isn't incorrectly counted as an argument transition.
- **Robustness:** Replaced literal space checks with `isspace()` (casting to `unsigned char` for safety) to support tabs and other whitespace.
- **Precision:** Added a trailing loop to skip any leading whitespace of the target argument, so the returned pointer always points to the start of the token.
- **Testing:** Expanded `bitfighter_test/TestStringUtils.cpp` with new test cases covering leading spaces, tabs, and multiple spaces between words.

I identify as an AI agent.

---
*PR created automatically by Jules for task [12128347953611315048](https://jules.google.com/task/12128347953611315048) started by @eykamp*