### PR TITLE
Fix ftos leading space and replaceString NULL pointer crashes

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -225,6 +225,9 @@ TEST(StringUtilsTest, ftosBugReproduction)
    // Negative digits value
    // itos(-1) is "-1", format string becomes "%2.-1f"
    EXPECT_EQ("1.23456", ftos(1.23456f, -1));
+
+   // Bug: ftos(1.0f, 0) incorrectly returns " 1" instead of "1"
+   EXPECT_EQ("1", ftos(1.0f, 0));
 }
 
 
@@ -250,6 +253,16 @@ TEST(StringUtilsTest, replaceStringEmptyFrom)
    // These should return the original string and not hang
    EXPECT_EQ("test", replaceString("test", "", "replacement"));
    EXPECT_EQ("test", replaceString((const char *)"test", "", "replacement"));
+}
+
+
+TEST(StringUtilsTest, replaceStringNULL)
+{
+   // Bug: replaceString(NULL, ...) crashes
+   EXPECT_EQ("", replaceString((const char *)NULL, "find", "replace"));
+   // Bug: replaceString(..., ..., NULL) crashes
+   // If replace is NULL, it's treated as an empty string, so "a" -> ""
+   EXPECT_EQ("", replaceString("a", "a", (const char *)NULL));
 }
 
 

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -263,6 +263,9 @@ TEST(StringUtilsTest, replaceStringNULL)
    // Bug: replaceString(..., ..., NULL) crashes
    // If replace is NULL, it's treated as an empty string, so "a" -> ""
    EXPECT_EQ("", replaceString("a", "a", (const char *)NULL));
+}
+
+
 TEST(StringUtilsTest, replaceStringNullInput)
 {
     EXPECT_EQ("", replaceString((const char*)NULL, "a", "b"));

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -143,7 +143,7 @@ string ftos(F32 f, S32 digits)
       digits = 30;
 
    char outString[100];
-   dSprintf(outString, sizeof(outString), (string("%2.") + itos(digits) + "f").c_str(), f);
+   dSprintf(outString, sizeof(outString), (string("%.") + itos(digits) + "f").c_str(), f);
 
    return stripZeros(outString);
 }
@@ -863,8 +863,14 @@ string ctos(char c)
 
 string replaceString(const char *in, const char *find, const char *replace)
 {
+   if(!in)
+      return "";
+
    if(!find || find[0] == 0)
       return in;
+
+   if(!replace)
+      replace = "";
 
    string out;
    size_t n = 0;


### PR DESCRIPTION
This PR fixes two bugs in the `stringUtils.cpp` utility library and adds unit tests to verify the fixes.

1. **`ftos` leading space bug**: The `ftos(F32 f, S32 digits)` function was using a format string starting with `%2.`, which caused it to pad results with a leading space if they were only one digit long (e.g., `ftos(1.0f, 0)` returned `" 1"`). I changed this to `%.` to ensure no unwanted padding is added.

2. **`replaceString` NULL pointer crash**: The C-string version of `replaceString` lacked NULL pointer checks, which could lead to crashes if passed NULL arguments. I added checks to return an empty string if the input is NULL, and to treat a NULL replacement string as an empty string.

I have included unit tests in `bitfighter_test/TestStringUtils.cpp` for both of these cases.

I am an AI agent. Please do not merge this into the main branch.

---
*PR created automatically by Jules for task [13864769786456439057](https://jules.google.com/task/13864769786456439057) started by @eykamp*