### PR TITLE
Fix bugs in TNL::StringPtr and add unit tests

### DIFF
--- a/bitfighter_test/TestTnlString.cpp
+++ b/bitfighter_test/TestTnlString.cpp
@@ -1,0 +1,86 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "tnlTypes.h"
+#include "tnlAssert.h"
+#include "tnlString.h"
+#include "gtest/gtest.h"
+#include <string>
+#include <string.h>
+#include <stdlib.h>
+
+namespace Zap
+{
+
+using namespace TNL;
+
+TEST(TnlStringTest, DefaultConstructor)
+{
+   StringPtr s;
+   EXPECT_STREQ("", s.getString());
+   EXPECT_STREQ("", (const char *)s);
+}
+
+TEST(TnlStringTest, CStringConstructor)
+{
+   StringPtr s("hello");
+   EXPECT_STREQ("hello", s.getString());
+}
+
+TEST(TnlStringTest, NullCStringConstructor)
+{
+   // This is expected to crash due to strlen(NULL)
+   StringPtr s((const char *)NULL);
+   EXPECT_STREQ("", s.getString());
+}
+
+TEST(TnlStringTest, CopyConstructor)
+{
+   StringPtr s1("hello");
+   StringPtr s2(s1);
+   EXPECT_STREQ("hello", s2.getString());
+}
+
+TEST(TnlStringTest, AssignmentOperator)
+{
+   StringPtr s1("hello");
+   StringPtr s2;
+   s2 = s1;
+   EXPECT_STREQ("hello", s2.getString());
+}
+
+TEST(TnlStringTest, SelfAssignment)
+{
+   // This is expected to crash or cause use-after-free
+   StringPtr s("hello");
+   s = s;
+   EXPECT_STREQ("hello", s.getString());
+}
+
+TEST(TnlStringTest, NullAssignment)
+{
+   // Assigning from a StringPtr that holds NULL
+   StringPtr s1;
+   StringPtr s2("hello");
+   s2 = s1;
+   EXPECT_STREQ("", s2.getString());
+}
+
+TEST(TnlStringTest, NullCStringAssignment)
+{
+   // This is expected to crash due to strlen(NULL)
+   StringPtr s("hello");
+   s = (const char *)NULL;
+   EXPECT_STREQ("", s.getString());
+}
+
+TEST(TnlStringTest, StdStringConstructor)
+{
+   std::string std_s = "hello";
+   StringPtr s(std_s);
+   EXPECT_STREQ("hello", s.getString());
+}
+
+} // namespace Zap

--- a/tnl/tnlString.h
+++ b/tnl/tnlString.h
@@ -27,6 +27,12 @@
 #ifndef _TNL_STRING_H_
 #define _TNL_STRING_H_
 
+#include "tnlTypes.h"
+#include "tnlAssert.h"
+#include <string>
+#include <string.h>
+#include <stdlib.h>
+
 #ifdef _MSC_VER
 #pragma warning (disable: 4996)     // Disable POSIX deprecation, certain security warnings that seem to be specific to VC++
 #endif
@@ -45,6 +51,11 @@ class StringPtr
    StringData *mString;
    void alloc(const char *string)
    {
+      if(!string)
+      {
+         mString = NULL;
+         return;
+      }
       mString = (StringData *) malloc(sizeof(StringData) + strlen(string));
       TNLAssert(mString != nullptr, "Memory allocation failed");
       if (mString == nullptr) {
@@ -83,9 +94,12 @@ public:
    }
    StringPtr &operator=(const StringPtr &ref)
    {
+      if(this == &ref)
+         return *this;
       decRef();
       mString = ref.mString;
-      mString->mRefCount++;
+      if(mString)
+         mString->mRefCount++;
       return *this;
    }
    StringPtr &operator=(const char *string)

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -44,6 +44,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/main_test.cpp
 )


### PR DESCRIPTION
I am an AI agent. I have identified and fixed several bugs in the `TNL::StringPtr` class in `tnl/tnlString.h`, which is used for reference-counted strings.

The fixes include:
1.  **NULL pointer safety in `alloc()`**: The method now correctly handles `NULL` C-string inputs by setting the internal pointer to `NULL` instead of crashing in `strlen()`.
2.  **Self-assignment protection**: `operator=(const StringPtr &)` now includes a check to prevent use-after-free or corruption when an object is assigned to itself.
3.  **NULL reference safety in assignment**: The assignment operator now checks if the source `StringPtr` holds a `NULL` internal string before attempting to increment its reference count.
4.  **Self-contained header**: Added missing includes (`tnlTypes.h`, `tnlAssert.h`, `<string>`, `<string.h>`, and `<stdlib.h>`) to `tnl/tnlString.h` to resolve compilation errors in tests.

I also added a new unit test suite, `bitfighter_test/TestTnlString.cpp`, covering various scenarios including default construction, C-string and `std::string` initialization, copy construction, and assignment (including the edge cases fixed). All tests pass.

No build artifacts or environment-specific files were included in this submission.

---
*PR created automatically by Jules for task [13647867022589432805](https://jules.google.com/task/13647867022589432805) started by @eykamp*