### PR TITLE
Fix bug in chopComment to respect quoted strings

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -88,6 +88,16 @@ TEST(StringUtilsTest, chopComment)
    EXPECT_EQ("LevelName \"My #1 Level\" ", chopComment("LevelName \"My #1 Level\" # comment"));
    EXPECT_EQ("LevelName \"My #1 Level\"",  chopComment("LevelName \"My #1 Level\""));
    EXPECT_EQ("LevelName \"\"\"#\"\"\"",    chopComment("LevelName \"\"\"#\"\"\""));
+
+   // 8 more tests
+   EXPECT_EQ("No hash here",               chopComment("No hash here"));
+   EXPECT_EQ("Quotes \"but no hash\"",     chopComment("Quotes \"but no hash\""));
+   EXPECT_EQ("\"#HashAtStart\"",           chopComment("\"#HashAtStart\""));
+   EXPECT_EQ("\"HashAtEnd#\"",             chopComment("\"HashAtEnd#\""));
+   EXPECT_EQ("Mix \"#1\" and \"#2\"",      chopComment("Mix \"#1\" and \"#2\""));
+   EXPECT_EQ("Mix \"#1\" and \"#2\" ",     chopComment("Mix \"#1\" and \"#2\" # then comment"));
+   EXPECT_EQ("\"\"\"#\"\"\" \"\"\"#\"\"\"", chopComment("\"\"\"#\"\"\" \"\"\"#\"\"\""));
+   EXPECT_EQ("Escaped \"\"quote\"\" ",     chopComment("Escaped \"\"quote\"\" # comment"));
 }
 
 

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -84,6 +84,10 @@ TEST(StringUtilsTest, chopComment)
    EXPECT_EQ("This is a comment", chopComment("This is a comment"));
    EXPECT_EQ("",                  chopComment("#"));
 
+   // Bug: '#' inside quotes should not be treated as a comment
+   EXPECT_EQ("LevelName \"My #1 Level\" ", chopComment("LevelName \"My #1 Level\" # comment"));
+   EXPECT_EQ("LevelName \"My #1 Level\"",  chopComment("LevelName \"My #1 Level\""));
+   EXPECT_EQ("LevelName \"\"\"#\"\"\"",    chopComment("LevelName \"\"\"#\"\"\""));
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -887,15 +887,36 @@ string replaceString(const char *in, const char *find, const char *replace)
 
 
 // Strip comments from passed lines.  Comments are denoted with a "#".
+// Respects quoted strings and escaped quotes ("").
 string chopComment(const string &line)
 {
-   string copy = line;
-   string::size_type pos = copy.find('#');
+   bool inQuotes = false;
 
-   if(pos == string::npos)    // # not found
-      return line;
+   for(size_t i = 0; i < line.length(); ++i)
+   {
+      char c = line[i];
 
-   return copy.erase(copy.find('#'), string::npos);
+      if(inQuotes)
+      {
+         if(c == '"')
+         {
+            // Check for escaped quote ""
+            if(i + 1 < line.length() && line[i + 1] == '"')
+               i++;
+            else
+               inQuotes = false;
+         }
+      }
+      else
+      {
+         if(c == '"')
+            inQuotes = true;
+         else if(c == '#')
+            return line.substr(0, i);
+      }
+   }
+
+   return line;
 }
 
 


### PR DESCRIPTION
Identify and fix a bug in `chopComment` where '#' characters inside quoted strings were incorrectly treated as comments.

Changes:
- Modified `Zap::chopComment` in `zap/stringUtils.cpp` to use a stateful parser that respects quoted strings.
- Added support for escaped quotes (`""`) within `chopComment`.
- Added new test cases to `StringUtilsTest.chopComment` in `bitfighter_test/TestStringUtils.cpp` covering:
    - '#' inside quoted strings.
    - Comments appearing after quoted strings.
    - '#' inside triple-quoted (escaped) strings.

Verified by running `bitfighter_test` with a focus on `StringUtilsTest` cases. All tests passed.

I am an AI agent.

---
*PR created automatically by Jules for task [15940690809369943782](https://jules.google.com/task/15940690809369943782) started by @eykamp*