### PR TITLE
Fix string trimming truncation and inconsistent file I/O modes

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -635,6 +635,7 @@ TEST(StringUtilsTest, trim)
 {
    EXPECT_EQ("abc", trim("  abc  "));
    EXPECT_EQ("abc", trim("\n\t abc \r\n"));
+   EXPECT_EQ("abc", trim("\vabc\v"));
    EXPECT_EQ("abc  ", trim_left("  abc  "));
    EXPECT_EQ("  abc", trim_right("  abc  "));
 
@@ -717,6 +718,13 @@ TEST(StringUtilsTest, fileUtils)
    ASSERT_TRUE(writeFile(testFile, content));
    EXPECT_TRUE(fileExists(testFile));
    EXPECT_EQ(content, readFile(testFile));
+
+   // Verify consistency of writeFile/readFile with potentially tricky characters
+   // On Windows, text mode would translate \n to \r\n
+   string binaryContent = "Line1\nLine2\r\nLine3";
+   ASSERT_TRUE(writeFile("test_binary.txt", binaryContent));
+   EXPECT_EQ(binaryContent, readFile("test_binary.txt"));
+   remove("test_binary.txt");
 
    string appendContent = " Append";
    ASSERT_TRUE(writeFile(testFile, appendContent, true));

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -968,6 +968,7 @@ string writeLevelString(const char *in)
 bool writeFile(const string &path, const string &contents, bool append)
 {
    ios_base::openmode mode = append ? ios_base::out | ios_base::app : ios_base::out;
+   mode |= ios_base::binary;
 
    ofstream file(path.c_str(), mode);
 

--- a/zap/stringUtils.h
+++ b/zap/stringUtils.h
@@ -105,7 +105,7 @@ string strictjoindir(const string &part1, const string &part2, const string &par
 
 // By default we'll mimic the behavior or PHP.  Because that's something to aspire to!
 // http://lu1.php.net/trim
-#define DEFAULT_TRIM_CHARS " \n\r\t\0\x0B"
+#define DEFAULT_TRIM_CHARS " \n\r\t\v"
 
 string trim_right(const string &source, const string &t = DEFAULT_TRIM_CHARS);
 string trim_left(const string &source, const string &t = DEFAULT_TRIM_CHARS);


### PR DESCRIPTION
This PR addresses two bugs in the `stringUtils` component:
1. **Truncated `DEFAULT_TRIM_CHARS`**: The `DEFAULT_TRIM_CHARS` macro in `zap/stringUtils.h` contained an embedded null character (`\0`), which caused `std::string` objects initialized with it to be truncated. This resulted in the vertical tab character (`\x0B`) being excluded from the default trim set. I removed the null character and replaced the hex code with the more readable `\v` escape sequence.
2. **Inconsistent file I/O modes**: `writeFile` in `zap/stringUtils.cpp` was opening files in text mode, while `readFile` used binary mode. This could lead to inconsistent behavior on platforms that perform newline translation (like Windows). I updated `writeFile` to use `ios_base::binary` for cross-platform consistency.

Unit tests have been added to `bitfighter_test/TestStringUtils.cpp` to verify that vertical tabs are now correctly trimmed and that file content is preserved exactly through a write-read cycle.

I am an AI agent assisting with this task.

---
*PR created automatically by Jules for task [4846388644399424801](https://jules.google.com/task/4846388644399424801) started by @eykamp*