### PR TITLE
Fix non-ASCII ordering and over-read bugs in stricmp/strnicmp

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -509,6 +509,24 @@ TEST(StringUtilsTest, strnicmpNonASCII)
 }
 
 
+TEST(StringUtilsTest, stricmpOrderingNonASCII)
+{
+   // 'a' is 0x61, '\xFF' is 0xFF.
+   // Unsigned: 0x61 < 0xFF (stricmp should return negative)
+   // Signed: 97 > -1 (stricmp would incorrectly return positive)
+   EXPECT_LT(stricmp("a", "\xFF"), 0);
+   EXPECT_GT(stricmp("\xFF", "a"), 0);
+}
+
+
+TEST(StringUtilsTest, strnicmpOverRead)
+{
+   // strnicmp should stop at null terminator even if len is larger
+   EXPECT_EQ(0, strnicmp("abc", "abc", 10));
+   EXPECT_LT(strnicmp("abc", "abd", 10), 0);
+}
+
+
 TEST(StringUtilsTest, countCharInString)
 {
    EXPECT_EQ(3, countCharInString("banana", 'a'));

--- a/tnl/platform.cpp
+++ b/tnl/platform.cpp
@@ -527,8 +527,8 @@ int stricmp(const char *str1, const char *str2)
       str1++;
       str2++;
    }
-   char c1 = toUpper(*str1);
-   char c2 = toUpper(*str2);
+   unsigned char c1 = (unsigned char)toUpper(*str1);
+   unsigned char c2 = (unsigned char)toUpper(*str2);
    return (c1 > c2) ? 1 : ((c1 < c2) ? -1 : 0);
 }
 
@@ -536,11 +536,12 @@ int strnicmp(const char *str1, const char *str2, unsigned int len)
 {
    for(unsigned int i = 0; i < len; i++)
    {
-      char c1 = toUpper(str1[i]);
-      char c2 = toUpper(str2[i]);
-      if(c1 == c2)
-         continue;
-      return (c1 > c2) ? 1 : ((c1 < c2) ? -1 : 0);
+      unsigned char c1 = (unsigned char)toUpper(str1[i]);
+      unsigned char c2 = (unsigned char)toUpper(str2[i]);
+      if(c1 != c2)
+         return (c1 > c2) ? 1 : -1;
+      if(!c1)
+         break;
    }
    return 0;
 }


### PR DESCRIPTION
I found and fixed two bugs in the `stricmp` and `strnicmp` functions within `tnl/platform.cpp`. 

The first bug caused incorrect ordering of non-ASCII characters (those with values > 127) because the code was performing magnitude comparisons on signed `char` types. On many systems, this caused high-bit characters to be treated as negative values, incorrectly placing them before standard ASCII letters. I fixed this by casting characters to `unsigned char` before comparison.

The second bug in `strnicmp` allowed the function to potentially read beyond the null terminator if the specified length exceeded the string's actual length. I added a check to stop comparison once a null terminator is encountered.

I also added two new unit tests to `bitfighter_test/TestStringUtils.cpp` to verify these fixes and ensure no regressions. All 55 string utility tests now pass correctly.

I am an AI agent, and these changes were implemented as part of a task to identify and fix a bug with associated unit testing.

---
*PR created automatically by Jules for task [9039131355654857357](https://jules.google.com/task/9039131355654857357) started by @eykamp*