### PR TITLE
macOS arm64: dedicated server (bitfighterd)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,17 @@ endif()
 
 
 # LuaJIT / Lua
+#
+# The in-tree LuaJIT is 2.0.5, which predates Apple Silicon and cannot target
+# arm64 macOS.  Require a system LuaJIT 2.1 (e.g. `brew install luajit`) there.
+if(APPLE AND LUAJIT_BUILTIN AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+	message(FATAL_ERROR
+		"The bundled LuaJIT 2.0.5 cannot be built for arm64 macOS.\n"
+		"Install LuaJIT 2.1 and configure with the system copy:\n"
+		"    brew install luajit\n"
+		"    cmake .. -DLUAJIT_BUILTIN=NO")
+endif()
+
 if(NOT LUAJIT_BUILTIN)
 find_with_fallback(LuaJit LUAJIT lua)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,10 @@ endif()
 #
 # The in-tree LuaJIT is 2.0.5, which predates Apple Silicon and cannot target
 # arm64 macOS.  Require a system LuaJIT 2.1 (e.g. `brew install luajit`) there.
-if(APPLE AND LUAJIT_BUILTIN AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+# CMAKE_OSX_ARCHITECTURES may be a list (e.g. a universal "arm64;x86_64"), so test
+# for membership rather than equality -- the bundled LuaJIT can't build an arm64
+# slice in that case either.
+if(APPLE AND LUAJIT_BUILTIN AND "arm64" IN_LIST CMAKE_OSX_ARCHITECTURES)
 	message(FATAL_ERROR
 		"The bundled LuaJIT 2.0.5 cannot be built for arm64 macOS.\n"
 		"Install LuaJIT 2.1 and configure with the system copy:\n"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ Similar to Linux, but with some additional steps.  In a shell, in the `build` di
 * `cmake ..`
 * `make Bitfighter`
 
+#### Apple Silicon (arm64)
+
+The build now targets the host CPU by default, so Apple Silicon Macs build native
+`arm64` binaries (no Rosetta).  The bundled LuaJIT is 2.0.5, which predates Apple
+Silicon, so a native build needs LuaJIT 2.1 from Homebrew:
+* `brew install luajit`
+* `cmake .. -DLUAJIT_BUILTIN=NO`
+* `make bitfighterd`
+
+The binary lands in `exe/bitfighterd` as a native `arm64` executable.
+
+The full client (`make Bitfighter`) still depends on the Intel-only prebuilt
+frameworks in `lib/` (SDL2, libpng, OpenAL, Sparkle, ...), so it isn't native yet;
+build it x86_64-under-Rosetta with `cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64`.
+
 ## INSTALLATION AND PACKAGING
 ### Linux
 After running `make`, the bitfighter executable is put into the directory `exe/`.  Copy everything from the `resources/` directory into the `exe/` directory, keeping the folders intact (like sfx, scripts, etc.).

--- a/cmake/Modules/FindLuaJit.cmake
+++ b/cmake/Modules/FindLuaJit.cmake
@@ -8,7 +8,8 @@ set(LUAJIT_SEARCH_PATHS
 	${LUAJIT_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
-	/usr/local
+	/opt/homebrew # Homebrew on Apple Silicon
+	/usr/local    # Homebrew on Intel
 	/usr
 	/sw # Fink
 	/opt/local # DarwinPorts
@@ -17,15 +18,15 @@ set(LUAJIT_SEARCH_PATHS
 )
 
 
-find_path(LUAJIT_INCLUDE_DIR 
+find_path(LUAJIT_INCLUDE_DIR
 	NAMES lua.h
 	HINTS ENV LUAJITDIR
-	PATH_SUFFIXES include include/luajit luajit luajit-2.0 luajit-2.1 luajit/src luajit-5_1-2.0
+	PATH_SUFFIXES include include/luajit include/luajit-2.0 include/luajit-2.1 luajit luajit-2.0 luajit-2.1 luajit/src luajit-5_1-2.0
 	PATHS ${LUAJIT_SEARCH_PATHS}
 )
 
-find_library(LUAJIT_LIBRARIES NAMES 
-	NAMES luajit libluajit luajit luajit-5.1
+find_library(LUAJIT_LIBRARIES
+	NAMES luajit libluajit luajit-5.1
 	HINTS ENV LUAJITDIR
 	PATH_SUFFIXES lib64 lib libs64 libs libs/Win32 libs/Win64
 	PATHS ${LUAJIT_SEARCH_PATHS}

--- a/cmake/Platform/Apple.cmake
+++ b/cmake/Platform/Apple.cmake
@@ -121,7 +121,11 @@ endfunction()
 
 
 function(BF_PLATFORM_SET_EXTRA_LIBS)
-	set(EXTRA_LIBS dl m PARENT_SCOPE)
+	# Directory.mm is a shared source that uses Foundation (NSFileManager,
+	# NSBundle, NSSearchPathForDirectoriesInDomains, ...), so every macOS
+	# target -- including the dedicated server -- must link it.
+	find_library(FOUNDATION_LIBRARY Foundation)
+	set(EXTRA_LIBS dl m ${FOUNDATION_LIBRARY} PARENT_SCOPE)
 endfunction()
 
 
@@ -176,7 +180,20 @@ function(BF_PLATFORM_POST_BUILD_INSTALL_RESOURCES targetName)
 	file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/lib/ libDir)
 	file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/lua/luajit/src/ luaLibDir)
 	file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/exe exeDir)
-	
+
+	# Non-bundle targets (the dedicated server and the test runner) are plain
+	# executables in exe/.  They locate resources relative to the binary (see
+	# FolderManager::resolveDirs), so just drop resource/* alongside the binary
+	# and skip the .app bundle / framework bundling, which assumes a .app layout
+	# and Intel-only prebuilt frameworks.
+	get_target_property(isBundle ${targetName} MACOSX_BUNDLE)
+	if(NOT isBundle)
+		add_custom_command(TARGET ${targetName} POST_BUILD
+			COMMAND cp -rp ${resDir}* ${exeDir}
+		)
+		return()
+	endif()
+
 	# Create extra dirs in the .app
 	set(frameworksDir "${exeDir}/${targetName}.app/Contents/Frameworks")
 	set(resourcesDir "${exeDir}/${targetName}.app/Contents/Resources")

--- a/cmake/Platform/Apple.cmake
+++ b/cmake/Platform/Apple.cmake
@@ -29,12 +29,18 @@ if(NOT XCOMPILE)
 
 
 	# Make sure the compiling architecture is set
+	#
+	# Honor an explicit -DCMAKE_OSX_ARCHITECTURES=... (e.g. to cross-build x86_64
+	# under Rosetta).  Otherwise default to the host CPU so Apple Silicon Macs
+	# build native arm64 binaries instead of x86_64-under-Rosetta.
 	if(OSX_DEPLOY_TARGET VERSION_LESS "10.5")
 		message(FATAL_ERROR "Bitfighter cannot be compiled on OSX earlier than 10.5")
-	elseif(OSX_DEPLOY_TARGET VERSION_LESS "10.6")
-		set(CMAKE_OSX_ARCHITECTURES "i386")
-	else()
-		set(CMAKE_OSX_ARCHITECTURES "x86_64")
+	elseif(NOT CMAKE_OSX_ARCHITECTURES)
+		if(OSX_DEPLOY_TARGET VERSION_LESS "10.6")
+			set(CMAKE_OSX_ARCHITECTURES "i386")
+		else()
+			set(CMAKE_OSX_ARCHITECTURES "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+		endif()
 	endif()
 	
 	message(STATUS "CMAKE_OSX_SYSROOT: ${CMAKE_OSX_SYSROOT}")
@@ -247,6 +253,8 @@ function(BF_PLATFORM_CREATE_PACKAGES targetName)
 	
 	if(CMAKE_OSX_ARCHITECTURES STREQUAL "i386")
 		set(DMG_ARCH "32bit-Intel")
+	elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+		set(DMG_ARCH "arm64")
 	else()
 		set(DMG_ARCH "64bit-Intel")
 	endif()

--- a/zap/Directory.mm
+++ b/zap/Directory.mm
@@ -11,6 +11,8 @@
 #include "tnlVector.h"
 #ifdef TNL_OS_MAC_OSX
 #import <Cocoa/Cocoa.h>
+// Sparkle is a client-only auto-updater; the dedicated server doesn't link it
+#ifndef ZAP_DEDICATED
 #import "SUUpdater.h"
 // Here we add a GET parameter for the different OSX architectures.  This way we
 // can serve up a different download URL dynamically
@@ -24,6 +26,7 @@
       // Default to x86_64 since that is all OSX runs on these days...
 #     define SPARKLE_APPCAST_URL @"http://bitfighter.org/files/getDownloadUrl.php?platform=osxx86_64"
 #  endif
+#endif // !ZAP_DEDICATED
 #else
 #import <Foundation/Foundation.h>
 #endif
@@ -67,7 +70,7 @@ void prepareFirstLaunchMac()
 
 void checkForUpdates()
 {
-#ifdef TNL_OS_MAC_OSX
+#if defined(TNL_OS_MAC_OSX) && !defined(ZAP_DEDICATED)
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     SUUpdater* updater = [SUUpdater sharedUpdater];
     [updater setFeedURL:[NSURL URLWithString:SPARKLE_APPCAST_URL]];


### PR DESCRIPTION
> **Apple Silicon stack** — review/merge bottom-up:
> 1. **#816 — dedicated server (`bitfighterd`)** ← you are here
> 2. #817 — client (`Bitfighter.app`)
> 3. #818 — relocatable `.app` + DMG packaging

Makes the **dedicated server** (`bitfighterd`) and test runner build and run natively on arm64 macOS, instead of x86_64-under-Rosetta. First branch in the Apple Silicon stack; the client and packaging follow in separate PRs that depend on this one.

## Changes
- **Un-hardcode the macOS architecture** — `Apple.cmake` forced `CMAKE_OSX_ARCHITECTURES=x86_64`; now defaults to the host CPU. An explicit `-DCMAKE_OSX_ARCHITECTURES=x86_64` still works for Rosetta/cross builds.
- **LuaJIT 2.1 via Homebrew** — the bundled LuaJIT 2.0.5 predates Apple Silicon. The find module searches `/opt/homebrew`, and configure fails fast on arm64 + builtin LuaJIT with guidance to use `-DLUAJIT_BUILTIN=NO`.
- **Gate Sparkle out of dedicated builds** — `Directory.mm` no longer references the client-only Sparkle framework under `ZAP_DEDICATED`.
- **Bundle-aware post-build** — non-bundle targets (server, tests) get resources copied next to the binary instead of the `.app`/lipo/rpath path that assumed a bundle.
- **Link Foundation** — `Directory.mm` (a shared source) uses `NSFileManager`/`NSBundle`; the missing framework is why a native server never linked before.

x86_64/Rosetta builds are unchanged.

## Test plan
```
brew install luajit
cd build && cmake .. -DLUAJIT_BUILTIN=NO && make bitfighterd
cd ../exe && ./bitfighterd -dedicated
```
Verified on Apple Silicon: native `arm64` binary, links Homebrew LuaJIT 2.1, hosts on UDP 28000, loads levels, connects to the master server.
