### PR TITLE
ci: package the arm64 macOS client as a DMG artifact

### DIFF
--- a/.github/workflows/BuildPackages.yml
+++ b/.github/workflows/BuildPackages.yml
@@ -18,3 +18,19 @@ jobs:
           name: Bitfighter-Linux
           path: |
             exe/
+  Build-macOS-arm64:
+    runs-on: macos-14                 # Apple Silicon (arm64) runner
+    steps:
+      - uses: actions/checkout@v4
+      - run: brew install luajit sdl2 libpng libogg libvorbis speex libmodplug openal-soft dylibbundler
+      # -DLUAJIT_BUILTIN=NO: bundled LuaJIT 2.0.5 has no arm64; use Homebrew 2.1.
+      # -DBUNDLE_DEPENDENCIES=YES: copy Homebrew dylibs into the .app and re-point
+      # their load commands (via dylibbundler), then ad-hoc sign, producing a
+      # relocatable, distributable bundle -> DMG (see cmake/Platform/Apple.cmake).
+      - run: cd build && cmake .. -DLUAJIT_BUILTIN=NO -DBUNDLE_DEPENDENCIES=YES && make Bitfighter && make package
+      - uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Bitfighter-macOS-arm64
+          path: |
+            build/*.dmg
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

The Build Packages workflow (CD) only produced a Linux artifact, so there was no downloadable Apple Silicon build despite the native arm64 client and relocatable `.app`/DMG packaging already landing in tree. This adds a macOS arm64 job that produces a distributable DMG alongside the Linux artifact.

## Changes

- Add a `Build-macOS-arm64` job to `.github/workflows/BuildPackages.yml`, running on the `macos-14` (Apple Silicon) runner.
  - Installs Homebrew deps plus `dylibbundler`, then builds the relocatable, ad-hoc-signed client with `-DLUAJIT_BUILTIN=NO -DBUNDLE_DEPENDENCIES=YES` and packages a DMG via `make package` (see `cmake/Platform/Apple.cmake`).
  - Uploads `build/*.dmg` as the `Bitfighter-macOS-arm64` artifact, mirroring the existing Linux job's artifact-only, `upload-artifact@v4.6.2` style.
  - Sets `if-no-files-found: error` so a failed package build fails the job rather than silently uploading nothing.

## Validation

CI is green — [Build Packages run 28721569133](https://github.com/bitfighter/bitfighter/actions/runs/28721569133): the `Build-macOS-arm64` job builds the relocatable `.app`, packages it, and uploads the `Bitfighter-macOS-arm64` artifact. With `if-no-files-found: error`, a passing run confirms the DMG was actually produced.

Downloaded the artifact (`gh run download`) and verified the bundle locally on Apple Silicon:
- `Bitfighter.app/Contents/MacOS/Bitfighter` is `arm64`, ad-hoc signed (`flags=0x2(adhoc)`).
- `dylibbundler` copied all Homebrew deps (SDL2, PNG, OpenAL, modplug, ogg, speex, vorbis, LuaJIT) into `Contents/Frameworks/`, with load commands rewritten to `@executable_path/../Frameworks/` — relocatable, no `/opt/homebrew` paths.

## Notes

- The bundle is **ad-hoc signed** (no Apple Developer ID), so downloaders right-click → Open the first time; Developer ID signing + notarization would be a separate change requiring secrets.
- `cpack -G DragNDrop` can intermittently fail with `hdiutil: create failed - Resource busy` on hosted runners; if it flakes, wrap `make package` in a short retry.
- The failing **Validate Code** check on this PR is unrelated to these changes: that separate workflow's `Build-macOS-arm64` job segfaults in the test suite (`GameUserInterfaceTest.Engineer`) — a pre-existing macOS-arm64 issue. `BuildPackages.yml` runs no tests.