### PR TITLE
Fix bugs in GeomUtils circle intersection and point-in-triangle

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -1988,4 +1988,31 @@ TEST(GeomUtilsTest, isConvexConcaveC)
 
    EXPECT_FALSE(isConvex(&cshape));
 }
+
+TEST(GeomUtilsTest, polygonCircleIntersectDegenerateEdge)
+{
+   // Single vertex polygon - forms a degenerate edge with itself (v1=v2)
+   Point vertex(100, 100);
+   Point center(100.5f, 100.5f);
+   F32 radiusSq = 1.0f; // radius 1, dist is sqrt(0.5) < 1
+   Point outPoint;
+
+   // This should return true and not crash/divide by zero
+   EXPECT_TRUE(polygonCircleIntersect(&vertex, 1, center, radiusSq, outPoint));
+   EXPECT_EQ(vertex, outPoint);
+}
+
+TEST(GeomUtilsTest, TriangulateInsideTriangleWinding)
+{
+   // CCW Triangle
+   // (0,0), (10,0), (5,10)
+   EXPECT_TRUE(Triangulate::InsideTriangle(0, 0, 10, 0, 5, 10, 5, 5));
+   EXPECT_FALSE(Triangulate::InsideTriangle(0, 0, 10, 0, 5, 10, 15, 5));
+
+   // CW Triangle
+   // (0,0), (5,10), (10,0)
+   EXPECT_TRUE(Triangulate::InsideTriangle(0, 0, 5, 10, 10, 0, 5, 5));
+   EXPECT_FALSE(Triangulate::InsideTriangle(0, 0, 5, 10, 10, 0, 15, 5));
+}
+
 }; // namespace Zap

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -314,7 +314,7 @@ bool polygonCircleIntersect(const Point *inVertices, int inNumVertices, const Po
       Point v1_v2 = *v2 - *v1;
       Point v1_center = inCenter - *v1;
       F32 fraction = v1_center.dot(v1_v2);
-      if (fraction < 0.0f)
+      if (fraction <= 0.0f)
       {
          // Closest point is v1
          F32 dist_sq = v1_center.lenSquared();
@@ -329,7 +329,7 @@ bool polygonCircleIntersect(const Point *inVertices, int inNumVertices, const Po
       else
       {
          F32 v1_v2_len_sq = v1_v2.lenSquared();
-         if (fraction <= v1_v2_len_sq)
+         if (v1_v2_len_sq > 0.0f && fraction <= v1_v2_len_sq)
          {
             // Closest point is on line segment
             Point point = *v1 + v1_v2 * (fraction / v1_v2_len_sq);
@@ -836,7 +836,8 @@ bool Triangulate::InsideTriangle(float Ax, float Ay,
   cCROSSap = cx*apy - cy*apx;
   bCROSScp = bx*cpy - by*cpx;
 
-  return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f));
+  return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f)) ||
+         ((aCROSSbp <= 0.0f) && (bCROSScp <= 0.0f) && (cCROSSap <= 0.0f));
 };
 
 


### PR DESCRIPTION
I am an AI agent. This PR fixes two bugs in the geometric utility functions:

1. **division-by-zero in `polygonCircleIntersect`**: When a polygon contains a degenerate edge (where two consecutive vertices are at the same position), the function could attempt to divide by zero when calculating the projection of the circle center onto that edge. I added a check for edge length and updated the logic to correctly treat these as vertex hits.
2. **Winding order dependency in `Triangulate::InsideTriangle`**: This function previously only returned `true` for points inside triangles wound in one direction (likely CCW). I updated it to use a cross-product sign consistency check that works for both CW and CCW wound triangles.

Unit tests covering both edge cases have been added to `TestGeomUtils.cpp`, and the full test suite passes.

---
*PR created automatically by Jules for task [13486188101278062751](https://jules.google.com/task/13486188101278062751) started by @eykamp*