### PR TITLE
Fix whitespace quoting and NULL safety in writeLevelString

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -766,6 +766,13 @@ TEST(StringUtilsTest, writeLevelString)
    EXPECT_EQ("\"String with space\"", writeLevelString("String with space"));
    EXPECT_EQ("\"String with #\"", writeLevelString("String with #"));
    EXPECT_EQ("\"String with \"\"quotes\"\"\"", writeLevelString("String with \"quotes\""));
+
+   // Bug: these should be quoted
+   EXPECT_EQ("\"String with\ttab\"", writeLevelString("String with\ttab"));
+   EXPECT_EQ("\"String with\nnewline\"", writeLevelString("String with\nnewline"));
+
+   // Bug: should not crash
+   EXPECT_EQ("", writeLevelString(NULL));
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -923,9 +923,13 @@ string chopComment(const string &line)
 
 string writeLevelString(const char *in)
 {
-   int c=0;
-   while(in[c] != 0 && in[c] != '\"' && in[c] != '#' && in[c] != ' ')
+   if(!in)
+      return "";
+
+   int c = 0;
+   while(in[c] != 0 && in[c] != '\"' && in[c] != '#' && !isSpace(in[c]))
       c++;
+
    if(in[c] == 0 && c != 0)
       return string(in);  // string does not need to be changed if not zero length and there is no space or any of: # "
 


### PR DESCRIPTION
This PR fixes two issues in the `writeLevelString` utility:
1.  **Incomplete Quoting**: The function previously only quoted strings if they contained a literal space character. It now uses `isSpace()` to properly detect and quote strings containing tabs, newlines, or other whitespace that would otherwise break the level parser.
2.  **NULL Safety**: Added a guard to return an empty string instead of crashing when `NULL` is passed as an argument.

Comprehensive unit tests have been added to `bitfighter_test/TestStringUtils.cpp` to verify these fixes.

---
*PR created automatically by Jules for task [9631784826196334012](https://jules.google.com/task/9631784826196334012) started by @eykamp*