### PR TITLE
Fix: chopComment incorrectly strips '#' inside quoted strings

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -83,7 +83,14 @@ TEST(StringUtilsTest, chopComment)
    EXPECT_EQ("This is a comment", chopComment("This is a comment#"));
    EXPECT_EQ("This is a comment", chopComment("This is a comment"));
    EXPECT_EQ("",                  chopComment("#"));
+}
 
+
+TEST(StringUtilsTest, chopCommentWithQuotes)
+{
+   EXPECT_EQ("\"#not_a_comment\" ", chopComment("\"#not_a_comment\" #comment"));
+   EXPECT_EQ("No comment here \"#\"", chopComment("No comment here \"#\""));
+   EXPECT_EQ("\"A \"\"#\"\" B\" ", chopComment("\"A \"\"#\"\" B\" #comment"));
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -886,16 +886,46 @@ string replaceString(const char *in, const char *find, const char *replace)
 }
 
 
-// Strip comments from passed lines.  Comments are denoted with a "#".
+// Strip comments from passed lines.  Comments are denoted with a "#", but '#'
+// characters inside double-quoted strings are ignored. Supports escaped
+// quotes using "".
 string chopComment(const string &line)
 {
-   string copy = line;
-   string::size_type pos = copy.find('#');
+   bool inQuotes = false;
 
-   if(pos == string::npos)    // # not found
-      return line;
+   for(size_t i = 0; i < line.length(); ++i)
+   {
+      char c = line[i];
 
-   return copy.erase(copy.find('#'), string::npos);
+      if(inQuotes)
+      {
+         if(c == '"')
+         {
+            // Check for escaped quote ""
+            if(i + 1 < line.length() && line[i + 1] == '"')
+            {
+               i++;
+            }
+            else
+            {
+               inQuotes = false;
+            }
+         }
+      }
+      else
+      {
+         if(c == '"')
+         {
+            inQuotes = true;
+         }
+         else if(c == '#')
+         {
+            return line.substr(0, i);
+         }
+      }
+   }
+
+   return line;
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -903,25 +903,17 @@ string chopComment(const string &line)
          {
             // Check for escaped quote ""
             if(i + 1 < line.length() && line[i + 1] == '"')
-            {
                i++;
-            }
             else
-            {
                inQuotes = false;
-            }
          }
       }
       else
       {
          if(c == '"')
-         {
             inQuotes = true;
-         }
          else if(c == '#')
-         {
             return line.substr(0, i);
-         }
       }
    }
 


### PR DESCRIPTION
I have identified and fixed a bug in the `chopComment` utility function where it incorrectly treated '#' characters inside double-quoted strings as the start of a comment.

### Changes:
- **Logic Fix:** Updated `zap/stringUtils.cpp` to include a quote-aware parser in `chopComment`. It now correctly maintains an `inQuotes` state and handles escaped quotes (`""`).
- **Unit Testing:** Added a new test suite `chopCommentWithQuotes` in `bitfighter_test/TestStringUtils.cpp` which covers:
    - '#' inside a quoted string at the beginning of a line.
    - '#' inside a quoted string in the middle of a line.
    - '#' inside escaped quotes (`""`).
    - Standard comments still being correctly stripped.

I have verified these changes by building and running the test suite on Linux. All tests in `StringUtilsTest` passed, including the new cases.

**Note:** I am an AI agent.

---
*PR created automatically by Jules for task [17550203772850322879](https://jules.google.com/task/17550203772850322879) started by @eykamp*