### PR TITLE
Fix precision and overflow bugs in Timer class

### DIFF
--- a/bitfighter_test/TestTimer.cpp
+++ b/bitfighter_test/TestTimer.cpp
@@ -123,4 +123,27 @@ TEST(TimerTest, ExtendUnderflow)
    EXPECT_EQ(0u, t.getCurrent());
 }
 
+TEST(TimerTest, InvertPrecisionBug)
+{
+   U32 largePeriod = 100000000; // 10^8
+   Timer t(largePeriod);
+   t.reset(1, largePeriod); // 1 unit left
+
+   t.invert();
+
+   // Expected: largePeriod - 1 = 99999999
+   // If it has the bug, it might stay at largePeriod due to float precision
+   EXPECT_EQ(99999999u, t.getCurrent());
+}
+
+TEST(TimerTest, ExtendS32MinBug)
+{
+   Timer t(1000);
+   // S32_MIN is -2147483648
+   t.extend(-2147483647 - 1); // S32_MIN
+
+   EXPECT_EQ(0u, t.getPeriod());
+   EXPECT_EQ(0u, t.getCurrent());
+}
+
 }

--- a/zap/Timer.cpp
+++ b/zap/Timer.cpp
@@ -54,7 +54,7 @@ F32 Timer::getFraction() const
 
 void Timer::invert()
 {
-   mCurrentCounter = U32((1.0f - getFraction()) * mPeriod);
+   mCurrentCounter = mPeriod - mCurrentCounter;
 }
 
 
@@ -85,7 +85,7 @@ void Timer::reset()
 // Note that time could be negative to shorten timer!  -- TODO: Do we really want to alter the timer period here?
 void Timer::extend(S32 time)
 {
-   U32 U32time = U32(abs(time));
+   U32 U32time = (time < 0) ? (U32)-(S64)time : (U32)time;
 
    if(time > 0)
    {


### PR DESCRIPTION
I am an AI agent. I have identified and fixed two bugs in the Timer class in zap/Timer.cpp:

1. Precision loss in invert(): Replaced floating-point calculation with exact integer subtraction (mPeriod - mCurrentCounter).
2. Undefined behavior in extend(): Fixed a potential overflow/undefined behavior when passing S32_MIN to extend() by using S64 casting for safe negation.

I have also added unit tests in bitfighter_test/TestTimer.cpp to verify these fixes and prevent regressions.

---
*PR created automatically by Jules for task [3492056576794687526](https://jules.google.com/task/3492056576794687526) started by @eykamp*