### PR TITLE
Add unit tests for BitSet32 and Matrix4 foundational classes

### DIFF
--- a/bitfighter_test/TestBitSet.cpp
+++ b/bitfighter_test/TestBitSet.cpp
@@ -1,0 +1,97 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "tnlBitSet.h"
+#include "gtest/gtest.h"
+
+namespace Zap {
+
+using namespace TNL;
+
+TEST(BitSetTest, Construction)
+{
+   BitSet32 b1;
+   EXPECT_EQ(0u, b1.getMask());
+
+   BitSet32 b2(0xDEADBEEF);
+   EXPECT_EQ(0xDEADBEEFUL, b2.getMask());
+
+   BitSet32 b3(b2);
+   EXPECT_EQ(0xDEADBEEFUL, b3.getMask());
+
+   BitSet32 b4 = 0x12345678;
+   EXPECT_EQ(0x12345678UL, b4.getMask());
+}
+
+TEST(BitSetTest, SetMethods)
+{
+   BitSet32 b;
+   b.set();
+   EXPECT_EQ(0xFFFFFFFFUL, b.getMask());
+
+   b.clear();
+   EXPECT_EQ(0u, b.getMask());
+
+   b.set(0x1);
+   EXPECT_EQ(0x1u, b.getMask());
+
+   b.set(0x2);
+   EXPECT_EQ(0x3u, b.getMask());
+
+   b.clear(0x1);
+   EXPECT_EQ(0x2u, b.getMask());
+
+   b.toggle(0x3); // Toggle bits 1 and 2. Bit 2 is currently set, so it becomes clear. Bit 1 is clear, so it becomes set.
+   EXPECT_EQ(0x1u, b.getMask());
+}
+
+TEST(BitSetTest, BooleanSet)
+{
+   BitSet32 b(0xF0);
+
+   // set(BitSet32 s, bool b)
+   // For each bit set in s, sets or clears that bit in this, depending on b.
+
+   b.set(BitSet32(0x0F), true);
+   EXPECT_EQ(0xFFu, b.getMask());
+
+   b.set(BitSet32(0xAA), false);
+   // 0xFF & ~0xAA = 0x55
+   EXPECT_EQ(0x55u, b.getMask());
+}
+
+TEST(BitSetTest, TestingMethods)
+{
+   BitSet32 b(0x0000000F);
+
+   EXPECT_TRUE(b.test(0x01));
+   EXPECT_TRUE(b.test(0x08));
+   EXPECT_FALSE(b.test(0x10));
+   EXPECT_TRUE(b.test(0x03)); // Tests if ANY of these bits are set
+
+   EXPECT_TRUE(b.testStrict(0x0F));
+   EXPECT_TRUE(b.testStrict(0x01));
+   EXPECT_FALSE(b.testStrict(0x1F));
+}
+
+TEST(BitSetTest, Operators)
+{
+   BitSet32 b(0x0F);
+
+   EXPECT_EQ(0x1Fu, (b | 0x10u).getMask());
+   EXPECT_EQ(0x0Eu, (b & 0x0Eu).getMask());
+   EXPECT_EQ(0xF0u, (b ^ 0xFFu).getMask());
+
+   b |= 0x10;
+   EXPECT_EQ(0x1Fu, b.getMask());
+
+   b &= 0x01;
+   EXPECT_EQ(0x01u, b.getMask());
+
+   b ^= 0x11;
+   EXPECT_EQ(0x10u, b.getMask());
+}
+
+} // namespace Zap

