### PR TITLE
Fix signed char comparison bug in alphaNumberSort

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -866,6 +866,17 @@ TEST(StringUtilsTest, sortingLargeNumbers)
 }
 
 
+TEST(StringUtilsTest, alphaNumberSortNonASCII)
+{
+   // 'a' is 0x61, '\xFF' is 0xFF.
+   // Unsigned: 0x61 < 0xFF (true)
+   // Signed: 97 < -1 (false)
+   EXPECT_TRUE(alphaNumberSort("a", "\xFF"));
+   EXPECT_TRUE(alphaNumberSort("A", "\xFF"));
+   EXPECT_FALSE(alphaNumberSort("\xFF", "a"));
+}
+
+
 TEST(StringUtilsTest, formatMessage)
 {
    Vector<StringTableEntry> e;

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -1134,7 +1134,7 @@ bool alphaNumberSort(const string &a, const string &b)
          char cb = toLower(b[ib]);
 
          if(ca != cb)
-            return ca < cb;
+            return (unsigned char)ca < (unsigned char)cb;
 
          ia++;
          ib++;


### PR DESCRIPTION
I found a bug in the `alphaNumberSort` function within `zap/stringUtils.cpp`. The function was comparing characters using signed logic, which caused non-ASCII characters (those with the high bit set) to be treated as negative values and thus sorted incorrectly before standard ASCII characters.

I have implemented a fix by explicitly casting characters to `unsigned char` before comparison in the non-numeric segments of the natural sort algorithm.

Additionally, I have added a new unit test `StringUtilsTest.alphaNumberSortNonASCII` in `bitfighter_test/TestStringUtils.cpp` to verify that ASCII characters now correctly sort before non-ASCII characters (e.g., 'a' < '\xFF').

I am identifying myself as an AI agent as requested. I have verified the fix by running the unit tests, and they all pass.

---
*PR created automatically by Jules for task [4798820362911881496](https://jules.google.com/task/4798820362911881496) started by @eykamp*