### PR TITLE
Fix: Escape control characters in sanitizeForJson

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -521,6 +521,30 @@ TEST(StringUtilsTest, sanitizeForJson)
    EXPECT_EQ("\\n\\r\\t", sanitizeForJson("\n\r\t"));
    EXPECT_EQ("&amp;&lt;&gt;", sanitizeForJson("&<>"));
    EXPECT_EQ("", sanitizeForJson(NULL));
+
+   // Control characters
+   EXPECT_EQ("a\\u0001b", sanitizeForJson("a\x01""b"));
+   EXPECT_EQ("\\u001F", sanitizeForJson("\x1F"));
+
+   // Verify all control characters (1-31)
+   for(int i = 1; i <= 31; ++i)
+   {
+      char input[2] = {(char)i, 0};
+      string result = sanitizeForJson(input);
+
+      // Some control characters have special short escapes in sanitizeForJson
+      if(i == '\b')      EXPECT_EQ("\\b", result);
+      else if(i == '\f') EXPECT_EQ("\\f", result);
+      else if(i == '\n') EXPECT_EQ("\\n", result);
+      else if(i == '\r') EXPECT_EQ("\\r", result);
+      else if(i == '\t') EXPECT_EQ("\\t", result);
+      else
+      {
+         char expected[8];
+         sprintf(expected, "\\u00%.2X", i);
+         EXPECT_EQ(expected, result) << "Failed for control character " << i;
+      }
+   }
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -311,11 +311,9 @@ string sanitizeForJson(const char *value)
          default:
             if(isControlCharacter(*c))
             {
-               // Do nothing for the moment -- there shouldn't be any control chars here, and if there are we don't really care.
-               // However, some day we might want to support this, so we'll leave the code in place.
-               //std::ostringstream oss;
-               //oss << "\\u" << std::hex << std::uppercase << std::setfill('0') << std::setw(4) << static_cast<int>(*c);
-               //result += oss.str();
+               char buf[7];
+               dSprintf(buf, sizeof(buf), "\\u%.4X", (U32)*c);
+               result += buf;
             }
             else
                result += *c;


### PR DESCRIPTION
This PR fixes a bug in the `sanitizeForJson` function where ASCII control characters (0-31) were incorrectly skipped during sanitization. According to the JSON specification, these characters must be escaped.

The fix implements the standard `\uXXXX` Unicode escape sequence for any control character that doesn't already have a designated short escape (like `\n` or `\r`). 

Comprehensive unit tests have been added to `bitfighter_test/TestStringUtils.cpp` to verify the fix across all 31 ASCII control characters and to ensure no regressions in existing sanitization logic.

I am an AI agent. This PR should not be merged into the main line codebase.

---
*PR created automatically by Jules for task [2038407331503596342](https://jules.google.com/task/2038407331503596342) started by @eykamp*