### PR TITLE
fix: hermetic HttpRequestTest.successTest (mock isWritable)

### DIFF
--- a/bitfighter_test/MockSocket.h
+++ b/bitfighter_test/MockSocket.h
@@ -19,8 +19,8 @@ using namespace std;
 /**
  * Mock class for testing low level network functions
  *
- * {connect,send,receive}Error sets the return value of the mocked function
- *
+ * {connect,send,receive}Error sets the return value of the mocked function.
+ * isWritableResult controls Socket::isWritable (HttpRequest::send waits on it).
  */
 class MockSocket : public Socket
 {
@@ -32,17 +32,22 @@ class MockSocket : public Socket
    // the data to pretend we've received
    string data;
    bool dataSent;
+   bool isWritableResult;
 
    MockSocket()
       : Socket(Address(), 0, 0, false, true),
         dataSent(false),
         connectError(NoError),
         sendError(NoError),
-        receiveError(NoError)
+        receiveError(NoError),
+        isWritableResult(true)
    { }
 
-   NetError connect(const Address &address) { return connectError; };
+   NetError connect(const Address &address) { return connectError; }
    NetError send(const U8 *data, S32 size) { return sendError; }
+
+   // Avoid the real select()-based wait (five seconds of hang on unconnected fds)
+   bool isWritable(U32 timeout = 0) { return isWritableResult; }
 
    /**
     * Copies the contents of this->data to buffer and sets bytesRead.

--- a/bitfighter_test/TestHttpRequest.cpp
+++ b/bitfighter_test/TestHttpRequest.cpp
@@ -147,8 +147,18 @@ TEST_F(HttpRequestTest, connectError)
    sock->data = "HTTP/1.1 200 OK\r\n\r\nresponse";
    sock->connectError = UnknownError;
    EXPECT_FALSE(req.send());
+   EXPECT_EQ("Connect error", req.getError());
 }
 
+
+TEST_F(HttpRequestTest, notWritable)
+{
+   plantMocks();
+   sock->data = "HTTP/1.1 200 OK\r\n\r\nresponse";
+   sock->isWritableResult = false;
+   EXPECT_FALSE(req.send());
+   EXPECT_EQ("Socket not writable", req.getError());
+}
 
 
 TEST_F(HttpRequestTest, sendError)
@@ -157,6 +167,7 @@ TEST_F(HttpRequestTest, sendError)
    sock->data = "HTTP/1.1 200 OK\r\n\r\nresponse";
    sock->sendError = UnknownError;
    EXPECT_FALSE(req.send());
+   EXPECT_EQ("Can't send request", req.getError());
 }
 
 
@@ -166,6 +177,7 @@ TEST_F(HttpRequestTest, receiveFail)
    sock->data = "HTTP/1.1 200 OK\r\n\r\nresponse";
    sock->receiveError = UnknownError;
    EXPECT_FALSE(req.send());
+   EXPECT_EQ("No response", req.getError());
 }
 
 
@@ -173,7 +185,9 @@ TEST_F(HttpRequestTest, successTest)
 {
    plantMocks();
    sock->data = "HTTP/1.1 200 OK\r\n\r\nresponse";
-   EXPECT_TRUE(req.send());
+   ASSERT_TRUE(req.send()) << req.getError();
+   EXPECT_EQ(200, req.getResponseCode());
+   EXPECT_EQ("response", req.getResponseBody());
 }
 
 };

--- a/tnl/tnlUDP.h
+++ b/tnl/tnlUDP.h
@@ -188,7 +188,8 @@ public:
    virtual NetError recv(U8 *buffer, S32 bufferSize, S32 *bytesRead);
    virtual NetError send(const U8 *buffer, S32 bufferSize);
 
-   bool isWritable(U32 timeout = 0);
+   /// Must be virtual so test mocks can override without a real connect/select.
+   virtual bool isWritable(U32 timeout = 0);
 };
 
 //inline void read(BitStream &s, IPAddress *val)


### PR DESCRIPTION
## Summary

`HttpRequestTest.successTest` failed on arm64 CI (and locally in isolation) after a ~5s hang. `HttpRequest::send()` waits on `Socket::isWritable(FIVE_SECONDS)`; `MockSocket` never overrode that path, and `isWritable` was non-virtual, so mocks used a real unconnected `select()` that always timed out.

## Changes

- Make `Socket::isWritable` virtual (`tnl/tnlUDP.h`)
- `MockSocket`: default `isWritableResult = true` (no real select)
- Strengthen HttpRequest tests: assert error strings for connect/send/receive/not-writable; assert status/body on success

## Validation

- `./bitfighter_test --gtest_filter='HttpRequestTest.*'` — 16/16 pass (~0.4s; was ~15s with timeouts)

Closes #823