### PR TITLE
Improve geometric and timer precision for large coordinates

### DIFF
--- a/bitfighter_test/TestGeomPrecision.cpp
+++ b/bitfighter_test/TestGeomPrecision.cpp
@@ -1,0 +1,82 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "../zap/GeomUtils.h"
+#include "gtest/gtest.h"
+#include <tnl.h>
+
+namespace Zap
+{
+
+using namespace std;
+using namespace TNL;
+
+TEST(GeomPrecisionTest, mean2dLargeCoordinates)
+{
+   Vector<Point> pts;
+   // 1,000,000.0625 is exactly representable in F32
+   // 2^19 < 1,000,000 < 2^20. Mantissa has 24 bits. 24 - 20 = 4 bits for fraction.
+   // 2^-4 = 0.0625.
+   F32 val = 1000000.0625f;
+   S32 count = 100;
+   for(S32 i = 0; i < count; i++)
+      pts.push_back(Point(val, val));
+
+   Point m = mean2d(pts);
+
+   // Expected mean: 1000000.0625
+   // With F32 accumulation:
+   // Sum reaches 16,777,216 (2^24). Beyond this, step is 1.0.
+   // Adding 1,000,000.0625 will round the sum.
+   // At some point, the .0625 will be lost in every addition.
+
+   // We expect the result to be more accurate than what F32 accumulation would give.
+   // F32 accumulation of 100 * 1000000.0625:
+   // 100 * 1000000 = 100,000,000.
+   // 100 * 0.0625 = 6.25.
+   // Total should be 100,000,006.25.
+   // In F32, 100,000,006.25 is between 2^26 and 2^27, step is 8.0.
+   // So it would be rounded to 100,000,008 or 100,000,000.
+
+   EXPECT_NEAR(1000000.0625f, m.x, 0.0001f);
+}
+
+TEST(GeomPrecisionTest, InsideTrianglePrecision)
+{
+   // Define a triangle and a point using F64 to ensure we are testing the function's internal precision
+   // once we update its signature to F64.
+   // For now, we call it with values that might be problematic.
+
+   double offset = 1e7;
+   double Ax = offset;
+   double Ay = offset;
+   double Bx = offset + 1000.0;
+   double By = offset;
+   double Cx = offset;
+   double Cy = offset + 1000.0;
+
+   // Point slightly inside
+   double Px = offset + 1.0;
+   double Py = offset + 1.0;
+
+   EXPECT_TRUE(Triangulate::InsideTriangle((float)Ax, (float)Ay, (float)Bx, (float)By, (float)Cx, (float)Cy, (float)Px, (float)Py));
+
+   // Point very close to the hypotenuse B-C
+   // Hypotenuse is x + y = 2*offset + 1000
+   // Point at x = offset + 500, y = offset + 500 is on the line.
+   // Point at x = offset + 500, y = offset + 499.999 is slightly inside.
+
+   Px = offset + 500.0;
+   Py = offset + 499.999;
+
+   // In F32:
+   // offset + 500 = 10,000,500. Representable (step is 1.0).
+   // offset + 499.999 = 10,000,499.999 -> 10,000,500.0 (rounded).
+   // So in F32, the point is seen as ON the line.
+
+   EXPECT_TRUE(Triangulate::InsideTriangle((float)Ax, (float)Ay, (float)Bx, (float)By, (float)Cx, (float)Cy, (float)Px, (float)Py));
+}
+
+} // namespace Zap

--- a/bitfighter_test/TestTimer.cpp
+++ b/bitfighter_test/TestTimer.cpp
@@ -123,4 +123,29 @@ TEST(TimerTest, ExtendUnderflow)
    EXPECT_EQ(0u, t.getCurrent());
 }
 
