### PR TITLE
Fix NULL pointer crash in replaceString utility function

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -253,6 +253,16 @@ TEST(StringUtilsTest, replaceStringEmptyFrom)
 }
 
 
+TEST(StringUtilsTest, replaceStringNullChecks)
+{
+   // NULL input string should return empty string and not crash
+   EXPECT_EQ("", replaceString((const char *)NULL, "find", "replace"));
+
+   // NULL replacement string should treat it as an empty replacement
+   EXPECT_EQ("f", replaceString("foo", "o", (const char *)NULL));
+}
+
+
 TEST(StringUtilsTest, lcase_ucase)
 {
    EXPECT_EQ("abc", lcase("ABC"));

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -863,8 +863,14 @@ string ctos(char c)
 
 string replaceString(const char *in, const char *find, const char *replace)
 {
+   if(!in)
+      return "";
+
    if(!find || find[0] == 0)
       return in;
+
+   if(!replace)
+      replace = "";
 
    string out;
    size_t n = 0;

--- a/zap/stringUtils.h
+++ b/zap/stringUtils.h
@@ -55,6 +55,7 @@ string ftos(F32 f);
 F64 stof(const string &s);
 
 string replaceString(const string &strString, const string &strOld, const string &strNew);
+string replaceString(const char *in, const char *find, const char *replace);
 string stripExtension(string filename);
 
 string listToString(const Vector<string> &words, const string &seperator);


### PR DESCRIPTION
I have identified and fixed a bug in the `replaceString` utility function where passing NULL pointers as arguments would result in a crash or a C++ exception (`basic_string: construction from null is not valid`).

The fix involves:
1. Adding NULL pointer guards to the `replaceString(const char *in, const char *find, const char *replace)` implementation in `zap/stringUtils.cpp`.
2. Adding the missing declaration for this overload in `zap/stringUtils.h`, which ensures that calls with C-string literals or NULL are correctly routed to the safe C-string implementation rather than triggering an implicit `std::string` construction.
3. Adding a new unit test case `replaceStringNullChecks` in `bitfighter_test/TestStringUtils.cpp` to verify that the function handles NULL inputs gracefully without crashing.

I have verified the fix by running the unit test suite, and all 53 `StringUtilsTest` cases now pass.

I am an AI agent.

---
*PR created automatically by Jules for task [2249411616661121181](https://jules.google.com/task/2249411616661121181) started by @eykamp*