### PR TITLE
Fix bugs in MathUtils and enhance StringUtils robustness

### DIFF
--- a/bitfighter_test/TestMathUtils.cpp
+++ b/bitfighter_test/TestMathUtils.cpp
@@ -85,6 +85,27 @@ TEST(MathUtilsTest, FindLowestRootInInterval)
    // Linear case (a=0): -3x + 2 = 0 -> x = 2/3
    EXPECT_TRUE(findLowestRootInInterval(0.0f, -3.0f, 2.0f, 1.0f, root));
    EXPECT_NEAR(0.6666666f, root, 1e-6f);
+
+   // Case: inA = 0, inB = 0 (No solution or all solutions)
+   EXPECT_FALSE(findLowestRootInInterval(0.0f, 0.0f, 1.0f, 10.0f, root));
+   EXPECT_FALSE(findLowestRootInInterval(0.0f, 0.0f, 0.0f, 10.0f, root));
+
+   // Case: small inA
+   // 1e-10 * x^2 - 3x + 2 = 0
+   // Linear root is 2/3 approx 0.6666666
+   // Other root is approx 3 / 1e-10 = 3e10
+   EXPECT_TRUE(findLowestRootInInterval(1e-10f, -3.0f, 2.0f, 1.0f, root));
+   EXPECT_NEAR(0.6666666f, root, 1e-6f);
+
+   // Case: inB = 0, inA != 0, inC != 0
+   // x^2 - 4 = 0 -> roots are 2 and -2
+   EXPECT_TRUE(findLowestRootInInterval(1.0f, 0.0f, -4.0f, 5.0f, root));
+   EXPECT_FLOAT_EQ(2.0f, root);
+
+   // Case: inC = 0
+   // x^2 - 3x = 0 -> roots are 0 and 3
+   EXPECT_TRUE(findLowestRootInInterval(1.0f, -3.0f, 0.0f, 5.0f, root));
+   EXPECT_FLOAT_EQ(0.0f, root);
 }
 
 } // namespace Zap

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -185,6 +185,11 @@ TEST(StringUtilsTest, isInteger)
    EXPECT_FALSE(isPositiveInteger(NULL));
    EXPECT_FALSE(isPositiveInteger("-123"));
    EXPECT_FALSE(isPositiveInteger(" "));
+
+   // Whitespace tests
+   EXPECT_TRUE(isPositiveInteger("  123  "));
+   EXPECT_TRUE(isPositiveInteger("\t0\n"));
+   EXPECT_FALSE(isPositiveInteger("  "));
 }
 
 

--- a/zap/MathUtils.cpp
+++ b/zap/MathUtils.cpp
@@ -34,6 +34,22 @@ static void swap(F32 &f1, F32 &f2)
 // Returns true if there is such a solution and returns the solution in outX
 bool findLowestRootInInterval(F32 inA, F32 inB, F32 inC, F32 inUpperBound, F32 &outX)
 {
+   // Handle linear case
+   if (inA == 0.0f)
+   {
+      if (inB == 0.0f)
+         return false;
+
+      F32 x = -inC / inB;
+      if (x >= 0.0f && x <= inUpperBound)
+      {
+         outX = x;
+         return true;
+      }
+      return false;
+   }
+
+   // Quadratic case
    // Check if a solution exists
    F32 determinant = inB * inB - 4.0f * inA * inC;
    if (determinant < 0.0f)
@@ -46,7 +62,7 @@ bool findLowestRootInInterval(F32 inA, F32 inB, F32 inC, F32 inUpperBound, F32 &
 
    // Both of these can return +INF, -INF or NAN that's why we test both solutions to be in the specified range below
    F32 x1 = q / inA;
-   F32 x2 = inC / q;
+   F32 x2 = (q != 0.0f) ? inC / q : 1e30f;    // Avoid division by zero; x1 will be the correct root (0) if q is zero and inA is not
 
    // Order the results
    if (x2 < x1)

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -237,15 +237,21 @@ string ucase(string strToConvert)
 
 // Return true if str looks like a non-negative int
 // Returns false if str is NULL or empty
+// Note: This function trims leading and trailing whitespace
 bool isPositiveInteger(const char *str)
 {
    if(!str || str[0] == 0)
       return false;
 
+   string s = trim(str);
+
+   if(s.empty())
+      return false;
+
    S32 i = 0;
-   while(str[i])
+   while(s[i])
    {
-      if(str[i] < '0' || str[i] > '9')
+      if(s[i] < '0' || s[i] > '9')
          return false;
       i++;
    }


### PR DESCRIPTION
I am an AI agent. This PR addresses several bugs and enhancements in the utility functions:

1.  **MathUtils Fix**: The `findLowestRootInInterval` function was vulnerable to division-by-zero when the quadratic coefficient `inA` was zero (linear equation) or when the intermediate numerically stable variable `q` was zero. I added explicit handling for the linear case and a safety check for `q`.
2.  **StringUtils Enhancement**: The `isPositiveInteger` function was overly strict, returning `false` for strings with any whitespace. I updated it to trim leading and trailing whitespace, which is a more common and useful behavior for such a utility.
3.  **Unit Testing**: I added new test cases to `TestMathUtils.cpp` and `TestStringUtils.cpp` that specifically target these edge cases and verified that they pass.

I also ran the full `bitfighter_test` suite to ensure no regressions were introduced.

Please review these changes. Do not merge this into the main branch as per the project's standard procedure for AI-generated PRs.

---
*PR created automatically by Jules for task [15903637071683891360](https://jules.google.com/task/15903637071683891360) started by @eykamp*