--- a/bitfighter_test/TestMatrix4.cpp
+++ b/bitfighter_test/TestMatrix4.cpp
@@ -1,0 +1,155 @@
+//------------------------------------------------------------------------------
+// Copyright Chris Eykamp
+// See LICENSE.txt for full copyright information
+//------------------------------------------------------------------------------
+
+#include "Matrix4.h"
+#include "gtest/gtest.h"
+#include <cmath>
+
+#ifndef M_PI
+#  define M_PI 3.14159265358979323846
+#endif
+
+namespace Zap {
+
+TEST(Matrix4Test, Identity)
+{
+   Matrix4 identity;
+   const F32 *data = identity.getData();
+
+   for(int c = 0; c < 4; ++c)
+   {
+      for(int r = 0; r < 4; ++r)
+      {
+         if(c == r)
+            EXPECT_FLOAT_EQ(1.0f, data[c * 4 + r]);
+         else
+            EXPECT_FLOAT_EQ(0.0f, data[c * 4 + r]);
+      }
+   }
+}
+
+TEST(Matrix4Test, ConstructorF32)
+{
+   F32 initial[16] = {
+      0, 1, 2, 3,
+      4, 5, 6, 7,
+      8, 9, 10, 11,
+      12, 13, 14, 15
+   };
+
+   Matrix4 m(initial);
+   const F32 *data = m.getData();
+
+   for(int i = 0; i < 16; ++i)
+      EXPECT_FLOAT_EQ(initial[i], data[i]);
+}
+
+TEST(Matrix4Test, Multiply)
+{
+   // A = [ 1 2 ]  B = [ 5 6 ]  AB = [ 1*5+2*7 1*6+2*8 ] = [ 19 22 ]
+   //     [ 3 4 ]      [ 7 8 ]       [ 3*5+4*7 3*6+4*8 ]   [ 43 50 ]
+
+   // Our Matrix4 is 4x4 and column-major. mData[col][row].
+   // data[col * 4 + row]
+
+   F32 dataA[16] = {0};
+   dataA[0*4 + 0] = 1; dataA[1*4 + 0] = 2;
+   dataA[0*4 + 1] = 3; dataA[1*4 + 1] = 4;
+   dataA[2*4 + 2] = 1; dataA[3*4 + 3] = 1;
+
+   F32 dataB[16] = {0};
+   dataB[0*4 + 0] = 5; dataB[1*4 + 0] = 6;
+   dataB[0*4 + 1] = 7; dataB[1*4 + 1] = 8;
+   dataB[2*4 + 2] = 1; dataB[3*4 + 3] = 1;
+
+   Matrix4 mA(dataA);
+   Matrix4 mB(dataB);
+   Matrix4 mAB = mA * mB;
+
+   const F32 *data = mAB.getData();
+   EXPECT_FLOAT_EQ(19.0f, data[0*4 + 0]);
+   EXPECT_FLOAT_EQ(22.0f, data[1*4 + 0]);
+   EXPECT_FLOAT_EQ(43.0f, data[0*4 + 1]);
+   EXPECT_FLOAT_EQ(50.0f, data[1*4 + 1]);
+}
+
+TEST(Matrix4Test, Translate)
+{
+   Matrix4 m;
+   m = m.translate(10.0f, 20.0f, 30.0f);
+
+   // For column-major 4x4 matrix, translation is in the 4th column (index 3).
+   // mData[3][0], mData[3][1], mData[3][2]
+   const F32 *data = m.getData();
+   EXPECT_FLOAT_EQ(10.0f, data[3*4 + 0]);
+   EXPECT_FLOAT_EQ(20.0f, data[3*4 + 1]);
+   EXPECT_FLOAT_EQ(30.0f, data[3*4 + 2]);
+}
+
+TEST(Matrix4Test, Scale)
+{
+   Matrix4 m;
+   m = m.scale(2.0f, 3.0f, 4.0f);
+
+   const F32 *data = m.getData();
+   EXPECT_FLOAT_EQ(2.0f, data[0*4 + 0]);
+   EXPECT_FLOAT_EQ(3.0f, data[1*4 + 1]);
+   EXPECT_FLOAT_EQ(4.0f, data[2*4 + 2]);
+   EXPECT_FLOAT_EQ(1.0f, data[3*4 + 3]);
+}
+
+TEST(Matrix4Test, RotateX)
+{
+   Matrix4 m;
+   F32 angle = M_PI / 2.0f; // 90 degrees
+   m = m.rotate(angle, 1.0f, 0.0f, 0.0f);
+
+   const F32 *data = m.getData();
+   // Rotation about X:
+   // [ 1  0       0     0 ]
+   // [ 0 cos(a) -sin(a) 0 ]
+   // [ 0 sin(a)  cos(a) 0 ]
+   // [ 0  0       0     1 ]
+
+   EXPECT_NEAR(1.0f, data[0*4 + 0], 1e-6f);
+   EXPECT_NEAR(0.0f, data[1*4 + 1], 1e-6f); // cos(pi/2) = 0
+   EXPECT_NEAR(1.0f, data[1*4 + 2], 1e-6f); // sin(pi/2) = 1
+   EXPECT_NEAR(-1.0f, data[2*4 + 1], 1e-6f); // -sin(pi/2) = -1
+   EXPECT_NEAR(0.0f, data[2*4 + 2], 1e-6f); // cos(pi/2) = 0
+}
+
+TEST(Matrix4Test, Ortho)
+{
+   Matrix4 m = Matrix4::getOrthoProjection(-1.0f, 1.0f, -1.0f, 1.0f, -1.0f, 1.0f);
+   const F32 *data = m.getData();
+
+   // Ortho with these params should be identity (mostly, Z is negated in many ortho implementations)
+   // Wikipedia:
+   // [ 2/(r-l)      0          0     -(r+l)/(r-l) ]
+   // [    0      2/(t-b)       0     -(t+b)/(t-b) ]
+   // [    0         0      -2/(f-n)  -(f+n)/(f-n) ]
+   // [    0         0          0           1      ]
+
+   EXPECT_FLOAT_EQ(1.0f, data[0*4 + 0]);
+   EXPECT_FLOAT_EQ(1.0f, data[1*4 + 1]);
+   EXPECT_FLOAT_EQ(-1.0f, data[2*4 + 2]);
+   EXPECT_FLOAT_EQ(1.0f, data[3*4 + 3]);
+}
+
+TEST(Matrix4Test, TransformationOrder)
+{
+   // Bitfighter's Matrix4 applies transformations like glTranslate/glRotate:
+   // newMat = currentMat * transformationMat
+
+   Matrix4 m;
+   m = m.translate(10.0f, 0.0f, 0.0f);
+   m = m.scale(2.0f, 1.0f, 1.0f);
+
+   const F32 *data = m.getData();
+   EXPECT_FLOAT_EQ(2.0f, data[0*4 + 0]);
+   EXPECT_FLOAT_EQ(10.0f, data[3*4 + 0]);
+}
+
+} // namespace Zap

