### PR TITLE
Improve geometric precision for large world coordinates

### DIFF
--- a/bitfighter_test/TestGeomPrecision.cpp
+++ b/bitfighter_test/TestGeomPrecision.cpp
@@ -1,0 +1,56 @@
+#include "../zap/GeomUtils.h"
+#include "gtest/gtest.h"
+#include <tnl.h>
+
+namespace Zap
+{
+
+using namespace std;
+using namespace TNL;
+
+TEST(GeomPrecisionTest, InsideTriangleLargeCoords)
+{
+   // Large triangle at 10^7
+   F32 offset = 1e7f;
+   F32 Ax = offset, Ay = offset;
+   F32 Bx = offset + 1000.0f, By = offset;
+   F32 Cx = offset, Cy = offset + 1000.0f;
+
+   // Point inside
+   EXPECT_TRUE(Triangulate::InsideTriangle(Ax, Ay, Bx, By, Cx, Cy, offset + 100.0f, offset + 100.0f));
+
+   // Point outside
+   EXPECT_FALSE(Triangulate::InsideTriangle(Ax, Ay, Bx, By, Cx, Cy, offset - 100.0f, offset - 100.0f));
+   EXPECT_FALSE(Triangulate::InsideTriangle(Ax, Ay, Bx, By, Cx, Cy, offset + 1100.0f, offset + 100.0f));
+}
+
+TEST(GeomPrecisionTest, triangulatedFillContainsLargeCoords)
+{
+   F32 offset = 1e7f;
+   Vector<Point> triangles;
+   triangles.push_back(Point(offset, offset));
+   triangles.push_back(Point(offset + 1000.0f, offset));
+   triangles.push_back(Point(offset, offset + 1000.0f));
+
+   // Point inside
+   EXPECT_TRUE(triangulatedFillContains(&triangles, Point(offset + 100.0f, offset + 100.0f)));
+
+   // Point outside
+   EXPECT_FALSE(triangulatedFillContains(&triangles, Point(offset - 100.0f, offset - 100.0f)));
+}
+
+TEST(GeomPrecisionTest, mean2dLargeCoords)
+{
+   F32 offset = 1e7f;
+   Vector<Point> pts;
+   for(int i = 0; i < 1000; ++i)
+   {
+      pts.push_back(Point(offset + 10.0f, offset + 20.0f));
+   }
+
+   Point m = mean2d(pts);
+   EXPECT_NEAR(offset + 10.0f, m.x, 1.0f);
+   EXPECT_NEAR(offset + 20.0f, m.y, 1.0f);
+}
+
+} // namespace Zap

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -228,9 +228,9 @@ bool triangulatedFillContains(const Vector<Point>* triangles, const Point& point
 
       // Cross-product sign test — zero means point is exactly on that edge,
       // which we treat as inside (non-strict / inclusive boundary).
-      F32 d1 = (point.x - p1.x) * (p0.y - p1.y) - (p0.x - p1.x) * (point.y - p1.y);
-      F32 d2 = (point.x - p2.x) * (p1.y - p2.y) - (p1.x - p2.x) * (point.y - p2.y);
-      F32 d3 = (point.x - p0.x) * (p2.y - p0.y) - (p2.x - p0.x) * (point.y - p0.y);
+      F64 d1 = (F64(point.x) - p1.x) * (F64(p0.y) - p1.y) - (F64(p0.x) - p1.x) * (F64(point.y) - p1.y);
+      F64 d2 = (F64(point.x) - p2.x) * (F64(p1.y) - p2.y) - (F64(p1.x) - p2.x) * (F64(point.y) - p2.y);
+      F64 d3 = (F64(point.x) - p0.x) * (F64(p2.y) - p0.y) - (F64(p2.x) - p0.x) * (F64(point.y) - p0.y);
 
       bool has_neg = (d1 < 0) || (d2 < 0) || (d3 < 0);
       bool has_pos = (d1 > 0) || (d2 > 0) || (d3 > 0);
@@ -816,14 +816,14 @@ F32 area(const Vector<Point> &contour)
      InsideTriangle decides if a point P is Inside of the triangle
      defined by A, B, C.
    */
-bool Triangulate::InsideTriangle(float Ax, float Ay,
-                                 float Bx, float By,
-                                 float Cx, float Cy,
-                                 float Px, float Py)
+bool Triangulate::InsideTriangle(F64 Ax, F64 Ay,
+                                 F64 Bx, F64 By,
+                                 F64 Cx, F64 Cy,
+                                 F64 Px, F64 Py)
 
 {
-  float ax, ay, bx, by, cx, cy, apx, apy, bpx, bpy, cpx, cpy;
-  float cCROSSap, bCROSScp, aCROSSbp;
+  F64 ax, ay, bx, by, cx, cy, apx, apy, bpx, bpy, cpx, cpy;
+  F64 cCROSSap, bCROSScp, aCROSSbp;
 
   ax = Cx - Bx;  ay = Cy - By;
   bx = Ax - Cx;  by = Ay - Cy;
@@ -836,15 +836,15 @@ bool Triangulate::InsideTriangle(float Ax, float Ay,
   cCROSSap = cx*apy - cy*apx;
   bCROSScp = bx*cpy - by*cpx;
 
-  return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f)) ||
-         ((aCROSSbp <= 0.0f) && (bCROSScp <= 0.0f) && (cCROSSap <= 0.0f));
+  return ((aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0)) ||
+         ((aCROSSbp <= 0.0) && (bCROSScp <= 0.0) && (cCROSSap <= 0.0));
 };
 
 
 bool Triangulate::Snip(const Vector<Point> &contour, int u, int v, int w, int n, int *V)
 {
   int p;
-  float Ax, Ay, Bx, By, Cx, Cy, Px, Py;
+  F64 Ax, Ay, Bx, By, Cx, Cy, Px, Py;
 
   Ax = contour[V[u]].x;
   Ay = contour[V[u]].y;
@@ -1724,8 +1724,8 @@ Point mean2d(const Vector<Point> &polyPoints)
 
    S32 size = polyPoints.size();
 
-   F32 x = 0;
-   F32 y = 0;
+   F64 x = 0;
+   F64 y = 0;
    Point p1;
 
    for(S32 i = 0; i < size; i++)
@@ -1737,8 +1737,8 @@ Point mean2d(const Vector<Point> &polyPoints)
       y += p1.y;
    }
 
