### PR TITLE
Fix bugs in formatMessage and findLowestRootInInterval utility functions

### DIFF
--- a/bitfighter_test/TestMathUtils.cpp
+++ b/bitfighter_test/TestMathUtils.cpp
@@ -85,6 +85,15 @@ TEST(MathUtilsTest, FindLowestRootInInterval)
    // Linear case (a=0): -3x + 2 = 0 -> x = 2/3
    EXPECT_TRUE(findLowestRootInInterval(0.0f, -3.0f, 2.0f, 1.0f, root));
    EXPECT_NEAR(0.6666666f, root, 1e-6f);
+
+   // Bug: handle linear equations correctly (currently might return false or crash)
+   // 2x - 4 = 0 -> x = 2
+   EXPECT_TRUE(findLowestRootInInterval(0.0f, 2.0f, -4.0f, 5.0f, root));
+   EXPECT_FLOAT_EQ(2.0f, root);
+
+   // Bug: avoid division by zero when q = 0
+   // 0x^2 + 0x + 0 = 0 -> any x is a root, but we should handle it gracefully
+   EXPECT_FALSE(findLowestRootInInterval(0.0f, 0.0f, 0.0f, 5.0f, root));
 }
 
 } // namespace Zap

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -957,14 +957,23 @@ TEST(StringUtilsTest, formatMessage)
 
    EXPECT_EQ("entry0 and entry1", formatMessage("%e0 and %e1", e, s, i));
    EXPECT_EQ("ptr0 is 42", formatMessage("%s0 is %i0", e, s, i));
+
+   // Bug: formatMessage should support multi-digit indices
+   for(int j = 2; j < 12; ++j) e.push_back("entry");
+   e[10] = "ten";
+   EXPECT_EQ("ten", formatMessage("%e10", e, s, i));
+
+   // Bug: formatMessage should support %% to escape %
+   EXPECT_EQ("%e0", formatMessage("%%e0", e, s, i));
+
    EXPECT_EQ("plain text", formatMessage("plain text", e, s, i));
    EXPECT_EQ("invalid %x9 tokens", formatMessage("invalid %x9 tokens", e, s, i));
-   EXPECT_EQ("out of range ", formatMessage("out of range %e9", e, s, i));
+   EXPECT_EQ("out of range ", formatMessage("out of range %e12", e, s, i));
 
    // Long string test to ensure no overflow
    std::string longStr(500, 'a');
    e.push_back(longStr.c_str());
-   EXPECT_EQ(longStr, formatMessage("%e2", e, s, i));
+   EXPECT_EQ(longStr, formatMessage("%e12", e, s, i));
 
    // Multiple placeholders and mixed types
    EXPECT_EQ("entry0 entry1 ptr0 42 entry0", formatMessage("%e0 %e1 %s0 %i0 %e0", e, s, i));

--- a/zap/MathUtils.cpp
+++ b/zap/MathUtils.cpp
@@ -34,6 +34,21 @@ static void swap(F32 &f1, F32 &f2)
 // Returns true if there is such a solution and returns the solution in outX
 bool findLowestRootInInterval(F32 inA, F32 inB, F32 inC, F32 inUpperBound, F32 &outX)
 {
+   // Handle linear case
+   if (inA == 0.0f)
+   {
+      if (inB == 0.0f)
+         return false;
+
+      F32 x = -inC / inB;
+      if (x >= 0.0f && x <= inUpperBound)
+      {
+         outX = x;
+         return true;
+      }
+      return false;
+   }
+
    // Check if a solution exists
    F32 determinant = inB * inB - 4.0f * inA * inC;
    if (determinant < 0.0f)
@@ -43,6 +58,9 @@ bool findLowestRootInInterval(F32 inA, F32 inB, F32 inC, F32 inUpperBound, F32 &
    // is not numerically stable when a is close to zero.
    // Solve the equation according to "Numerical Recipies in C" paragraph 5.6
    F32 q = -0.5f * (inB + (inB < 0.0f? -1.0f : 1.0f) * sqrt(determinant));
+
+   if (q == 0.0f)
+      return false;
 
    // Both of these can return +INF, -INF or NAN that's why we test both solutions to be in the specified range below
    F32 x1 = q / inA;

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -341,25 +341,42 @@ string formatMessage(const char *format, const Vector<StringTableEntry> &e, cons
    const char *src = format;
    while(*src)
    {
-      if(src[0] == '%' && (src[1] == 'e' || src[1] == 's' || src[1] == 'i') && isDigit(src[2]))
+      if(src[0] == '%')
       {
-         S32 index = src[2] - '0';
-         switch(src[1])
+         if(src[1] == '%')
          {
-            case 'e':
-               if(index < e.size())
-                  result += e[index].getString();
-               break;
-            case 's':
-               if(index < s.size())
-                  result += s[index].getString();
-               break;
-            case 'i':
-               if(index < i.size())
-                  result += itos(i[index]);
-               break;
+            result += '%';
+            src += 2;
          }
-         src += 3;
+         else if((src[1] == 'e' || src[1] == 's' || src[1] == 'i') && isDigit(src[2]))
+         {
+            const char *type = src + 1;
+            src += 2;
+            S32 index = 0;
+            while(isDigit(*src))
+            {
+               index = index * 10 + (*src - '0');
+               src++;
+            }
+
+            switch(*type)
+            {
+               case 'e':
+                  if(index < e.size())
+                     result += e[index].getString();
+                  break;
+               case 's':
+                  if(index < s.size())
+                     result += s[index].getString();
+                  break;
+               case 'i':
+                  if(index < i.size())
+                     result += itos(i[index]);
+                  break;
+            }
+         }
+         else
+            result += *src++;
       }
       else
          result += *src++;


### PR DESCRIPTION
I have identified and fixed several bugs in the utility functions `formatMessage` and `findLowestRootInInterval`.

Changes:
1.  **`formatMessage` multi-digit support**: The function now correctly parses indices with more than one digit (e.g., `%e12`), whereas it previously only supported single digits.
2.  **`formatMessage` escape sequence**: Added support for `%%` to allow literal percent signs in formatted messages.
3.  **`findLowestRootInInterval` linear handling**: The quadratic solver now explicitly handles cases where the quadratic coefficient `inA` is zero, solving it as a linear equation instead of potentially producing NaN or failing.
4.  **`findLowestRootInInterval` safety**: Added a check to prevent division by zero when the intermediate variable `q` is zero.

I have also updated `TestStringUtils.cpp` and `TestMathUtils.cpp` with new test cases that reproduce these issues and verify the fixes. All tests in the `bitfighter_test` suite pass successfully.

This PR was generated by an AI agent.

---
*PR created automatically by Jules for task [12794011070831723940](https://jules.google.com/task/12794011070831723940) started by @eykamp*