### PR TITLE
Fix TNL::Vector<bool> storage and address() behavior

### DIFF
--- a/bitfighter_test/TestTnlVectorBool.cpp
+++ b/bitfighter_test/TestTnlVectorBool.cpp
@@ -1,0 +1,40 @@
+#include "tnlVector.h"
+#include "gtest/gtest.h"
+
+namespace Zap {
+
+TEST(TnlVectorBoolTest, AddressBehavior)
+{
+   TNL::Vector<bool> v;
+   v.push_back(true);
+   v.push_back(false);
+   v.push_back(true);
+
+   ASSERT_EQ(3, v.size());
+
+   bool* ptr = v.address();
+   ASSERT_NE(nullptr, ptr);
+
+   // v[0] should be at ptr[0]
+   // v[1] should be at ptr[1]
+   // v[2] should be at ptr[2]
+
+   EXPECT_EQ(true, ptr[0]);
+
+   // In the buggy version, ptr[1] points to the second byte of the first S32.
+   // Since v[0] was true (1), the S32 is 0x00000001 (on little endian).
+   // So ptr[1] will be 0, which is false.
+   // But v[1] was set to false, so this might accidentally pass if we're not careful.
+
+   v.clear();
+   v.push_back(true);
+   v.push_back(true);
+   v.push_back(true);
+
+   ptr = v.address();
+   EXPECT_EQ(true, ptr[0]);
+   EXPECT_EQ(true, ptr[1]); // This will FAIL in buggy version because ptr[1] is the 2nd byte of v[0]'s S32
+   EXPECT_EQ(true, ptr[2]); // This will FAIL too
+}
+
+} // namespace Zap

--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 set(MASTER_DEPS tnl)
 # Add tomcypt if not already found on system
 if(NOT TOMCRYPT_FOUND)
-	list(APPEND MASTER_DEPS libtomcrypt)
+	list(APPEND MASTER_DEPS tomcrypt)
 endif()
 
 set(MASTER_LIBS 

--- a/tnl/tnlVector.h
+++ b/tnl/tnlVector.h
@@ -68,7 +68,7 @@ protected:
 template<> class VectorBase<bool>
 {
 protected:
-   std::vector<S32> innerVector;  // Use 'int' instead of 'char' to prevent endian-issues
+   std::vector<U8> innerVector;  // Use 'U8' to match sizeof(bool) so address() and indexing work correctly
 };
 
 

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -43,7 +43,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestStringUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestSymbolStrings.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVector.cpp
-	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlVectorBool.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTimer.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestTnlString.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestUtils.cpp


### PR DESCRIPTION
I am an AI agent. I have fixed a bug in the `TNL::Vector<bool>` specialization where the underlying storage used `S32` (4 bytes). This caused the `address()` method, which returns a `bool*` (1 byte), to provide a pointer that broke standard pointer arithmetic and indexing. I have changed the storage to `U8` (1 byte) to align with the size of a `bool` on the target platforms, ensuring that `address()` works correctly.

Key changes:
- Modified `tnl/tnlVector.h` to use `std::vector<U8>` for `VectorBase<bool>`.
- Added a new unit test `bitfighter_test/TestTnlVectorBool.cpp` to verify the fix.
- Updated `zap/bitfighter_test.cmake` to include the new test and remove a duplicate entry for `TestTnlString.cpp`.
- Fixed a dependency target name in `master/CMakeLists.txt` from `libtomcrypt` to `tomcrypt` to fix build failures when using the in-tree version.

I have verified the fix by running the full test suite and confirmed that components previously failing due to this bug (e.g., `GameUserInterfaceTest.Engineer`) now pass.

---
*PR created automatically by Jules for task [2651556514029939174](https://jules.google.com/task/2651556514029939174) started by @eykamp*