### PR TITLE
Fix player name trimming and JSON sanitization in master server

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -637,6 +637,18 @@ TEST(StringUtilsTest, sanitizeForJson)
 }
 
 
+TEST(StringUtilsTest, cleanString)
+{
+   EXPECT_EQ("abc", cleanString("  abc  "));
+   EXPECT_EQ("abc", cleanString("\n\t abc \r\n"));
+   EXPECT_EQ("abc", cleanString("abc"));
+   EXPECT_EQ("Default", cleanString("  ", "Default"));
+   EXPECT_EQ("Default", cleanString("", "Default"));
+   EXPECT_EQ("", cleanString("", ""));
+   EXPECT_EQ("Default", cleanString("\v \v", "Default"));
+}
+
+
 TEST(StringUtilsTest, trim)
 {
    EXPECT_EQ("abc", trim("  abc  "));

--- a/master/MasterServerConnection.cpp
+++ b/master/MasterServerConnection.cpp
@@ -535,7 +535,7 @@ void MasterServerConnection::writeClientServerList_JSON()
 
          fprintf(f, "%s\n\t\t{\n\t\t\t\"serverName\": \"%s\",\n\t\t\t\"protocolVersion\": %d,\n\t\t\t\"currentLevelName\": \"%s\",\n\t\t\t\"currentLevelType\": \"%s\",\n\t\t\t\"playerCount\": %d\n\t\t}",
                      first ? "" : ", ", sanitizeForJson(server->mPlayerOrServerName.getString()).c_str(),
-                     server->mCSProtocolVersion, server->mLevelName.getString(), server->mLevelType.getString(), server->mPlayerCount);
+                     server->mCSProtocolVersion, sanitizeForJson(server->mLevelName.getString()).c_str(), sanitizeForJson(server->mLevelType.getString()).c_str(), server->mPlayerCount);
          playerCount += server->mPlayerCount;
          serverCount++;
          first = false;
@@ -1477,11 +1477,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, s2mRequestAuthentication, (Ve
 // Remove leading/trailing spaces, provide default if name is empty
 string MasterServerConnection::cleanName(string name)    // Makes copy of name that we can alter
 {
-   trim(name);
-   if(name == "")
-      return "ChumpChange";
-
-   return name;
+   return Zap::cleanString(name, "ChumpChange");
 }
 
 

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -812,6 +812,17 @@ string trim(const string &source, const string &t)
 }
 
 
+// Removes leading and trailing whitespace; if string is empty, returns defaultValue
+string cleanString(string str, const string &defaultValue)
+{
+   trim_in_place(str);
+   if(str == "")
+      return defaultValue;
+
+   return str;
+}
+
+
 // These string methods operate on the given string in-place
 void trim_left_in_place(string &source, const string &t)
 {

--- a/zap/stringUtils.h
+++ b/zap/stringUtils.h
@@ -110,6 +110,7 @@ string strictjoindir(const string &part1, const string &part2, const string &par
 string trim_right(const string &source, const string &t = DEFAULT_TRIM_CHARS);
 string trim_left(const string &source, const string &t = DEFAULT_TRIM_CHARS);
 string trim(const string &source, const string &t = DEFAULT_TRIM_CHARS);
+string cleanString(string str, const string &defaultValue = "");
 
 void trim_right_in_place(string &source, const string &t = DEFAULT_TRIM_CHARS);
 void trim_left_in_place(string &source, const string &t = DEFAULT_TRIM_CHARS);


### PR DESCRIPTION
Hello! I am an AI agent and I've identified and fixed two bugs in the master server code:

1.  **Broken Trim Logic**: In `MasterServerConnection::cleanName`, the code called `trim(name)` but ignored the return value. Since `trim` returns a new string, the input was never actually cleaned. I've moved this logic to a new, testable utility function `Zap::cleanString` and updated the call site.
2.  **Missing JSON Sanitization**: In `MasterServerConnection::writeClientServerList_JSON`, level names and types were being written to the JSON output without being sanitized. If a level name contained a double quote, the resulting JSON would be invalid. I've added the necessary `sanitizeForJson` calls.

I've also included unit tests for the new `cleanString` function to ensure it behaves as expected. All string utility tests passed successfully.

---
*PR created automatically by Jules for task [4442366860032694845](https://jules.google.com/task/4442366860032694845) started by @eykamp*