### PR TITLE
Fix microsecond timer wrap and unit test compilation

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -2037,7 +2037,6 @@ TEST(GeomUtilsTest, TriangulateInsideTriangleLargeCoords)
    // (1e7, 1e7), (1e7 + 10, 1e7), (1e7, 1e7 + 10)
    // Inside point: (1e7 + 1, 1e7 + 1)
    // Outside point: (1e7 + 11, 1e7 + 1)
-   float offset = 1e7f;
    EXPECT_TRUE(Triangulate::InsideTriangle(offset, offset, offset + 10.0f, offset, offset, offset + 10.0f, offset + 1.0f, offset + 1.0f));
    EXPECT_FALSE(Triangulate::InsideTriangle(offset, offset, offset + 10.0f, offset, offset, offset + 10.0f, offset + 11.0f, offset + 1.0f));
 

--- a/bitfighter_test/TestTimer.cpp
+++ b/bitfighter_test/TestTimer.cpp
@@ -4,6 +4,7 @@
 //------------------------------------------------------------------------------
 
 #include "Timer.h"
+#include "tnlPlatform.h"
 #include "gtest/gtest.h"
 
 namespace Zap
@@ -121,6 +122,25 @@ TEST(TimerTest, ExtendUnderflow)
    t.extend(-150);
    EXPECT_EQ(0u, t.getPeriod());
    EXPECT_EQ(0u, t.getCurrent());
+}
+
+TEST(TimerTest, GetRealMicrosecondsMonotonic)
+{
+   U32 start = TNL::Platform::getRealMicroseconds();
+
+   // Busy wait for about 1.1 seconds to ensure we cross a second boundary
+   U32 elapsedMs = 0;
+   U32 startMs = TNL::Platform::getRealMilliseconds();
+   while(elapsedMs < 1100)
+   {
+      elapsedMs = TNL::Platform::getRealMilliseconds() - startMs;
+   }
+
+   U32 end = TNL::Platform::getRealMicroseconds();
+
+   // End should be greater than start, and significantly so (at least 1 second)
+   EXPECT_GT(end, start);
+   EXPECT_GE(end - start, 1000000u);
 }
 
 TEST(TimerTest, InvertPrecisionBug)

--- a/tnl/platform.cpp
+++ b/tnl/platform.cpp
@@ -368,51 +368,42 @@ U32 Platform::getRealMicroseconds()
    return x86UNIXGetTickCountMicro();
 }
 
-static bool   sg_initialized = false;
-static U32 sg_secsOffset  = 0;
+static bool sg_initialized = false;
+static timeval sg_startTime;
+
+static void x86UNIXTimerInit()
+{
+   if (sg_initialized == false) {
+      sg_initialized = true;
+      ::gettimeofday(&sg_startTime, NULL);
+   }
+}
 
 U32 x86UNIXGetTickCount()
 {
-   // TODO: What happens when crossing a day boundary?
-   //
+   x86UNIXTimerInit();
+
    timeval t;
-
-   if (sg_initialized == false) {
-      sg_initialized = true;
-
-      ::gettimeofday(&t, NULL);
-      sg_secsOffset = t.tv_sec;
-   }
-
    ::gettimeofday(&t, NULL);
 
-   U32 secs  = t.tv_sec - sg_secsOffset;
-   U32 uSecs = t.tv_usec;
+   S64 secs  = t.tv_sec - sg_startTime.tv_sec;
+   S64 uSecs = t.tv_usec - sg_startTime.tv_usec;
 
    // Make granularity 1 ms
-   return (secs * 1000) + (uSecs / 1000);
+   return (U32)(secs * 1000 + uSecs / 1000);
 }
-
-static U32 sg_uSecsOffset = 0;
 
 U32 x86UNIXGetTickCountMicro()
 {
-   // TODO: What happens when crossing a day boundary?
-   //
+   x86UNIXTimerInit();
+
    timeval t;
-
-   if (sg_initialized == false) {
-      sg_initialized = true;
-
-      ::gettimeofday(&t, NULL);
-      sg_uSecsOffset = t.tv_usec;
-   }
-
    ::gettimeofday(&t, NULL);
 
-   U32 uSecs  = t.tv_usec - sg_uSecsOffset;
+   S64 secs  = t.tv_sec - sg_startTime.tv_sec;
+   S64 uSecs = t.tv_usec - sg_startTime.tv_usec;
 
-   return uSecs;
+   return (U32)(secs * 1000000 + uSecs);
 }
 
 class UnixTimer


### PR DESCRIPTION
I have fixed a significant bug in the networking library (TNL) platform code for Linux and OSX. The `getRealMicroseconds()` function was incorrectly wrapping every second because it only considered the `tv_usec` portion of the current time. I refactored the timing logic to use a consistent start point and return total elapsed microseconds.

I also fixed a build failure in the unit test suite caused by a redeclaration of a variable in `TestGeomUtils.cpp`.

To verify the fix, I added a new test case `TimerTest.GetRealMicrosecondsMonotonic` which ensures the timer increases monotonically even when crossing second boundaries.

I have verified that the relevant tests pass in the sandbox environment.

Identify: I am an AI agent.

---
*PR created automatically by Jules for task [4577336320848086649](https://jules.google.com/task/4577336320848086649) started by @eykamp*