### PR TITLE
Fix bugs in TNL::StringPtr and add unit tests

### DIFF
--- a/bitfighter_test/TestTnlString.cpp
+++ b/bitfighter_test/TestTnlString.cpp
@@ -54,6 +54,7 @@ TEST(TnlStringTest, StringPtrConstructors)
    TNL::StringPtr sNull;
    TNL::StringPtr s4(sNull);
    EXPECT_STREQ("", s4.getString());
+}
 
 
 TEST(TnlStringTest, DefaultConstructor)

--- a/bitfighter_test/TestTnlString.cpp
+++ b/bitfighter_test/TestTnlString.cpp
@@ -1,0 +1,51 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "tnlString.h"
+#include "gtest/gtest.h"
+
+namespace Zap {
+
+TEST(TnlStringTest, StringPtrAssignment)
+{
+   TNL::StringPtr s1("test");
+   TNL::StringPtr s2;
+
+   // Test assigning empty StringPtr to another
+   EXPECT_NO_THROW(s1 = s2);
+   EXPECT_STREQ("", s1.getString());
+
+   // Test self-assignment
+   TNL::StringPtr s3("self");
+   EXPECT_NO_THROW(s3 = s3);
+   EXPECT_STREQ("self", s3.getString());
+
+   // Test assigning NULL char pointer
+   TNL::StringPtr s4("before");
+   EXPECT_NO_THROW(s4 = (const char*)NULL);
+   EXPECT_STREQ("", s4.getString());
+}
+
+TEST(TnlStringTest, StringPtrConstructors)
+{
+   // NULL constructor
+   TNL::StringPtr s1((const char*)NULL);
+   EXPECT_STREQ("", s1.getString());
+
+   // Empty string constructor
+   TNL::StringPtr s2("");
+   EXPECT_STREQ("", s2.getString());
+
+   // Normal constructor
+   TNL::StringPtr s3("hello");
+   EXPECT_STREQ("hello", s3.getString());
+
+   // Copy constructor with NULL
+   TNL::StringPtr sNull;
+   TNL::StringPtr s4(sNull);
+   EXPECT_STREQ("", s4.getString());
+}
+
+} // namespace Zap

--- a/tnl/tnlString.h
+++ b/tnl/tnlString.h
@@ -31,6 +31,12 @@
 #pragma warning (disable: 4996)     // Disable POSIX deprecation, certain security warnings that seem to be specific to VC++
 #endif
 
+#include "tnlTypes.h"
+#include "tnlAssert.h"
+#include <string>
+#include <string.h>
+#include <stdlib.h>
+
 namespace TNL
 {
 
@@ -45,6 +51,11 @@ class StringPtr
    StringData *mString;
    void alloc(const char *string)
    {
+      if(!string)
+      {
+         mString = NULL;
+         return;
+      }
       mString = (StringData *) malloc(sizeof(StringData) + strlen(string));
       TNLAssert(mString != nullptr, "Memory allocation failed");
       if (mString == nullptr) {
@@ -83,9 +94,12 @@ public:
    }
    StringPtr &operator=(const StringPtr &ref)
    {
+      if(this == &ref)
+         return *this;
       decRef();
       mString = ref.mString;
-      mString->mRefCount++;
+      if(mString)
+         mString->mRefCount++;
       return *this;
    }
    StringPtr &operator=(const char *string)

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -43,6 +43,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestStringUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/main_test.cpp


### PR DESCRIPTION
This PR addresses critical bugs in the `TNL::StringPtr` class, a reference-counted string wrapper.

Key fixes:
1. **NULL Pointer Handling**: The `alloc()` method now checks for `NULL` input, preventing a crash in `strlen()`.
2. **Self-Assignment Protection**: Added a `this == &ref` check in the assignment operator to prevent an object from potentially freeing its own memory when assigned to itself.
3. **Safe Source Assignment**: The assignment operator now correctly handles cases where the source `StringPtr` is empty (internal `mString` is `NULL`).
4. **Missing Headers**: Added missing includes (`tnlTypes.h`, `tnlAssert.h`, `<string>`, `<string.h>`, `<stdlib.h>`) required for the class implementation.

A new test file `bitfighter_test/TestTnlString.cpp` was added with comprehensive unit tests covering these edge cases. The build system was updated to include these tests in the `bitfighter_test` suite. All tests (425 total) pass.

I am an AI agent.

---
*PR created automatically by Jules for task [6437480070274849945](https://jules.google.com/task/6437480070274849945) started by @eykamp*