### PR TITLE
Fix Vector<bool> storage and pointer alignment in TNL

### DIFF
--- a/bitfighter_test/TestTnlVectorBool.cpp
+++ b/bitfighter_test/TestTnlVectorBool.cpp
@@ -1,0 +1,51 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "tnlVector.h"
+#include "gtest/gtest.h"
+
+using namespace TNL;
+
+namespace Zap {
+
+TEST(TnlVectorBoolTest, AddressCompatibility)
+{
+   Vector<bool> v;
+   v.push_back(true);
+   v.push_back(false);
+   v.push_back(true);
+   v.push_back(false);
+
+   EXPECT_EQ(4, v.size());
+
+   bool *ptr = v.address();
+   ASSERT_NE(nullptr, ptr);
+
+   // This is expected to fail with the current implementation because
+   // address() returns a bool* into a std::vector<S32>, so ptr[1]
+   // is actually the second byte of the first S32, not the first byte
+   // of the second S32 (which is where v[1] is stored).
+   EXPECT_EQ(v[0], ptr[0]);
+   EXPECT_EQ(v[1], ptr[1]);
+   EXPECT_EQ(v[2], ptr[2]);
+   EXPECT_EQ(v[3], ptr[3]);
+}
+
+TEST(TnlVectorBoolTest, OperatorAndAddressConsistency)
+{
+    Vector<bool> v;
+    for(int i = 0; i < 10; ++i)
+        v.push_back((i % 2) == 0);
+
+    bool *ptr = v.address();
+    for(int i = 0; i < 10; ++i)
+    {
+        // v[i] accesses innerVector[i], which is at offset i * sizeof(S32)
+        // ptr[i] accesses *(ptr + i), which is at offset i * sizeof(bool)
+        EXPECT_EQ(v[i], ptr[i]) << "Mismatch at index " << i;
+    }
+}
+
+} // namespace Zap

--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 set(MASTER_DEPS tnl)
 # Add tomcypt if not already found on system
 if(NOT TOMCRYPT_FOUND)
-	list(APPEND MASTER_DEPS libtomcrypt)
+	list(APPEND MASTER_DEPS tomcrypt)
 endif()
 
 set(MASTER_LIBS 

--- a/tnl/tnlVector.h
+++ b/tnl/tnlVector.h
@@ -68,7 +68,11 @@ protected:
 template<> class VectorBase<bool>
 {
 protected:
-   std::vector<S32> innerVector;  // Use 'int' instead of 'char' to prevent endian-issues
+   // We use U8 (1 byte) instead of S32 (4 bytes) to ensure that sizeof(bool)
+   // matches the size of each element in the vector. This is necessary because
+   // Vector::address() returns a T* (bool*), and pointer arithmetic on bool*
+   // expects elements to be 1 byte apart.
+   std::vector<U8> innerVector;
 };
 
 

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -43,6 +43,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestStringUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVectorBool.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp


### PR DESCRIPTION
This PR fixes a bug in the `TNL::Vector<bool>` specialization where elements were stored as `S32` (4 bytes) but accessed via `address()` as `bool*` (typically 1 byte). This caused pointer arithmetic to fail, leading to misaligned data access and potential memory corruption.

### Changes
- **TNL Core:** Modified `tnl/tnlVector.h` to use `std::vector<U8>` for `VectorBase<bool>`. This ensures each element occupies exactly 1 byte, aligning with `sizeof(bool)` and ensuring `address()` returns a pointer compatible with standard array indexing.
- **Testing:** Created `bitfighter_test/TestTnlVectorBool.cpp` with test cases verifying that `address()` and `operator[]` access the same data points.
- **Build System:** 
    - Registered the new test file in `zap/bitfighter_test.cmake`.
    - Fixed a dependency name in `master/CMakeLists.txt` (changed `libtomcrypt` to `tomcrypt`) to resolve build errors.

I am an AI agent. Please do not merge this change into the main line codebase.

---
*PR created automatically by Jules for task [9284688017668044739](https://jules.google.com/task/9284688017668044739) started by @eykamp*