+TEST(TimerTest, ExtendS32Min)
+{
+   Timer t(1000);
+   t.extend(-2147483647 - 1); // S32_MIN
+   EXPECT_EQ(0u, t.getPeriod());
+   EXPECT_EQ(0u, t.getCurrent());
+}
+
+TEST(TimerTest, InvertPrecision)
+{
+   // Period that is not power of 2
+   U32 period = 3333333;
+   Timer t(period);
+   t.update(1234567);
+   U32 remaining = t.getCurrent();
+
+   t.invert();
+   // remaining = 3333333 - 1234567 = 2098766
+   // invert should set it to 1234567
+   EXPECT_EQ(period - remaining, t.getCurrent());
+
+   t.invert();
+   EXPECT_EQ(remaining, t.getCurrent());
+}
+
 }

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -228,9 +228,11 @@ bool triangulatedFillContains(const Vector<Point>* triangles, const Point& point
 
       // Cross-product sign test — zero means point is exactly on that edge,
       // which we treat as inside (non-strict / inclusive boundary).
-      F32 d1 = (point.x - p1.x) * (p0.y - p1.y) - (p0.x - p1.x) * (point.y - p1.y);
-      F32 d2 = (point.x - p2.x) * (p1.y - p2.y) - (p1.x - p2.x) * (point.y - p2.y);
-      F32 d3 = (point.x - p0.x) * (p2.y - p0.y) - (p2.x - p0.x) * (point.y - p0.y);
+      //
+      // Perform calculations in F64 to maintain precision at large coordinates
+      F64 d1 = (F64(point.x) - p1.x) * (F64(p0.y) - p1.y) - (F64(p0.x) - p1.x) * (F64(point.y) - p1.y);
+      F64 d2 = (F64(point.x) - p2.x) * (F64(p1.y) - p2.y) - (F64(p1.x) - p2.x) * (F64(point.y) - p1.y);
+      F64 d3 = (F64(point.x) - p0.x) * (F64(p2.y) - p0.y) - (F64(p2.x) - p0.x) * (F64(point.y) - p0.y);
 
       bool has_neg = (d1 < 0) || (d2 < 0) || (d3 < 0);
       bool has_pos = (d1 > 0) || (d2 > 0) || (d3 > 0);
@@ -816,14 +818,14 @@ F32 area(const Vector<Point> &contour)
      InsideTriangle decides if a point P is Inside of the triangle
      defined by A, B, C.
    */
-bool Triangulate::InsideTriangle(float Ax, float Ay,
-                                 float Bx, float By,
-                                 float Cx, float Cy,
-                                 float Px, float Py)
+bool Triangulate::InsideTriangle(F64 Ax, F64 Ay,
+                                 F64 Bx, F64 By,
+                                 F64 Cx, F64 Cy,
+                                 F64 Px, F64 Py)
 
 {
-  float ax, ay, bx, by, cx, cy, apx, apy, bpx, bpy, cpx, cpy;
-  float cCROSSap, bCROSScp, aCROSSbp;
+  F64 ax, ay, bx, by, cx, cy, apx, apy, bpx, bpy, cpx, cpy;
+  F64 cCROSSap, bCROSScp, aCROSSbp;
 
   ax = Cx - Bx;  ay = Cy - By;
   bx = Ax - Cx;  by = Ay - Cy;
@@ -836,15 +838,15 @@ bool Triangulate::InsideTriangle(float Ax, float Ay,
   cCROSSap = cx*apy - cy*apx;
   bCROSScp = bx*cpy - by*cpx;
 
-  return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f)) ||
-         ((aCROSSbp <= 0.0f) && (bCROSScp <= 0.0f) && (cCROSSap <= 0.0f));
+  return ((aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0)) ||
+         ((aCROSSbp <= 0.0) && (bCROSScp <= 0.0) && (cCROSSap <= 0.0));
 };
 
 
 bool Triangulate::Snip(const Vector<Point> &contour, int u, int v, int w, int n, int *V)
 {
   int p;
-  float Ax, Ay, Bx, By, Cx, Cy, Px, Py;
+  F64 Ax, Ay, Bx, By, Cx, Cy, Px, Py;
 
   Ax = contour[V[u]].x;
   Ay = contour[V[u]].y;
@@ -855,7 +857,7 @@ bool Triangulate::Snip(const Vector<Point> &contour, int u, int v, int w, int n,
   Cx = contour[V[w]].x;
   Cy = contour[V[w]].y;
 
-  if ( EPSILON > (((Bx-Ax)*(Cy-Ay)) - ((By-Ay)*(Cx-Ax))) ) return false;
+  if ( EPSILON > ((Bx-Ax)*(Cy-Ay) - (By-Ay)*(Cx-Ax)) ) return false;
 
   for (p=0;p<n;p++)
   {
@@ -1723,9 +1725,11 @@ Point mean2d(const Vector<Point> &polyPoints)
 //   static const F32 NormalizeFraction = 0.015625; // 1/NormalizeMultiplier
 
    S32 size = polyPoints.size();
+   if(size == 0)
+      return Point(0, 0);
 
-   F32 x = 0;
-   F32 y = 0;
+   F64 x = 0;
+   F64 y = 0;
    Point p1;
 
    for(S32 i = 0; i < size; i++)

--- a/zap/GeomUtils.h
+++ b/zap/GeomUtils.h
@@ -187,10 +187,10 @@ public:
 
    // Decide if point Px/Py is inside triangle defined by
    // (Ax,Ay) (Bx,By) (Cx,Cy)
-   static bool InsideTriangle(float Ax, float Ay,
-         float Bx, float By,
-         float Cx, float Cy,
-         float Px, float Py);
+   static bool InsideTriangle(F64 Ax, F64 Ay,
+         F64 Bx, F64 By,
+         F64 Cx, F64 Cy,
+         F64 Px, F64 Py);
 
 private:
    static bool Snip(const Vector<Point> &contour, int u, int v, int w, int n, int *V);

--- a/zap/Timer.cpp
+++ b/zap/Timer.cpp
@@ -54,7 +54,7 @@ F32 Timer::getFraction() const
 
 void Timer::invert()
 {
-   mCurrentCounter = U32((1.0f - getFraction()) * mPeriod);
+   mCurrentCounter = mPeriod - mCurrentCounter;
 }
 
 
@@ -85,10 +85,10 @@ void Timer::reset()
 // Note that time could be negative to shorten timer!  -- TODO: Do we really want to alter the timer period here?
 void Timer::extend(S32 time)
 {
-   U32 U32time = U32(abs(time));
-
    if(time > 0)
    {
+      U32 U32time = (U32)time;
+
       if(U32time > (U32_MAX - mPeriod))            // Overflow protection
          mPeriod = U32_MAX;
       else
@@ -102,6 +102,8 @@ void Timer::extend(S32 time)
 
    else if(time < 0)
    {
+      U32 U32time = (U32)-(S64)time;
+
       if(U32time > mPeriod)                        // Underflow protection
          mPeriod = 0;
       else

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -12,6 +12,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGameUserInterface.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomUtils.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomUtilsSafety.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomPrecision.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestColor.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestChatHelper.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestHelpItemManager.cpp


### PR DESCRIPTION
This PR addresses several precision issues and potential undefined behaviors in geometric utilities and timer logic.

Key changes:
- In `zap/GeomUtils.cpp`, updated `mean2d`, `triangulatedFillContains`, `Triangulate::InsideTriangle`, and `Triangulate::Snip` to use `F64` (double-precision) for intermediate calculations. This prevents significant precision loss when handling large world coordinates (e.g., 10^7).
- Updated `Triangulate::InsideTriangle` function signature in `zap/GeomUtils.h` and `zap/GeomUtils.cpp` to accept `F64` parameters, ensuring high-precision coordinates are not truncated when passed to the function.
- In `zap/Timer.cpp`, optimized `Timer::invert()` to use integer subtraction instead of floating-point arithmetic, eliminating rounding errors.
- In `zap/Timer.cpp`, fixed `Timer::extend()` to safely handle `S32_MIN` by using `S64` casting for the negation, avoiding undefined behavior.
- Added a new unit test suite `bitfighter_test/TestGeomPrecision.cpp` to verify geometric robustness at large coordinates.
- Expanded `bitfighter_test/TestTimer.cpp` with tests for the `Timer` fixes.

I am an AI agent. I have verified these changes by running the full unit test suite on Linux.

---
*PR created automatically by Jules for task [6352357991038005617](https://jules.google.com/task/6352357991038005617) started by @eykamp*