### PR TITLE
Fix chopComment bug with hashtags inside quotes

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -83,7 +83,16 @@ TEST(StringUtilsTest, chopComment)
    EXPECT_EQ("This is a comment", chopComment("This is a comment#"));
    EXPECT_EQ("This is a comment", chopComment("This is a comment"));
    EXPECT_EQ("",                  chopComment("#"));
+}
 
+
+TEST(StringUtilsTest, chopCommentWithQuotes)
+{
+   EXPECT_EQ("\"quoted # hashtag\"", chopComment("\"quoted # hashtag\""));
+   EXPECT_EQ("\"quoted # hashtag\" ", chopComment("\"quoted # hashtag\" #comment"));
+   EXPECT_EQ("\"\"", chopComment("\"\"#\"\"")); // "" is an empty quoted string, then # starts a comment
+   EXPECT_EQ("\"escaped \"\" quote\" ", chopComment("\"escaped \"\" quote\" #comment"));
+   EXPECT_EQ("mixed \"#\" and ", chopComment("mixed \"#\" and #comment"));
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -887,15 +887,31 @@ string replaceString(const char *in, const char *find, const char *replace)
 
 
 // Strip comments from passed lines.  Comments are denoted with a "#".
+// Quote-aware: will not chop a # that is inside a double-quoted string.
 string chopComment(const string &line)
 {
-   string copy = line;
-   string::size_type pos = copy.find('#');
+   bool inQuotes = false;
+   for(size_t i = 0; i < line.length(); ++i)
+   {
+      char c = line[i];
+      if(c == '"')
+      {
+         // Handle escaped quotes ""
+         if(inQuotes && i + 1 < line.length() && line[i + 1] == '"')
+         {
+            i++;
+            // We do NOT toggle inQuotes here, because an escaped quote is still inside (or outside) the same state
+            continue;
+         }
+         inQuotes = !inQuotes;
+      }
+      else if(c == '#' && !inQuotes)
+      {
+         return line.substr(0, i);
+      }
+   }
 
-   if(pos == string::npos)    // # not found
-      return line;
-
-   return copy.erase(copy.find('#'), string::npos);
+   return line;
 }
 
 


### PR DESCRIPTION
Identified a bug in `chopComment` where it incorrectly truncated strings if they contained a '#' character inside double quotes.

Modified `zap/stringUtils.cpp` to make `chopComment` quote-aware, tracking double-quote states and handling escaped quotes `""`.

Added unit tests to `bitfighter_test/TestStringUtils.cpp` to verify the fix and prevent regressions.

This PR was generated by an AI agent.

---
*PR created automatically by Jules for task [14095113701939351759](https://jules.google.com/task/14095113701939351759) started by @eykamp*