### PR TITLE
Fix tie detection bug in individual games

### DIFF
--- a/bitfighter_test/TestGameType.cpp
+++ b/bitfighter_test/TestGameType.cpp
@@ -4,11 +4,79 @@
 //------------------------------------------------------------------------------
 
 #include "gameType.h"
+#include "ServerGame.h"
+#include "TestUtils.h"
 #include "gtest/gtest.h"
+
+#include <memory>
 
 namespace Zap
 {
 
-// Need some tests here!
+class TestGameType : public GameType
+{
+public:
+   TestGameType() : GameType() {}
+   virtual bool isTeamGame() const { return false; } // Individual game
+};
+
+TEST(GameTypeTest, OnGameOverTieDetection)
+{
+   Address addr;
+   GameSettingsPtr settings = GameSettingsPtr(new GameSettings());
+   LevelSourcePtr levelSource = LevelSourcePtr(new StringLevelSource(""));
+
+   ServerGame serverGame(addr, settings, levelSource, false, false);
+   std::unique_ptr<TestGameType> gt(new TestGameType());
+   gt->addToGame(&serverGame, serverGame.getGameObjDatabase());
+
+   // Create 4 players - as robots
+   // RefPtr will handle cleanup of these once serverGame is destroyed
+   FullClientInfo *p1 = new FullClientInfo(&serverGame, NULL, "Player1", ClientInfo::ClassRobotAddedByAddbots);
+   FullClientInfo *p2 = new FullClientInfo(&serverGame, NULL, "Player2", ClientInfo::ClassRobotAddedByAddbots);
+   FullClientInfo *p3 = new FullClientInfo(&serverGame, NULL, "Player3", ClientInfo::ClassRobotAddedByAddbots);
+   FullClientInfo *p4 = new FullClientInfo(&serverGame, NULL, "Player4", ClientInfo::ClassRobotAddedByAddbots);
+
+   serverGame.addToClientList(p1);
+   serverGame.addToClientList(p2);
+   serverGame.addToClientList(p3);
+   serverGame.addToClientList(p4);
+
+   // Scenario 1: Tie in the middle [4, 5, 5, 4]
+   p1->setScore(4);
+   p2->setScore(5);
+   p3->setScore(5);
+   p4->setScore(4);
+
+   gt->onGameOver();
+   EXPECT_TRUE(gt->wasTied());
+
+   // Scenario 2: Unique winner [6, 5, 5, 4]
+   p1->setScore(6);
+   p2->setScore(5);
+   p3->setScore(5);
+   p4->setScore(4);
+
+   gt->onGameOver();
+   EXPECT_FALSE(gt->wasTied());
+
+   // Scenario 3: Unique winner at the end [4, 5, 5, 6]
+   p1->setScore(4);
+   p2->setScore(5);
+   p3->setScore(5);
+   p4->setScore(6);
+
+   gt->onGameOver();
+   EXPECT_FALSE(gt->wasTied());
+
+   // Scenario 4: Multiple-way tie [5, 5, 5, 5]
+   p1->setScore(5);
+   p2->setScore(5);
+   p3->setScore(5);
+   p4->setScore(5);
+
+   gt->onGameOver();
+   EXPECT_TRUE(gt->wasTied());
+}
 
 };

--- a/zap/gameType.cpp
+++ b/zap/gameType.cpp
@@ -68,6 +68,7 @@ GameType::GameType(S32 winningScore) : mScoreboardUpdateTimer(THREE_SECONDS), mG
    mNetFlags.set(Ghostable);
    mBetweenLevels = true;
    mGameOver = false;
+   mWasTied = false;
    mWinningScore = winningScore;
    mLeadingTeam = -1;
    mLeadingTeamScore = 0;
@@ -1056,10 +1057,13 @@ void GameType::onGameOver()
          {
             ClientInfo *clientInfo = mGame->getClientInfo(i);
 
-            tied = (clientInfo->getScore() == winningClient->getScore());     // TODO: I think this logic is wrong -- what if scores are in the order 4 5 5 4 will still be tied?
-
-            if(!tied && clientInfo->getScore() > winningClient->getScore())
+            if(clientInfo->getScore() == winningClient->getScore())
+               tied = true;
+            else if(clientInfo->getScore() > winningClient->getScore())
+            {
                winningClient = clientInfo;
+               tied = false;
+            }
          }
 
          if(!tied)
@@ -1072,6 +1076,8 @@ void GameType::onGameOver()
 
    static StringTableEntry tieMessage("The game ended in a tie.");
    static StringTableEntry winMessage("%e0%e1 wins the game!");
+
+   mWasTied = tied;
 
    if(tied)
       broadcastMessage(GameConnection::ColorNuclearGreen, SFXFlagDrop, tieMessage);

--- a/zap/gameType.h
+++ b/zap/gameType.h
@@ -75,6 +75,7 @@ private:
    bool mCanSwitchTeams;            // Player can switch teams when this is true, not when it is false
    bool mBetweenLevels;             // We'll need to prohibit certain things (like team changes) when game is in an "intermediate" state
    bool mGameOver;                  // Set to true when an end condition is met
+   bool mWasTied;                   // For testing purposes
 
    bool mEngineerEnabled;
    bool mEngineerUnrestrictedEnabled;
@@ -221,6 +222,7 @@ public:
                          const StringTableEntry &formatString, const Vector<StringTableEntry> &e);
 
    bool isGameOver() const;
+   bool wasTied() const { return mWasTied; }
 
    static const char *getGameTypeName(GameTypeId gameType);       // Return string like "Capture The Flag"
    static const char *getGameTypeClassName(GameTypeId gameType);  // Return string like "CTFGameType"


### PR DESCRIPTION
I am an AI agent.

This PR fixes a bug in the end-of-game tie detection logic for individual games.
In the previous implementation, the `tied` flag was overwritten in each iteration of the winner-selection loop, which meant that a tie was only correctly reported if the *last* player checked tied with the current leader. If two players tied earlier in the list and were subsequently followed by players with lower scores, the tie would be lost.

Changes:
- Modified the winner-selection loop in `GameType::onGameOver` (zap/gameType.cpp) to correctly set and maintain the `tied` flag.
- Added `mWasTied` and `wasTied()` to the `GameType` class (zap/gameType.h) to allow verification of the tie state in unit tests.
- Added a new unit test suite in `bitfighter_test/TestGameType.cpp` that covers:
    - Ties in the middle of the player list.
    - Unique winners at the beginning or end of the list.
    - Multiple-way ties.
- Ensured proper memory management and no regressions for unique winner scenarios.

All 228 unit tests (including the new one) pass successfully.

---
*PR created automatically by Jules for task [10926523106526867074](https://jules.google.com/task/10926523106526867074) started by @eykamp*