### PR TITLE
Fix s_fprintf truncation and readFile BOM trimming bugs

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -989,7 +989,7 @@ TEST(StringUtilsTest, formatMessage)
 
 TEST(StringUtilsTest, s_fprintf)
 {
-   string testFile = "test_fprintf.txt";
+   std::string testFile = "test_fprintf.txt";
    FILE *f = fopen(testFile.c_str(), "w");
    ASSERT_TRUE(f != NULL);
 
@@ -1000,5 +1000,38 @@ TEST(StringUtilsTest, s_fprintf)
    remove(testFile.c_str());
 }
 
+TEST(StringUtilsTest, readFileBOMBug)
+{
+   std::string testFile = "test_bom_bug.txt";
+   // \xBB is 187 decimal, or \273 octal. It is part of the UTF-8 BOM (\xEF\xBB\xBF).
+   std::string content = "\xBB" "Some content";
+   ASSERT_TRUE(writeFile(testFile, content));
+
+   // Current implementation uses trim_left_in_place(result, "\357\273\277");
+   // which will remove the leading \xBB even if it's not the full BOM.
+   std::string readContent = readFile(testFile);
+   EXPECT_EQ(content, readContent);
+
+   remove(testFile.c_str());
+}
+
+TEST(StringUtilsTest, s_fprintfTruncationBug)
+{
+   std::string testFile = "test_fprintf_truncation.txt";
+   FILE *f = fopen(testFile.c_str(), "w");
+   ASSERT_TRUE(f != NULL);
+
+   // Create a string longer than 2048 characters
+   std::string longString(2500, 'a');
+   s_fprintf(f, "%s", longString.c_str());
+   fclose(f);
+
+   std::string readContent = readFile(testFile);
+   // Current implementation has a 2048 byte buffer
+   EXPECT_EQ(longString.length(), readContent.length());
+   EXPECT_EQ(longString, readContent);
+
+   remove(testFile.c_str());
+}
 
 };

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -561,15 +561,13 @@ void s_fprintf(FILE *stream, const char *format, ...)
     va_list args;
     va_start(args, format);
 
-    char buffer[2048];
-    vsnprintf(buffer, sizeof(buffer), format, args);
-
-    va_end(args);
-
-    if(fprintf(stream, "%s", buffer) < 0)     // Uh-oh...
+    if(vfprintf(stream, format, args) < 0)     // Uh-oh...
     {
+       va_end(args);
        throw(SaveException("Error writing to file"));
     }
+
+    va_end(args);
 }
 
 
@@ -985,7 +983,9 @@ const string readFile(const string &path)
 
    // Remove the UTF-8 BOM if it exists
    // These are the first three bytes:  EF BB BF
-   trim_left_in_place(result, "\357\273\277");
+   static const string bom = "\xEF\xBB\xBF";
+   if (result.compare(0, bom.length(), bom) == 0)
+      result.erase(0, bom.length());
 
    return result;
 }


### PR DESCRIPTION
I am an AI agent. This PR fixes two bugs in `zap/stringUtils.cpp`:

1.  **`s_fprintf` Buffer Truncation:** The original implementation used a fixed 2048-byte buffer, which caused truncation for longer formatted strings. This has been replaced with a direct call to `vfprintf` on the file stream, removing the arbitrary limit.
2.  **`readFile` BOM Trimming:** The original code used `trim_left_in_place(result, "\357\273\277")` to remove the UTF-8 Byte Order Mark (BOM). This incorrectly stripped any character from that set (EF, BB, BF) if it appeared at the start of the file. It now performs a precise check for the 3-byte BOM sequence and erases it if present.

I have added reproduction unit tests in `bitfighter_test/TestStringUtils.cpp` (`s_fprintfTruncationBug` and `readFileBOMBug`) to verify these fixes and prevent regressions. All 442 tests in the project's test suite passed successfully.


---
*PR created automatically by Jules for task [14193482001130912870](https://jules.google.com/task/14193482001130912870) started by @eykamp*