### PR TITLE
fix: getExecutableDir directory on macOS (unblocks LuaEnvironment CI)

### DIFF
--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -1070,4 +1070,26 @@ TEST(StringUtilsTest, s_fprintfTruncationBug)
    remove(testFile.c_str());
 }
 
+
+// Regression for #820/#824: getExecutableDir must be a directory, not the
+// binary path. On macOS it used to return .../bitfighter_test, so luaDir became
+// .../bitfighter_test/scripts and LuaScriptRunner::startLua failed (L=null).
+TEST(StringUtilsTest, getExecutableDirIsContainingDirectory)
+{
+   string dir = getExecutableDir();
+   ASSERT_FALSE(dir.empty());
+
+   // Must not end with the test binary name (the old macOS bug)
+   string base = dir;
+   string::size_type slash = base.find_last_of("/\\");
+   if(slash != string::npos)
+      base = base.substr(slash + 1);
+   EXPECT_NE("bitfighter_test", base)
+         << "getExecutableDir() returned the binary path, not its parent: " << dir;
+
+   // Loose test runner is always launched from exe/ with scripts/ beside it
+   EXPECT_TRUE(fileExists(joindir(dir, "scripts")))
+         << "Expected scripts/ next to getExecutableDir() (" << dir << ")";
+}
+
 };

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -1026,7 +1026,8 @@ string getExecutableDir()
    path = extractDirectory(string(buffer));
 
 #elif defined(TNL_OS_MAC_OSX) || defined(TNL_OS_IOS)
-   getExecutablePath(path);  // Directory.h
+   getExecutablePath(path);        // Directory.h -- returns the full path to the binary
+   path = extractDirectory(path);  // ...so reduce to its containing directory, as on Linux/Win32
 
 #elif defined(TNL_OS_WIN32)
    char buffer[MAX_PATH] = {0};


### PR DESCRIPTION
## Summary

On macOS, `getExecutableDir()` returned the **binary path**, while Linux/Win32 return the containing directory. `FolderManager` then set `luaDir` to e.g. `exe/bitfighter_test/scripts`, so `LuaScriptRunner::startLua` could not load helpers and left `L == null`. That is the root cause of #824 (`prepareEnvironment` fails) and the existing open #820.

## Changes

- `zap/stringUtils.cpp`: after `getExecutablePath()`, call `extractDirectory()` (same as Linux/Win32) — cherry-pick of the #820 fix
- `StringUtilsTest.getExecutableDirIsContainingDirectory`: regression (dir must not end with the test binary; `scripts/` must resolve beside it)

## Validation

- `./bitfighter_test --gtest_filter='LuaEnvironmentTest.*:StringUtilsTest.getExecutableDirIsContainingDirectory'` — 9/9 pass

## Related

- Closes #824
- Closes #820 (same fix; this PR adds a regression test)
- Stacking note: independent of #822 / #826; should land early — other arm64 suite issues assume a working Lua dir