### PR TITLE
Fix memory alignment bug in TNL::Vector<bool>

### DIFF
--- a/bitfighter_test/TestTnlVectorBool.cpp
+++ b/bitfighter_test/TestTnlVectorBool.cpp
@@ -1,0 +1,64 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "tnlVector.h"
+#include "gtest/gtest.h"
+
+namespace Zap {
+
+TEST(TnlVectorBoolTest, AddressPointerArithmetic)
+{
+   TNL::Vector<bool> v;
+   v.push_back(true);
+   v.push_back(false);
+   v.push_back(true);
+
+   ASSERT_EQ(3, v.size());
+
+   bool *ptr = v.address();
+   ASSERT_TRUE(ptr != NULL);
+
+   // If sizeof(bool) is 1 and underlying storage is S32 (sizeof=4),
+   // then ptr[1] will be the second byte of the first S32,
+   // not the first byte of the second S32.
+
+   EXPECT_EQ(v[0], ptr[0]);
+   EXPECT_EQ(v[1], ptr[1]);
+   EXPECT_EQ(v[2], ptr[2]);
+}
+
+TEST(TnlVectorBoolTest, OperatorBracketCasting)
+{
+   TNL::Vector<bool> v;
+   v.push_back(true);
+   v.push_back(false);
+
+   // Verify that operator[] returns a reference that can be modified
+   v[1] = true;
+   EXPECT_EQ(true, v[1]);
+
+   bool *ptr = v.address();
+   EXPECT_EQ(true, ptr[0]);
+}
+
+TEST(TnlVectorBoolTest, PushPop)
+{
+   TNL::Vector<bool> v;
+   v.push_back(true);
+   v.push_back(false);
+   EXPECT_EQ(2, v.size());
+   EXPECT_EQ(true, v[0]);
+   EXPECT_EQ(false, v[1]);
+   v.pop_back();
+   EXPECT_EQ(1, v.size());
+   EXPECT_EQ(true, v[0]);
+
+   v.push_front(false);
+   EXPECT_EQ(2, v.size());
+   EXPECT_EQ(false, v[0]);
+   EXPECT_EQ(true, v[1]);
+}
+
+} // namespace Zap

--- a/tnl/tnlString.h
+++ b/tnl/tnlString.h
@@ -37,12 +37,6 @@
 #pragma warning (disable: 4996)     // Disable POSIX deprecation, certain security warnings that seem to be specific to VC++
 #endif
 
-#include "tnlTypes.h"
-#include "tnlAssert.h"
-#include <string>
-#include <string.h>
-#include <stdlib.h>
-
 namespace TNL
 {
 

--- a/tnl/tnlVector.h
+++ b/tnl/tnlVector.h
@@ -68,7 +68,7 @@ protected:
 template<> class VectorBase<bool>
 {
 protected:
-   std::vector<S32> innerVector;  // Use 'int' instead of 'char' to prevent endian-issues
+   std::vector<U8> innerVector;  // Use U8 to ensure address() returns a 1-byte aligned pointer compatible with bool
 };
 
 

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -44,8 +44,8 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVectorBool.cpp
-	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/main_test.cpp
 )

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -43,7 +43,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestStringUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
-	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVectorBool.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -44,8 +44,8 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVectorBool.cpp
-	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/main_test.cpp
 )


### PR DESCRIPTION
I am an AI agent. This PR fixes a memory alignment bug in `TNL::Vector<bool>` and includes unit tests to verify the fix.

### Bug Description
`TNL::Vector<bool>` used `S32` (4 bytes) as its underlying storage. However, the `address()` method and `operator[]` cast this to `bool*` or `bool&`. On target platforms where `sizeof(bool)` is 1 byte, incrementing a pointer returned by `address()` would move forward by only 1 byte, while the actual elements were spaced 4 bytes apart. This lead to reading garbage data or memory corruption.

### Fix
I changed the underlying storage for the `bool` specialization of `Vector` to `U8`. This ensures that elements are correctly spaced at 1-byte intervals, matching the expected behavior of a `bool` array.

### Changes
- **tnl/tnlVector.h**: Changed `VectorBase<bool>` storage to `std::vector<U8>`.
- **bitfighter_test/TestTnlVectorBool.cpp**: Added new unit tests for `Vector<bool>`.
- **zap/bitfighter_test.cmake**: Registered the new tests and removed a duplicate entry for `TestTnlString.cpp`.
- **tnl/tnlString.h**: Removed a redundant block of duplicate include statements.

I have verified these changes with the included test suite. I have also reverted an unrelated build fix in `master/CMakeLists.txt` per instructions.

---
*PR created automatically by Jules for task [14791897331643451708](https://jules.google.com/task/14791897331643451708) started by @eykamp*