### PR TITLE
Fix bugs in stripZeros and ftos for zero values

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -133,7 +133,7 @@ TEST(StringUtilsTest, stripZeros)
    EXPECT_EQ("1.1", stripZeros("1.100"));
    EXPECT_EQ("1", stripZeros("1.000"));
    EXPECT_EQ("0", stripZeros("0"));
-   EXPECT_EQ("", stripZeros(".000"));
+   EXPECT_EQ("0", stripZeros(".000"));
 }
 
 
@@ -233,6 +233,11 @@ TEST(StringUtilsTest, ftosBugReproduction)
 
    // Bug: ftos(1.0f, 0) incorrectly returns " 1" instead of "1"
    EXPECT_EQ("1", ftos(1.0f, 0));
+   EXPECT_EQ("0", ftos(0.0001f, 2));
+   EXPECT_EQ("0", ftos(-0.0001f, 2));
+   EXPECT_EQ("0", ftos(0.0f));
+   EXPECT_EQ("0", stripZeros(".000"));
+   EXPECT_EQ("0", stripZeros("-0"));
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -62,10 +62,10 @@ string extractDirectory(const string &path )
 {
    // Works on Windows and Linux/Mac!  (just don't have a path with a backslash on Linux/Mac)
   string::size_type pos = path.find_last_of("\\/");
-  if (pos == string::npos)
+  if(pos == string::npos)
      return "";
 
-  if (pos == 0)
+  if(pos == 0)
      return path.substr(0, 1);
 
   return path.substr( 0, pos ); // Paths should never end with the slash

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -121,14 +121,17 @@ string itos(S64 i)
 
 string stripZeros(string str)
 {
-   if (str.find('.') == string::npos)
-      return str;
+   if (str.find('.') != string::npos)
+   {
+      while(str.length() > 0 && str[str.length() - 1]  == '0')
+         str.erase(str.length() - 1);
 
-   while(str.length() > 0 && str[str.length() - 1]  == '0')
-      str.erase(str.length() - 1);
+      if(str.length() > 0 && str[str.length() - 1] == '.')
+         str.erase(str.length() - 1);
+   }
 
-   if(str.length() > 0 && str[str.length() - 1] == '.')
-      str.erase(str.length() - 1);
+   if(str.empty() || str == "-" || str == "-0" || str == "+0")
+      return "0";
 
    return str;
 }


### PR DESCRIPTION
I identified and fixed a bug where `stripZeros` could return an empty string or a signed zero (like `"-0"`) when processing values that should be represented as `"0"`. This affected `ftos` output for small floats and negative zero. I've added unit tests in `TestStringUtils.cpp` to verify the fix and ensure no regressions. I am an AI agent.

---
*PR created automatically by Jules for task [4977700170160937328](https://jules.google.com/task/4977700170160937328) started by @eykamp*