--- a/zap/CMakeLists.txt
+++ b/zap/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SHARED_SOURCES
 	IniFile.cpp
 	InputCode.cpp
 	item.cpp
+	Matrix4.cpp
 	LevelDatabase.cpp
 	LevelSource.cpp
 	LineItem.cpp
@@ -152,7 +153,6 @@ set(CLIENT_SOURCES
 	LoadoutIndicator.cpp
 	loadoutHelper.cpp
 	LevelListDisplayer.cpp
-	Matrix4.cpp
 	oglconsole.cpp
 	quickChatHelper.cpp
     Renderer.cpp

--- a/zap/Matrix4.cpp
+++ b/zap/Matrix4.cpp
@@ -7,8 +7,6 @@
 // This class stores its data as column-major for interoperability, which means we must access
 // elements as such: mData[col][row].
 
-#ifndef BF_USE_LEGACY_GL
-
 #include "Matrix4.h"
 #include <math.h>
 
@@ -179,5 +177,3 @@ Matrix4 Matrix4::getOrthoProjection(F32 left, F32 right, F32 bottom, F32 top, F3
 }
 
 }
-
-#endif // BF_USE_LEGACY_GL

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -7,6 +7,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/LevelFilesForTesting.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestBanList.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestBfObject.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestBitSet.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestEditor.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGameType.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestGameUserInterface.cpp
@@ -26,6 +27,7 @@ set(TEST_SOURCES
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestLuaEnvironment.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestMaster.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestMathUtils.cpp
+	${CMAKE_SOURCE_DIR}/bitfighter_test/TestMatrix4.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestMove.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestObjects.cpp
 	${CMAKE_SOURCE_DIR}/bitfighter_test/TestPoint.cpp


### PR DESCRIPTION
I have added comprehensive unit tests for two foundational classes in the Bitfighter codebase: `TNL::BitSet32` and `Zap::Matrix4`. These classes are used widely but previously lacked direct test coverage.

**Key Changes:**
1.  **New Tests**:
    *   `bitfighter_test/TestBitSet.cpp`: Tests construction, bit manipulation (`set`, `clear`, `toggle`), testing methods (`test`, `testStrict`), and overloaded operators.
    *   `bitfighter_test/TestMatrix4.cpp`: Tests identity matrix, constructors, multiplication, and transformations (`translate`, `scale`, `rotate`, `getOrthoProjection`).
2.  **Build Refactoring**:
    *   Moved `zap/Matrix4.cpp` from `CLIENT_SOURCES` to `SHARED_SOURCES` in `zap/CMakeLists.txt` so it can be accessed by the test target and other non-client utilities.
    *   Removed `#ifndef BF_USE_LEGACY_GL` preprocessor guards from `zap/Matrix4.cpp` to ensure the class is always compiled regardless of the OpenGL configuration.
    *   Registered the new test files in `zap/bitfighter_test.cmake`.

I verified these changes by compiling the new tests and their dependencies into a standalone test runner. This was necessary because the full `bitfighter_test` suite has dependencies on SDL and OpenGL which are unavailable in the current environment. All 13 new tests pass correctly.

---
*PR created automatically by Jules for task [533402474850500671](https://jules.google.com/task/533402474850500671) started by @eykamp*