### PR TITLE
Fix bug in quadratic root solver for ax^2=0 case

### DIFF
--- a/bitfighter_test/TestMathUtils.cpp
+++ b/bitfighter_test/TestMathUtils.cpp
@@ -115,6 +115,11 @@ TEST(MathUtilsTest, FindLowestRootInInterval)
    // Bug: avoid division by zero when q = 0
    // 0x^2 + 0x + 0 = 0 -> any x is a root, but we should handle it gracefully
    EXPECT_FALSE(findLowestRootInInterval(0.0f, 0.0f, 0.0f, 5.0f, root));
+
+   // Bug: handle case where q = 0, but inA != 0
+   // x^2 = 0 -> x = 0
+   EXPECT_TRUE(findLowestRootInInterval(1.0f, 0.0f, 0.0f, 5.0f, root));
+   EXPECT_FLOAT_EQ(0.0f, root);
 }
 
 } // namespace Zap

--- a/zap/MathUtils.cpp
+++ b/zap/MathUtils.cpp
@@ -60,9 +60,6 @@ bool findLowestRootInInterval(F32 inA, F32 inB, F32 inC, F32 inUpperBound, F32 &
    // Solve the equation according to "Numerical Recipies in C" paragraph 5.6
    F32 q = -0.5f * (inB + (inB < 0.0f? -1.0f : 1.0f) * sqrt(determinant));
 
-   if (q == 0.0f)
-      return false;
-
    // Both of these can return +INF, -INF or NAN that's why we test both solutions to be in the specified range below
    F32 x1 = q / inA;
    F32 x2 = (q != 0.0f) ? inC / q : 1e30f;    // Avoid division by zero; x1 will be the correct root (0) if q is zero and inA is not


### PR DESCRIPTION
This PR fixes a bug in `findLowestRootInInterval` within `zap/MathUtils.cpp`. The function was prematurely returning `false` when the intermediate numerically stable variable `q` evaluated to zero. This prevented it from finding valid roots (specifically $x=0$) for equations like $x^2=0$ ($a=1, b=0, c=0$). 

The redundant `q == 0.0f` check was removed, as the subsequent logic correctly handles `q=0` when $a \neq 0$ to find the $x=0$ root.

A new unit test case was added to `bitfighter_test/TestMathUtils.cpp` to verify this fix and ensure no regressions in the quadratic solver.

This PR was authored by an AI agent. Please do not merge this into the main branch.

---
*PR created automatically by Jules for task [8903953382537302636](https://jules.google.com/task/8903953382537302636) started by @eykamp*