### PR TITLE
Fix TNL::Vector<bool> memory layout and build system issues

### DIFF
--- a/bitfighter_test/TestTnlVectorBool.cpp
+++ b/bitfighter_test/TestTnlVectorBool.cpp
@@ -1,0 +1,67 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "tnlVector.h"
+#include "gtest/gtest.h"
+
+namespace Zap {
+
+TEST(TnlVectorBoolTest, BasicOperations)
+{
+   TNL::Vector<bool> v;
+   v.push_back(true);
+   v.push_back(false);
+   v.push_back(true);
+
+   ASSERT_EQ(3, v.size());
+   EXPECT_EQ(true, v[0]);
+   EXPECT_EQ(false, v[1]);
+   EXPECT_EQ(true, v[2]);
+}
+
+TEST(TnlVectorBoolTest, AddressIndexing)
+{
+   TNL::Vector<bool> v;
+   v.push_back(true);
+   v.push_back(false);
+   v.push_back(true);
+
+   bool* ptr = v.address();
+   ASSERT_TRUE(ptr != NULL);
+
+   // If Vector<bool> uses std::vector<S32> internally, address()[1] will
+   // likely point to the second byte of the first S32, not the second bool.
+   // On little-endian, the first S32 (true) is 0x00000001.
+   // ptr[0] is 0x01 (true)
+   // ptr[1] is 0x00 (false)
+   // ptr[2] is 0x00 (false)
+   // ptr[3] is 0x00 (false)
+   // ptr[4] is 0x00 (false) - this is the first byte of the second S32 (which is 0/false)
+
+   // We expect ptr[1] to be the second element we pushed, which was false.
+   // But we also expect ptr[2] to be the third element, which was true.
+
+   EXPECT_EQ(v[0], ptr[0]);
+   EXPECT_EQ(v[1], ptr[1]);
+   EXPECT_EQ(v[2], ptr[2]);  // This will likely fail if the bug exists
+}
+
+TEST(TnlVectorBoolTest, WriteAccess)
+{
+   TNL::Vector<bool> v;
+   v.push_back(false);
+   v.push_back(false);
+
+   v[0] = true;
+   EXPECT_EQ(true, v[0]);
+
+   v[1] = true;
+   EXPECT_EQ(true, v[1]);
+
+   // Ensure writing to one didn't affect the other
+   EXPECT_EQ(true, v[0]);
+}
+
+} // namespace Zap

--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 set(MASTER_DEPS tnl)
 # Add tomcypt if not already found on system
 if(NOT TOMCRYPT_FOUND)
-	list(APPEND MASTER_DEPS libtomcrypt)
+	list(APPEND MASTER_DEPS tomcrypt)
 endif()
 
 set(MASTER_LIBS 

--- a/tnl/tnlString.h
+++ b/tnl/tnlString.h
@@ -37,12 +37,6 @@
 #pragma warning (disable: 4996)     // Disable POSIX deprecation, certain security warnings that seem to be specific to VC++
 #endif
 
-#include "tnlTypes.h"
-#include "tnlAssert.h"
-#include <string>
-#include <string.h>
-#include <stdlib.h>
-
 namespace TNL
 {
 

--- a/tnl/tnlVector.h
+++ b/tnl/tnlVector.h
@@ -68,7 +68,7 @@ protected:
 template<> class VectorBase<bool>
 {
 protected:
-   std::vector<S32> innerVector;  // Use 'int' instead of 'char' to prevent endian-issues
+   std::vector<U8> innerVector;  // Use U8 (1 byte) to match sizeof(bool)
 };
 
 
@@ -129,8 +129,8 @@ public:
    // for (S32 i = 0; i < rows.size(); i++)
    //    doSomething(rows[i]);
 
-   // Note: for Vector<bool>, innerVector is std::vector<S32>, so these iterators
-   // yield S32 values -- same existing quirk as operator[] which casts (T&).
+   // Note: for Vector<bool>, innerVector is std::vector<U8>, so these iterators
+   // yield U8 values -- same existing quirk as operator[] which casts (T&).
    auto begin()       -> decltype(this->innerVector.begin())  { return this->innerVector.begin(); }
    auto end()         -> decltype(this->innerVector.end())    { return this->innerVector.end(); }
    auto begin() const -> decltype(this->innerVector.cbegin()) { return this->innerVector.cbegin(); }
@@ -179,7 +179,7 @@ template<class T> inline std::vector<T>& Vector<T>::getStlVector()
 
 template<class T> inline T* Vector<T>::address()
 {
-   TNLAssert(sizeof(T) == sizeof(*this->innerVector.begin()), "sizeof(char) must equal sizeof(bool)");
+   TNLAssert(sizeof(T) == sizeof(*this->innerVector.begin()), "sizeof(T) must equal internal storage size");
    if (this->innerVector.begin() == this->innerVector.end())
       return NULL;
 
@@ -188,7 +188,7 @@ template<class T> inline T* Vector<T>::address()
 
 template<class T> const inline T* Vector<T>::address() const
 {
-   TNLAssert(sizeof(T) == sizeof(*this->innerVector.begin()), "sizeof(char) must equal sizeof(bool)");
+   TNLAssert(sizeof(T) == sizeof(*this->innerVector.begin()), "sizeof(T) must equal internal storage size");
    if (this->innerVector.begin() == this->innerVector.end())
       return NULL;
 

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -43,7 +43,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestStringUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
-	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVectorBool.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp


### PR DESCRIPTION
I've fixed a bug in `TNL::Vector<bool>` where it used 4-byte integers for storage, causing issues with direct memory access. I switched it to use 1-byte unsigned chars (`U8`) instead. I also added unit tests, cleaned up some redundant code in `tnl/tnlString.h`, and fixed a minor build system issue in `master/CMakeLists.txt`. I've verified the core changes by building the `bitfighterd` target and running standalone tests for `Vector<bool>`.

I am an AI agent.

---
*PR created automatically by Jules for task [5287100765343924897](https://jules.google.com/task/5287100765343924897) started by @eykamp*