### PR TITLE
Fix stricmp/strnicmp signedness and over-read bugs

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -497,6 +497,12 @@ TEST(StringUtilsTest, stricmpNonASCII)
    EXPECT_EQ(0, stricmp("\xFF", "\xFF"));
    EXPECT_EQ(0, stricmp("A\x80", "a\x80"));
    EXPECT_NE(0, stricmp("\xFF", "\xFE"));
+
+   // Bug reproduction: ASCII should come before non-ASCII (high-bit set)
+   // 'a' is 97, '\xFF' is 255 (unsigned) or -1 (signed)
+   // We want stricmp("a", "\xFF") < 0
+   EXPECT_LT(stricmp("a", "\xFF"), 0);
+   EXPECT_GT(stricmp("\xFF", "a"), 0);
 }
 
 
@@ -506,6 +512,14 @@ TEST(StringUtilsTest, strnicmpNonASCII)
    EXPECT_EQ(0, strnicmp("A\x80", "a\x80", 2));
    EXPECT_NE(0, strnicmp("\xFF", "\xFE", 1));
    EXPECT_EQ(0, strnicmp("abc\xFF", "ABC\xFF", 3));
+}
+
+
+TEST(StringUtilsTest, strnicmpOverRead)
+{
+   // These should not crash or over-read
+   EXPECT_EQ(0, strnicmp("abc", "abc", 10));
+   EXPECT_NE(0, strnicmp("abc", "abd", 10));
 }
 
 
@@ -796,6 +810,10 @@ TEST(StringUtilsTest, sorting)
    EXPECT_TRUE(alphaSort("a", "B"));
    EXPECT_TRUE(alphaSort("A", "B"));
    EXPECT_FALSE(alphaSort("b", "a"));
+
+   // Bug reproduction: alphaSort should sort ASCII before non-ASCII
+   EXPECT_TRUE(alphaSort("a", "\xFF"));
+   EXPECT_FALSE(alphaSort("\xFF", "a"));
 
    EXPECT_TRUE(alphaNumberSort("2", "10"));
    EXPECT_TRUE(alphaNumberSort("10", "a"));

--- a/tnl/platform.cpp
+++ b/tnl/platform.cpp
@@ -527,8 +527,8 @@ int stricmp(const char *str1, const char *str2)
       str1++;
       str2++;
    }
-   char c1 = toUpper(*str1);
-   char c2 = toUpper(*str2);
+   unsigned char c1 = (unsigned char)toUpper(*str1);
+   unsigned char c2 = (unsigned char)toUpper(*str2);
    return (c1 > c2) ? 1 : ((c1 < c2) ? -1 : 0);
 }
 
@@ -536,10 +536,14 @@ int strnicmp(const char *str1, const char *str2, unsigned int len)
 {
    for(unsigned int i = 0; i < len; i++)
    {
-      char c1 = toUpper(str1[i]);
-      char c2 = toUpper(str2[i]);
+      unsigned char c1 = (unsigned char)toUpper(str1[i]);
+      unsigned char c2 = (unsigned char)toUpper(str2[i]);
       if(c1 == c2)
+      {
+         if(!c1)
+            break;
          continue;
+      }
       return (c1 > c2) ? 1 : ((c1 < c2) ? -1 : 0);
    }
    return 0;


### PR DESCRIPTION
This PR fixes two bugs in the `stricmp` and `strnicmp` functions in `tnl/platform.cpp`:
1. **Signedness Bug**: Characters were compared as signed `char`, causing characters with the high bit set (non-ASCII) to be treated as smaller than standard ASCII characters. This resulted in incorrect sorting. The fix casts characters to `unsigned char` before comparison.
2. **Over-read Bug**: `strnicmp` did not check for the null terminator within the loop, which could lead to reading past the end of the string if the length parameter was larger than the string itself.
Unit tests have been added to `bitfighter_test/TestStringUtils.cpp` to verify the fix and prevent regressions.
I am an AI agent completing this task.

---
*PR created automatically by Jules for task [16059273720801833215](https://jules.google.com/task/16059273720801833215) started by @eykamp*