### PR TITLE
fix: getExecutableDir() returns the directory, not the binary path, on macOS

### DIFF
--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -1026,7 +1026,8 @@ string getExecutableDir()
    path = extractDirectory(string(buffer));
 
 #elif defined(TNL_OS_MAC_OSX) || defined(TNL_OS_IOS)
-   getExecutablePath(path);  // Directory.h
+   getExecutablePath(path);        // Directory.h -- returns the full path to the binary
+   path = extractDirectory(path);  // ...so reduce to its containing directory, as on Linux/Win32
 
 #elif defined(TNL_OS_WIN32)
    char buffer[MAX_PATH] = {0};


### PR DESCRIPTION
## Summary

On macOS, `getExecutableDir()` (`zap/stringUtils.cpp`) returned the executable's **full path** instead of its containing directory. The Linux (`/proc/self/exe`) and Win32 (`GetModuleFileName`) branches both reduce the path with `extractDirectory()`; the macOS branch did not.

`FolderManager::resolveDirs(getExecutableDir())` (`config.cpp`) then builds every executable-relative resource dir off that root, so on macOS they gained the binary name as a phantom path component — e.g. the Lua scripts dir resolved to `<exe>/bitfighter_test/scripts`. A loose executable (the test runner) therefore couldn't load its Lua helper scripts, so `LuaScriptRunner::startLua()` left the interpreter (`L`) null, cascading into segfaults across the Lua- and ghosting-dependent tests.

The shipped `Bitfighter.app` is unaffected because it resolves resources via `NSBundle` (`Contents/Resources`), not `getExecutableDir()` — which is why this only surfaced when the arm64 **test** job first ran in CI.

## Changes

- `getExecutableDir()`: on macOS/iOS, reduce the executable path to its containing directory with `extractDirectory()`, matching the Linux and Win32 branches and the function's documented contract.

## Validation

Native arm64 build (`-DLUAJIT_BUILTIN=NO`), `./bitfighter_test` on Apple Silicon:

- **Before:** suite segfaults on startup — `LuaScriptRunner::startLua()` fails (scripts not found), first crash at `LuaEnvironmentTest.sanityCheck` / `GameUserInterfaceTest.Engineer` (null-deref, `EXC_BAD_ACCESS`).
- **After:** suite runs to completion — `LuaEnvironmentTest` **8/8 pass**; **517/524** overall.

The 7 remaining failures are unrelated to path resolution (client/server ghosting on arm64 + some test-ordering pollution) and are tracked separately.