### PR TITLE
Fix memory safety in StringPtr and enhance string utility robustness

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -265,6 +265,12 @@ TEST(StringUtilsTest, replaceStringNullReplace)
 }
 
 
+TEST(StringUtilsTest, replaceStringNullFind)
+{
+    EXPECT_EQ("foo", replaceString("foo", (const char*)NULL, "a"));
+}
+
+
 TEST(StringUtilsTest, lcase_ucase)
 {
    EXPECT_EQ("abc", lcase("ABC"));

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -253,6 +253,18 @@ TEST(StringUtilsTest, replaceStringEmptyFrom)
 }
 
 
+TEST(StringUtilsTest, replaceStringNullInput)
+{
+    EXPECT_EQ("", replaceString((const char*)NULL, "a", "b"));
+}
+
+
+TEST(StringUtilsTest, replaceStringNullReplace)
+{
+    EXPECT_EQ("foo", replaceString("foo", "a", (const char*)NULL));
+}
+
+
 TEST(StringUtilsTest, lcase_ucase)
 {
    EXPECT_EQ("abc", lcase("ABC"));

--- a/bitfighter_test/TestTnlString.cpp
+++ b/bitfighter_test/TestTnlString.cpp
@@ -117,6 +117,20 @@ TEST(TnlStringTest, NullCStringAssignment)
    EXPECT_STREQ("", s.getString());
 }
 
+TEST(TnlStringTest, StringPtrSelfAssignmentFromBuffer)
+{
+    TNL::StringPtr s("hello");
+    const char* ptr = s.getString();
+    s = ptr;
+    EXPECT_STREQ("hello", s.getString());
+
+    // Test with substring
+    s = "hello world";
+    ptr = s.getString() + 6;
+    s = ptr;
+    EXPECT_STREQ("world", s.getString());
+}
+
 TEST(TnlStringTest, StdStringConstructor)
 {
    std::string std_s = "hello";

--- a/tnl/tnlString.h
+++ b/tnl/tnlString.h
@@ -110,8 +110,18 @@ public:
    }
    StringPtr &operator=(const char *string)
    {
-      decRef();
-      alloc(string);
+      if (string && mString && string >= mString->mStringData && string <= mString->mStringData + strlen(mString->mStringData))
+      {
+         const char *copy = strdup(string);
+         decRef();
+         alloc(copy);
+         free((void *)copy);
+      }
+      else
+      {
+         decRef();
+         alloc(string);
+      }
       return *this;
    }
    operator const char *() const

--- a/tnl/tnlString.h
+++ b/tnl/tnlString.h
@@ -110,12 +110,15 @@ public:
    }
    StringPtr &operator=(const char *string)
    {
+      // Check if 'string' points into our own internal data buffer (aliasing).
+      // If it does, we must make a temporary copy before calling decRef(),
+      // which might free the memory 'string' is pointing to.
       if (string && mString && string >= mString->mStringData && string <= mString->mStringData + strlen(mString->mStringData))
       {
-         const char *copy = strdup(string);
-         decRef();
-         alloc(copy);
-         free((void *)copy);
+         const char *copy = strdup(string);   // Create a safe temporary copy
+         decRef();                            // Safe to release our buffer now
+         alloc(copy);                         // Allocate new buffer from the copy
+         free((void *)copy);                  // Clean up the temporary copy
       }
       else
       {

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -863,8 +863,14 @@ string ctos(char c)
 
 string replaceString(const char *in, const char *find, const char *replace)
 {
+   if(!in)
+      return "";
+
    if(!find || find[0] == 0)
       return in;
+
+   if(!replace)
+      replace = "";
 
    string out;
    size_t n = 0;

--- a/zap/stringUtils.h
+++ b/zap/stringUtils.h
@@ -55,6 +55,7 @@ string ftos(F32 f);
 F64 stof(const string &s);
 
 string replaceString(const string &strString, const string &strOld, const string &strNew);
+string replaceString(const char *in, const char *find, const char *replace);
 string stripExtension(string filename);
 
 string listToString(const Vector<string> &words, const string &seperator);


### PR DESCRIPTION
This PR fixes a critical memory safety issue in the `TNL::StringPtr` class and improves the robustness of the `replaceString` utility function.

### Bug Fixes

1.  **StringPtr Use-After-Free**: The `operator=(const char *string)` in `TNL::StringPtr` previously called `decRef()` (which could free the internal buffer) before `alloc(string)`. If `string` pointed inside the internal buffer being freed (e.g., `s = s.getString() + 5`), this resulted in a use-after-free during the `strlen` or `strcpy` inside `alloc`. The fix adds a check for aliasing and creates a temporary copy if necessary.
2.  **replaceString NULL Safety**: Added NULL checks to the C-string version of `replaceString` in `zap/stringUtils.cpp`. This prevents crashes when passing NULL as the input or replacement string.
3.  **Header Declaration**: Explicitly declared `replaceString(const char*, const char*, const char*)` in `zap/stringUtils.h` to ensure the correct overload is matched by callers, preventing unnecessary and potentially crash-prone `std::string` constructions from NULL.

### Testing

New unit tests were added to:
- `bitfighter_test/TestTnlString.cpp`: `StringPtrSelfAssignmentFromBuffer` verifies substring self-assignment.
- `bitfighter_test/TestStringUtils.cpp`: `replaceStringNullInput` and `replaceStringNullReplace` verify the new NULL handling.

All 438 tests in the `bitfighter_test` suite passed successfully.

I am an AI agent.

---
*PR created automatically by Jules for task [8306987770594820974](https://jules.google.com/task/8306987770594820974) started by @eykamp*