-   x /= size;
-   y /= size;
+   x /= (F64)size;
+   y /= (F64)size;
 
    return Point(x,y);
 }

--- a/zap/GeomUtils.h
+++ b/zap/GeomUtils.h
@@ -187,10 +187,10 @@ public:
 
    // Decide if point Px/Py is inside triangle defined by
    // (Ax,Ay) (Bx,By) (Cx,Cy)
-   static bool InsideTriangle(float Ax, float Ay,
-         float Bx, float By,
-         float Cx, float Cy,
-         float Px, float Py);
+   static bool InsideTriangle(F64 Ax, F64 Ay,
+         F64 Bx, F64 By,
+         F64 Cx, F64 Cy,
+         F64 Px, F64 Py);
 
 private:
    static bool Snip(const Vector<Point> &contour, int u, int v, int w, int n, int *V);

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -11,6 +11,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGameType.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGameUserInterface.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomUtils.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomPrecision.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGeomUtilsSafety.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestColor.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestChatHelper.cpp


### PR DESCRIPTION
I have improved the numerical stability and precision of several geometric utility functions in the `zap/` directory. 

Specifically:
- `mean2d` now uses `F64` for internal accumulation, avoiding significant drift when averaging many points or large coordinates.
- `triangulatedFillContains` uses `F64` for cross-product sign tests to prevent incorrect containment results due to rounding errors.
- `Triangulate::InsideTriangle` and `Triangulate::Snip` were updated to use `F64` for all calculations and parameters, ensuring reliable triangulation and point-in-triangle testing.

I added a new test file `bitfighter_test/TestGeomPrecision.cpp` that specifically targets these scenarios using coordinates around 10^7. All new and existing geometric tests pass.

I am an AI agent.

---
*PR created automatically by Jules for task [5219047762561471010](https://jules.google.com/task/5219047762561471010) started by @eykamp*