### PR TITLE
macOS arm64: client (Bitfighter.app)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,17 @@ endif()
 
 
 # LuaJIT / Lua
+#
+# The in-tree LuaJIT is 2.0.5, which predates Apple Silicon and cannot target
+# arm64 macOS.  Require a system LuaJIT 2.1 (e.g. `brew install luajit`) there.
+if(APPLE AND LUAJIT_BUILTIN AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+	message(FATAL_ERROR
+		"The bundled LuaJIT 2.0.5 cannot be built for arm64 macOS.\n"
+		"Install LuaJIT 2.1 and configure with the system copy:\n"
+		"    brew install luajit\n"
+		"    cmake .. -DLUAJIT_BUILTIN=NO")
+endif()
+
 if(NOT LUAJIT_BUILTIN)
 find_with_fallback(LuaJit LUAJIT lua)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,10 @@ endif()
 #
 # The in-tree LuaJIT is 2.0.5, which predates Apple Silicon and cannot target
 # arm64 macOS.  Require a system LuaJIT 2.1 (e.g. `brew install luajit`) there.
-if(APPLE AND LUAJIT_BUILTIN AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+# CMAKE_OSX_ARCHITECTURES may be a list (e.g. a universal "arm64;x86_64"), so test
+# for membership rather than equality -- the bundled LuaJIT can't build an arm64
+# slice in that case either.
+if(APPLE AND LUAJIT_BUILTIN AND "arm64" IN_LIST CMAKE_OSX_ARCHITECTURES)
 	message(FATAL_ERROR
 		"The bundled LuaJIT 2.0.5 cannot be built for arm64 macOS.\n"
 		"Install LuaJIT 2.1 and configure with the system copy:\n"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ Similar to Linux, but with some additional steps.  In a shell, in the `build` di
 * `cmake ..`
 * `make Bitfighter`
 
+#### Apple Silicon (arm64)
+
+The build now targets the host CPU by default, so Apple Silicon Macs build native
+`arm64` binaries (no Rosetta).  The bundled LuaJIT is 2.0.5, which predates Apple
+Silicon, so a native build needs LuaJIT 2.1 from Homebrew:
+* `brew install luajit`
+* `cmake .. -DLUAJIT_BUILTIN=NO`
+* `make bitfighterd`
+
+The binary lands in `exe/bitfighterd` as a native `arm64` executable.
+
+The full client (`make Bitfighter`) still depends on the Intel-only prebuilt
+frameworks in `lib/` (SDL2, libpng, OpenAL, Sparkle, ...), so it isn't native yet;
+build it x86_64-under-Rosetta with `cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64`.
+
 ## INSTALLATION AND PACKAGING
 ### Linux
 After running `make`, the bitfighter executable is put into the directory `exe/`.  Copy everything from the `resources/` directory into the `exe/` directory, keeping the folders intact (like sfx, scripts, etc.).

--- a/README.md
+++ b/README.md
@@ -96,10 +96,9 @@ so a native build resolves its dependencies from Homebrew:
 Silicon; the client is built without the Sparkle auto-updater (the bundled
 Sparkle is Intel-only Sparkle 1.x).
 
-The native `.app` links its Homebrew dylibs by absolute path and runs in place on
-the build machine — it is not yet a self-contained, distributable bundle.  Run it
-with its resource folder available, e.g.:
-* `exe/Bitfighter.app/Contents/MacOS/Bitfighter -rootdatadir exe`
+`exe/Bitfighter.app` runs in place (`open exe/Bitfighter.app`); it links its
+Homebrew dylibs by absolute path, so it is not yet a self-contained, relocatable
+bundle for distribution to other machines.
 
 To build the Intel client under Rosetta instead (using the bundled `lib/`
 frameworks), configure with `cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64`.

--- a/README.md
+++ b/README.md
@@ -83,18 +83,26 @@ Similar to Linux, but with some additional steps.  In a shell, in the `build` di
 
 #### Apple Silicon (arm64)
 
-The build now targets the host CPU by default, so Apple Silicon Macs build native
-`arm64` binaries (no Rosetta).  The bundled LuaJIT is 2.0.5, which predates Apple
-Silicon, so a native build needs LuaJIT 2.1 from Homebrew:
-* `brew install luajit`
+The build targets the host CPU by default, so Apple Silicon Macs build native
+`arm64` binaries (no Rosetta).  The prebuilt libraries in `lib/` are Intel-only,
+so a native build resolves its dependencies from Homebrew:
+
+* `brew install luajit sdl2 libpng libogg libvorbis speex libmodplug openal-soft`
 * `cmake .. -DLUAJIT_BUILTIN=NO`
-* `make bitfighterd`
+* `make bitfighterd`   &nbsp;# dedicated server &rarr; `exe/bitfighterd`
+* `make Bitfighter`    &nbsp;# client &rarr; `exe/Bitfighter.app`
 
-The binary lands in `exe/bitfighterd` as a native `arm64` executable.
+`-DLUAJIT_BUILTIN=NO` is required because the bundled LuaJIT 2.0.5 predates Apple
+Silicon; the client is built without the Sparkle auto-updater (the bundled
+Sparkle is Intel-only Sparkle 1.x).
 
-The full client (`make Bitfighter`) still depends on the Intel-only prebuilt
-frameworks in `lib/` (SDL2, libpng, OpenAL, Sparkle, ...), so it isn't native yet;
-build it x86_64-under-Rosetta with `cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64`.
+The native `.app` links its Homebrew dylibs by absolute path and runs in place on
+the build machine — it is not yet a self-contained, distributable bundle.  Run it
+with its resource folder available, e.g.:
+* `exe/Bitfighter.app/Contents/MacOS/Bitfighter -rootdatadir exe`
+
+To build the Intel client under Rosetta instead (using the bundled `lib/`
+frameworks), configure with `cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64`.
 
 ## INSTALLATION AND PACKAGING
 ### Linux

--- a/cmake/Modules/FindALURE.cmake
+++ b/cmake/Modules/FindALURE.cmake
@@ -8,6 +8,7 @@ set(ALURE_SEARCH_PATHS
 	${ALURE_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
+	/opt/homebrew # Homebrew on Apple Silicon
 	/usr/local
 	/usr
 	/sw # Fink

--- a/cmake/Modules/FindLuaJit.cmake
+++ b/cmake/Modules/FindLuaJit.cmake
@@ -8,7 +8,8 @@ set(LUAJIT_SEARCH_PATHS
 	${LUAJIT_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
-	/usr/local
+	/opt/homebrew # Homebrew on Apple Silicon
+	/usr/local    # Homebrew on Intel
 	/usr
 	/sw # Fink
 	/opt/local # DarwinPorts
@@ -17,15 +18,15 @@ set(LUAJIT_SEARCH_PATHS
 )
 
 
-find_path(LUAJIT_INCLUDE_DIR 
+find_path(LUAJIT_INCLUDE_DIR
 	NAMES lua.h
 	HINTS ENV LUAJITDIR
-	PATH_SUFFIXES include include/luajit luajit luajit-2.0 luajit-2.1 luajit/src luajit-5_1-2.0
+	PATH_SUFFIXES include include/luajit include/luajit-2.0 include/luajit-2.1 luajit luajit-2.0 luajit-2.1 luajit/src luajit-5_1-2.0
 	PATHS ${LUAJIT_SEARCH_PATHS}
 )
 
-find_library(LUAJIT_LIBRARIES NAMES 
-	NAMES luajit libluajit luajit luajit-5.1
+find_library(LUAJIT_LIBRARIES
+	NAMES luajit libluajit luajit-5.1
 	HINTS ENV LUAJITDIR
 	PATH_SUFFIXES lib64 lib libs64 libs libs/Win32 libs/Win64
 	PATHS ${LUAJIT_SEARCH_PATHS}

--- a/cmake/Modules/FindModPlug.cmake
+++ b/cmake/Modules/FindModPlug.cmake
@@ -9,6 +9,7 @@ set(MODPLUG_SEARCH_PATHS
 	${MODPLUG_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
+	/opt/homebrew # Homebrew on Apple Silicon
 	/usr/local
 	/usr
 	/sw # Fink

--- a/cmake/Modules/FindOGG.cmake
+++ b/cmake/Modules/FindOGG.cmake
@@ -9,6 +9,7 @@ SET(OGG_SEARCH_PATHS
 	${OGG_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
+	/opt/homebrew # Homebrew on Apple Silicon
 	/usr/local
 	/usr
 	/sw # Fink

--- a/cmake/Modules/FindSDL2.cmake
+++ b/cmake/Modules/FindSDL2.cmake
@@ -69,6 +69,7 @@ SET(SDL2_SEARCH_PATHS
 	${SDL2_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
+	/opt/homebrew # Homebrew on Apple Silicon
 	/usr/local
 	/usr
 	/sw # Fink

--- a/cmake/Modules/FindSpeex.cmake
+++ b/cmake/Modules/FindSpeex.cmake
@@ -8,6 +8,7 @@ set(SPEEX_SEARCH_PATHS
 	${SPEEX_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
+	/opt/homebrew # Homebrew on Apple Silicon
 	/usr/local
 	/usr
 	/sw # Fink

--- a/cmake/Modules/FindVorbis.cmake
+++ b/cmake/Modules/FindVorbis.cmake
@@ -9,6 +9,7 @@ SET(VORBIS_SEARCH_PATHS
 	${VORBIS_SEARCH_PATHS}
 	~/Library/Frameworks
 	/Library/Frameworks
+	/opt/homebrew # Homebrew on Apple Silicon
 	/usr/local
 	/usr
 	/sw # Fink

--- a/cmake/Platform/Apple.cmake
+++ b/cmake/Platform/Apple.cmake
@@ -92,10 +92,22 @@ if(BF_USE_HOMEBREW_LIBS)
 	endif()
 
 	execute_process(COMMAND ${BREW_COMMAND} --prefix
-		OUTPUT_VARIABLE HOMEBREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+		OUTPUT_VARIABLE HOMEBREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE
+		RESULT_VARIABLE BREW_PREFIX_RESULT)
 	# openal-soft is keg-only, so it isn't symlinked into the main prefix
 	execute_process(COMMAND ${BREW_COMMAND} --prefix openal-soft
-		OUTPUT_VARIABLE OPENAL_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+		OUTPUT_VARIABLE OPENAL_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE
+		RESULT_VARIABLE OPENAL_PREFIX_RESULT)
+
+	# Without these checks an uninstalled formula leaves the prefix empty and
+	# paths like ${OPENAL_PREFIX}/lib/libopenal.dylib silently resolve to
+	# /lib/..., which fails much later with a confusing message.
+	if(NOT BREW_PREFIX_RESULT EQUAL 0 OR NOT HOMEBREW_PREFIX)
+		message(FATAL_ERROR "Could not determine the Homebrew prefix from `brew --prefix`.")
+	endif()
+	if(NOT OPENAL_PREFIX_RESULT EQUAL 0 OR NOT OPENAL_PREFIX)
+		message(FATAL_ERROR "openal-soft is not installed. Install it with: brew install openal-soft")
+	endif()
 
 	message(STATUS "Resolving client dependencies from Homebrew: ${HOMEBREW_PREFIX}")
 

--- a/cmake/Platform/Apple.cmake
+++ b/cmake/Platform/Apple.cmake
@@ -78,32 +78,93 @@ endif()
 set(BF_LIB_DIR ${CMAKE_SOURCE_DIR}/lib)
 set(BF_LIB_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/lib/include)
 
-# Set some search paths
-set(SDL2_SEARCH_PATHS       ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libsdl)
-set(OGG_SEARCH_PATHS        ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libogg)
-set(VORBIS_SEARCH_PATHS     ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libvorbis)
-set(VORBISFILE_SEARCH_PATHS ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libvorbis)
-set(SPEEX_SEARCH_PATHS      ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libspeex)
-set(MODPLUG_SEARCH_PATHS    ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libmodplug)
-set(ALURE_SEARCH_PATHS      ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/alure)
+# The prebuilt frameworks/dylibs in lib/ are Intel-only.  On Apple Silicon we
+# resolve the client dependencies from Homebrew instead.  An x86_64 (Rosetta)
+# build keeps using the bundled libraries, so existing behaviour is unchanged.
+if(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+	set(BF_USE_HOMEBREW_LIBS TRUE)
+endif()
 
-# Directly set include dirs for some libraries
-set(OPENAL_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/openal/include")
-set(ZLIB_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/zlib")
-# libpng needs two for some weird reason
-set(PNG_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/libpng")
-set(PNG_PNG_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/libpng")
+if(BF_USE_HOMEBREW_LIBS)
+	find_program(BREW_COMMAND brew)
+	if(NOT BREW_COMMAND)
+		message(FATAL_ERROR "Homebrew is required for a native arm64 build. Install it from https://brew.sh and run: brew install sdl2 libpng libogg libvorbis speex libmodplug openal-soft")
+	endif()
 
-# Directly specify some libs
-set(OPENAL_LIBRARY "${BF_LIB_DIR}/libopenal.1.dylib")
-set(PNG_LIBRARY "${BF_LIB_DIR}/libpng.framework")
+	execute_process(COMMAND ${BREW_COMMAND} --prefix
+		OUTPUT_VARIABLE HOMEBREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+	# openal-soft is keg-only, so it isn't symlinked into the main prefix
+	execute_process(COMMAND ${BREW_COMMAND} --prefix openal-soft
+		OUTPUT_VARIABLE OPENAL_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(SPARKLE_SEARCH_PATHS ${BF_LIB_DIR})
-# OSX doesn't use vorbisfile (or it's built-in to normal vorbis, I think)
-set(VORBISFILE_LIBRARIES "")
+	message(STATUS "Resolving client dependencies from Homebrew: ${HOMEBREW_PREFIX}")
+
+	# Let the system find modules (PNG, etc.) search the Homebrew prefix
+	list(APPEND CMAKE_PREFIX_PATH ${HOMEBREW_PREFIX} ${OPENAL_PREFIX})
+
+	# Point our custom Find* modules at Homebrew instead of the bundled libs
+	set(SDL2_SEARCH_PATHS    ${HOMEBREW_PREFIX})
+	set(OGG_SEARCH_PATHS     ${HOMEBREW_PREFIX})
+	set(VORBIS_SEARCH_PATHS  ${HOMEBREW_PREFIX})
+	set(SPEEX_SEARCH_PATHS   ${HOMEBREW_PREFIX})
+	set(MODPLUG_SEARCH_PATHS ${HOMEBREW_PREFIX})
+	# ALURE has no system package on macOS; it is built in-tree against the
+	# Homebrew OpenAL/Vorbis/ModPlug resolved above.
+	set(ALURE_SEARCH_PATHS   ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/alure)
+
+	# openal-soft replaces the bundled (deprecated) OpenAL; specify it directly
+	# since CMake's FindOpenAL otherwise prefers the deprecated system framework.
+	# openal-soft installs its headers under include/AL, but the source uses the
+	# flat <al.h>/<alc.h> include style, so add both the parent and AL dirs.
+	set(OPENAL_INCLUDE_DIR "${OPENAL_PREFIX}/include" "${OPENAL_PREFIX}/include/AL")
+	set(OPENAL_LIBRARY "${OPENAL_PREFIX}/lib/libopenal.dylib")
+	# Homebrew ships vorbisfile as a separate dylib (the bundled Vorbis.framework
+	# had it baked in); ALURE needs it for ogg decoding.  PNG and zlib resolve
+	# through CMAKE_PREFIX_PATH / the system SDK.
+	set(VORBISFILE_LIBRARIES "${HOMEBREW_PREFIX}/lib/libvorbisfile.dylib")
+else()
+	# Set some search paths
+	set(SDL2_SEARCH_PATHS       ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libsdl)
+	set(OGG_SEARCH_PATHS        ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libogg)
+	set(VORBIS_SEARCH_PATHS     ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libvorbis)
+	set(VORBISFILE_SEARCH_PATHS ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libvorbis)
+	set(SPEEX_SEARCH_PATHS      ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libspeex)
+	set(MODPLUG_SEARCH_PATHS    ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/libmodplug)
+	set(ALURE_SEARCH_PATHS      ${BF_LIB_DIR} ${BF_LIB_INCLUDE_DIR}/alure)
+
+	# Directly set include dirs for some libraries
+	set(OPENAL_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/openal/include")
+	set(ZLIB_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/zlib")
+	# libpng needs two for some weird reason
+	set(PNG_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/libpng")
+	set(PNG_PNG_INCLUDE_DIR "${BF_LIB_INCLUDE_DIR}/libpng")
+
+	# Directly specify some libs
+	set(OPENAL_LIBRARY "${BF_LIB_DIR}/libopenal.1.dylib")
+	set(PNG_LIBRARY "${BF_LIB_DIR}/libpng.framework")
+
+	set(SPARKLE_SEARCH_PATHS ${BF_LIB_DIR})
+	# OSX doesn't use vorbisfile (or it's built-in to normal vorbis, I think)
+	set(VORBISFILE_LIBRARIES "")
+endif()
 
 
-find_package(Sparkle)
+# Sparkle auto-updater (client only).  The bundled Sparkle is 1.x and Intel-only;
+# a native arm64 build would require migrating to Sparkle 2.x, so default it off
+# there and build the client without the auto-updater for now.
+if(BF_USE_HOMEBREW_LIBS)
+	set(_use_sparkle_default OFF)
+else()
+	set(_use_sparkle_default ON)
+endif()
+option(USE_SPARKLE "Build the macOS client with the Sparkle auto-updater" ${_use_sparkle_default})
+
+if(USE_SPARKLE)
+	find_package(Sparkle)
+else()
+	message(STATUS "Building macOS client without the Sparkle auto-updater")
+	add_definitions(-DBF_NO_SPARKLE)
+endif()
 
 
 ## End Global project configuration
@@ -219,38 +280,48 @@ function(BF_PLATFORM_POST_BUILD_INSTALL_RESOURCES targetName)
 		COMMAND ${COPY_RES_4}
 	)
 	
-	# 64-bit OSX needs to use shared LuaJIT library
-	if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+	# Copy game resources into the bundle
+	add_custom_command(TARGET ${targetName} POST_BUILD
+		COMMAND ${RES_COPY_CMD}
+	)
+
+	# The prebuilt frameworks in lib/ are Intel-only.  A native (Homebrew) build
+	# links Homebrew dylibs by absolute path and runs in place, so don't bundle
+	# or lipo-thin them here.  Producing a self-contained, relocatable .app for
+	# distribution (e.g. via dylibbundler) is a separate packaging step.
+	if(NOT BF_USE_HOMEBREW_LIBS)
+		# 64-bit OSX needs to use shared LuaJIT library
+		if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+			add_custom_command(TARGET ${targetName} POST_BUILD
+				COMMAND cp -rp ${luaLibDir}libluajit.dylib ${frameworksDir}
+			)
+		endif()
+
+		# Copy the bundled frameworks/dylibs into the .app
 		add_custom_command(TARGET ${targetName} POST_BUILD
-			COMMAND cp -rp ${luaLibDir}libluajit.dylib ${frameworksDir}
+			COMMAND ${LIB_COPY_CMD}
+			COMMAND ${LIB_COPY_CMD_2}
+		)
+
+		# Thin out our installed frameworks by running 'lipo' to clean out the
+		# unwanted architectures and removing any header files
+		if(NOT LIPO_COMMAND)
+			set(LIPO_COMMAND lipo)
+		endif()
+
+		# This can happen when cross-compiling x86_64
+		if(NOT CMAKE_OSX_ARCHITECTURES)
+			set(CMAKE_OSX_ARCHITECTURES "x86_64")
+		endif()
+
+		set(THIN_FRAMEWORKS ${CMAKE_SOURCE_DIR}/build/osx/tools/thin_frameworks.sh ${LIPO_COMMAND} ${CMAKE_OSX_ARCHITECTURES} ${exeDir}/${targetName}.app)
+		set(DO_RPATH_THING ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/../Frameworks/" ${exeDir}/${targetName}.app/Contents/MacOS/${targetName})
+
+		add_custom_command(TARGET ${targetName} POST_BUILD
+			COMMAND ${THIN_FRAMEWORKS}
+			COMMAND ${DO_RPATH_THING}
 		)
 	endif()
-	
-	# Copy resources
-	add_custom_command(TARGET ${targetName} POST_BUILD 
-		COMMAND ${RES_COPY_CMD}
-		COMMAND ${LIB_COPY_CMD}
-		COMMAND ${LIB_COPY_CMD_2}
-	)
-	
-	# Thin out our installed frameworks by running 'lipo' to clean out the unwanted 
-	# architectures and removing any header files
-	if(NOT LIPO_COMMAND)
-		set(LIPO_COMMAND lipo)
-	endif()
-	
-	# This can happen when cross-compiling x86_64
-	if(NOT CMAKE_OSX_ARCHITECTURES)
-		set(CMAKE_OSX_ARCHITECTURES "x86_64")
-	endif()
-	
-	set(THIN_FRAMEWORKS ${CMAKE_SOURCE_DIR}/build/osx/tools/thin_frameworks.sh ${LIPO_COMMAND} ${CMAKE_OSX_ARCHITECTURES} ${exeDir}/${targetName}.app)
-	set(DO_RPATH_THING ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/../Frameworks/" ${exeDir}/${targetName}.app/Contents/MacOS/${targetName})
-	
-	add_custom_command(TARGET ${targetName} POST_BUILD
-		COMMAND ${THIN_FRAMEWORKS}
-		COMMAND ${DO_RPATH_THING}
-	)
 endfunction()
 
 

--- a/cmake/Platform/Apple.cmake
+++ b/cmake/Platform/Apple.cmake
@@ -121,7 +121,11 @@ endfunction()
 
 
 function(BF_PLATFORM_SET_EXTRA_LIBS)
-	set(EXTRA_LIBS dl m PARENT_SCOPE)
+	# Directory.mm is a shared source that uses Foundation (NSFileManager,
+	# NSBundle, NSSearchPathForDirectoriesInDomains, ...), so every macOS
+	# target -- including the dedicated server -- must link it.
+	find_library(FOUNDATION_LIBRARY Foundation)
+	set(EXTRA_LIBS dl m ${FOUNDATION_LIBRARY} PARENT_SCOPE)
 endfunction()
 
 
@@ -176,7 +180,20 @@ function(BF_PLATFORM_POST_BUILD_INSTALL_RESOURCES targetName)
 	file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/lib/ libDir)
 	file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/lua/luajit/src/ luaLibDir)
 	file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR}/exe exeDir)
-	
+
+	# Non-bundle targets (the dedicated server and the test runner) are plain
+	# executables in exe/.  They locate resources relative to the binary (see
+	# FolderManager::resolveDirs), so just drop resource/* alongside the binary
+	# and skip the .app bundle / framework bundling, which assumes a .app layout
+	# and Intel-only prebuilt frameworks.
+	get_target_property(isBundle ${targetName} MACOSX_BUNDLE)
+	if(NOT isBundle)
+		add_custom_command(TARGET ${targetName} POST_BUILD
+			COMMAND cp -rp ${resDir}* ${exeDir}
+		)
+		return()
+	endif()
+
 	# Create extra dirs in the .app
 	set(frameworksDir "${exeDir}/${targetName}.app/Contents/Frameworks")
 	set(resourcesDir "${exeDir}/${targetName}.app/Contents/Resources")

--- a/cmake/Platform/Apple.cmake
+++ b/cmake/Platform/Apple.cmake
@@ -29,12 +29,18 @@ if(NOT XCOMPILE)
 
 
 	# Make sure the compiling architecture is set
+	#
+	# Honor an explicit -DCMAKE_OSX_ARCHITECTURES=... (e.g. to cross-build x86_64
+	# under Rosetta).  Otherwise default to the host CPU so Apple Silicon Macs
+	# build native arm64 binaries instead of x86_64-under-Rosetta.
 	if(OSX_DEPLOY_TARGET VERSION_LESS "10.5")
 		message(FATAL_ERROR "Bitfighter cannot be compiled on OSX earlier than 10.5")
-	elseif(OSX_DEPLOY_TARGET VERSION_LESS "10.6")
-		set(CMAKE_OSX_ARCHITECTURES "i386")
-	else()
-		set(CMAKE_OSX_ARCHITECTURES "x86_64")
+	elseif(NOT CMAKE_OSX_ARCHITECTURES)
+		if(OSX_DEPLOY_TARGET VERSION_LESS "10.6")
+			set(CMAKE_OSX_ARCHITECTURES "i386")
+		else()
+			set(CMAKE_OSX_ARCHITECTURES "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+		endif()
 	endif()
 	
 	message(STATUS "CMAKE_OSX_SYSROOT: ${CMAKE_OSX_SYSROOT}")
@@ -247,6 +253,8 @@ function(BF_PLATFORM_CREATE_PACKAGES targetName)
 	
 	if(CMAKE_OSX_ARCHITECTURES STREQUAL "i386")
 		set(DMG_ARCH "32bit-Intel")
+	elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+		set(DMG_ARCH "arm64")
 	else()
 		set(DMG_ARCH "64bit-Intel")
 	endif()

--- a/zap/Directory.mm
+++ b/zap/Directory.mm
@@ -11,6 +11,8 @@
 #include "tnlVector.h"
 #ifdef TNL_OS_MAC_OSX
 #import <Cocoa/Cocoa.h>
+// Sparkle is a client-only auto-updater; the dedicated server doesn't link it
+#ifndef ZAP_DEDICATED
 #import "SUUpdater.h"
 // Here we add a GET parameter for the different OSX architectures.  This way we
 // can serve up a different download URL dynamically
@@ -24,6 +26,7 @@
       // Default to x86_64 since that is all OSX runs on these days...
 #     define SPARKLE_APPCAST_URL @"http://bitfighter.org/files/getDownloadUrl.php?platform=osxx86_64"
 #  endif
+#endif // !ZAP_DEDICATED
 #else
 #import <Foundation/Foundation.h>
 #endif
@@ -67,7 +70,7 @@ void prepareFirstLaunchMac()
 
 void checkForUpdates()
 {
-#ifdef TNL_OS_MAC_OSX
+#if defined(TNL_OS_MAC_OSX) && !defined(ZAP_DEDICATED)
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     SUUpdater* updater = [SUUpdater sharedUpdater];
     [updater setFeedURL:[NSURL URLWithString:SPARKLE_APPCAST_URL]];

--- a/zap/Directory.mm
+++ b/zap/Directory.mm
@@ -11,8 +11,9 @@
 #include "tnlVector.h"
 #ifdef TNL_OS_MAC_OSX
 #import <Cocoa/Cocoa.h>
-// Sparkle is a client-only auto-updater; the dedicated server doesn't link it
-#ifndef ZAP_DEDICATED
+// Sparkle is a client-only auto-updater; the dedicated server doesn't link it,
+// and BF_NO_SPARKLE builds (e.g. the native arm64 client) leave it out too.
+#if !defined(ZAP_DEDICATED) && !defined(BF_NO_SPARKLE)
 #import "SUUpdater.h"
 // Here we add a GET parameter for the different OSX architectures.  This way we
 // can serve up a different download URL dynamically
@@ -26,7 +27,7 @@
       // Default to x86_64 since that is all OSX runs on these days...
 #     define SPARKLE_APPCAST_URL @"http://bitfighter.org/files/getDownloadUrl.php?platform=osxx86_64"
 #  endif
-#endif // !ZAP_DEDICATED
+#endif // !ZAP_DEDICATED && !BF_NO_SPARKLE
 #else
 #import <Foundation/Foundation.h>
 #endif
@@ -70,7 +71,7 @@ void prepareFirstLaunchMac()
 
 void checkForUpdates()
 {
-#if defined(TNL_OS_MAC_OSX) && !defined(ZAP_DEDICATED)
+#if defined(TNL_OS_MAC_OSX) && !defined(ZAP_DEDICATED) && !defined(BF_NO_SPARKLE)
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     SUUpdater* updater = [SUUpdater sharedUpdater];
     [updater setFeedURL:[NSURL URLWithString:SPARKLE_APPCAST_URL]];

--- a/zap/main.cpp
+++ b/zap/main.cpp
@@ -769,12 +769,22 @@ string getUserDataDir()
 
 void setDefaultPaths(Vector<string> &argv)
 {
+   // Remember whether the user pointed us at a data root before we add our own
+   // default below, so the read-only asset dirs can honor an explicit -rootdatadir.
+   bool userSpecifiedRootDataDir = argv.contains("-rootdatadir");
+
    // If we don't already have -rootdatadir specified on the command line
-   if(!argv.contains("-rootdatadir"))
+   if(!userSpecifiedRootDataDir)
    {
       argv.push_back("-rootdatadir");
       argv.push_back(getUserDataDir());
    }
+
+   // sfx, fonts, and shaders are read-only engine assets that are never copied
+   // into the (mutable) user data dir, so they load straight from the install
+   // dir.  sfx/fonts always do; shaders follow an explicit -rootdatadir when the
+   // user gives one (resolveDirs derives shaderDir from rootDataDir), and
+   // otherwise default to the install dir too.
 
    // Same with -sfxdir
    if(!argv.contains("-sfxdir"))
@@ -788,6 +798,13 @@ void setDefaultPaths(Vector<string> &argv)
    {
       argv.push_back("-fontsdir");
       argv.push_back(getInstalledDataDir() + getFileSeparator() + "fonts");
+   }
+
+   // And with -shaderdir, unless the user steered us with -rootdatadir
+   if(!userSpecifiedRootDataDir && !argv.contains("-shaderdir"))
+   {
+      argv.push_back("-shaderdir");
+      argv.push_back(getInstalledDataDir() + getFileSeparator() + "shaders");
    }
 
    // iOS needs the INI in an editable location
@@ -810,7 +827,7 @@ void copyResourcesToUserData()
 
    printf("Copying resources\n");
 
-   // Everything but sfx amd fonts (which are loaded from the install dir)
+   // Everything but sfx, fonts, and shaders (which are loaded from the install dir)
    Vector<string> dirArray;
    dirArray.push_back("levels");
    dirArray.push_back("robots");


### PR DESCRIPTION
> **Apple Silicon stack** — review/merge bottom-up:
> 1. #816 — dedicated server (`bitfighterd`)
> 2. **#817 — client (`Bitfighter.app`)** ← you are here
> 3. #818 — relocatable `.app` + DMG packaging

Makes the **client** (`Bitfighter.app`) build and run natively on arm64 macOS.

> **Depends on #816** (native dedicated server). Until that merges, this PR's diff also includes #816's commits; review/merge #816 first and this will narrow to just the client-specific changes. (Can't base directly on that branch since it isn't in this repo.)

## Changes
- **Resolve client deps from Homebrew on arm64** — SDL2, libpng, OpenAL (openal-soft), ogg, vorbis, vorbisfile, speex, modplug come from `/opt/homebrew` instead of the Intel-only prebuilt frameworks in `lib/`, which have no arm64 slice. x86_64/Rosetta still uses the bundled libs.
- **`USE_SPARKLE` option** (default off on arm64) — builds the client without the auto-updater (bundled Sparkle is Intel-only 1.x); defines `BF_NO_SPARKLE`.
- **Skip Intel-framework bundling on Homebrew builds** — the `.app` no longer copies/lipo-thins the Intel `lib/` frameworks; the binary links Homebrew dylibs by absolute path and runs in place.
- **Fix shader resource resolution** — `shaderDir` was derived from `rootDataDir` (the user data dir), but shaders are never copied there, so the GL driver received empty source and logged "Compiled shader was corrupt". Shaders are read-only engine assets like sfx/fonts, so default `-shaderdir` to the install dir; an explicit `-rootdatadir` still wins. (Pre-existing bug that also affected Linux/Windows.)

## Test plan
```
brew install luajit sdl2 libpng libogg libvorbis speex libmodplug openal-soft
cd build && cmake .. -DLUAJIT_BUILTIN=NO && make Bitfighter
open ../exe/Bitfighter.app
```
Verified on Apple Silicon: native `arm64` `.app`, links all Homebrew dylibs, launches with no arguments, GL2 shaders compile and render.

## Not included (follow-ups)
- **Sparkle 2.x** auto-updater migration (1.x is Intel-only and the API changed).
- A **relocatable / notarized** `.app` for distribution (e.g. via `dylibbundler`); today it links Homebrew dylibs by absolute path and runs on the build machine.
