### PR TITLE
Surface level performance optimizations

### DIFF
--- a/bitfighter_test/BitfighterTestEnvironment.cpp
+++ b/bitfighter_test/BitfighterTestEnvironment.cpp
@@ -21,7 +21,7 @@ bool checkResources()
 {
     const string dirs[] = { "editor_plugins", "fonts", "levels", "music", "robots", "scripts", "sfx", "testing" };
 
-    for(S32 i = 0; i < ARRAYSIZE(dirs); i++)
+    for(S32 i = 0; i < ARRAYSIZE(dirs); ++i)
         if(!fileExists(dirs[i]))
             return false;
 

--- a/bitfighter_test/LevelFilesForTesting.cpp
+++ b/bitfighter_test/LevelFilesForTesting.cpp
@@ -68,7 +68,7 @@ string getLevelCodeForEmptyLevelWithBots(const string &botSpec)
       "LevelDescription\n"
       "LevelCredits Tyler Derden\n";
 
-   for(S32 i = 0; i < teams; i++)
+   for(S32 i = 0; i < teams; ++i)
    {
       level += "Team team" + itos(i) + " 0 0 0\n";
    }
@@ -78,9 +78,9 @@ string getLevelCodeForEmptyLevelWithBots(const string &botSpec)
       "MinPlayers\n"
       "MaxPlayers\n";
 
-   for(S32 i = 0; i < teams; i++)
+   for(S32 i = 0; i < teams; ++i)
       if(words[i] != "0")
-         for(S32 j = 0; j < words[i].size(); j++)
+         for(S32 j = 0; j < words[i].size(); ++j)
             level += "Robot " + itos(i) + " s_bot\n";
 
    return level;

--- a/bitfighter_test/TestChatHelper.cpp
+++ b/bitfighter_test/TestChatHelper.cpp
@@ -53,7 +53,7 @@ static ChatHelper *enterCommandChat(GameUserInterface *gameUI)
 static void clearChat(ChatHelper *chatHelper)
 {
    S32 len = (S32)strlen(chatHelper->getChatMessage());
-   for(S32 i = 0; i < len; i++)
+   for(S32 i = 0; i < len; ++i)
       chatHelper->processInputCode(KEY_BACKSPACE);
 }
 

--- a/bitfighter_test/TestFileLogging.cpp
+++ b/bitfighter_test/TestFileLogging.cpp
@@ -323,7 +323,8 @@ TEST_F(FileLoggingTest, BothLoggingPathsHaveTimestamps)
       if (!line.empty())
       {
          EXPECT_TRUE(lineContainsTimestamp(line)) << "Line " << (lineCount + 1) << " missing timestamp: " << line;
-         lineCount++;
+         ++lineCount;
+
       }
    }
 

--- a/bitfighter_test/TestGameUserInterface.cpp
+++ b/bitfighter_test/TestGameUserInterface.cpp
@@ -38,7 +38,7 @@ TEST(GameUserInterfaceTest, Engineer)
    ASSERT_NE(nullptr, serverGame->getGameType());
    ASSERT_TRUE(serverGame->getGameType()->isEngineerEnabled());
 
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       SCOPED_TRACE("i = " + itos(i));
       // Null-safe: a missing GameType means ghosting failed (see issue #821)
@@ -60,7 +60,7 @@ TEST(GameUserInterfaceTest, Engineer)
    // On this level, the ship spawn is inside a loadout zone, so loadout should take effect immediately
    GamePair::idle(10, 5);
    ASSERT_EQ("Engineer,Repair,Phaser,Bouncer,Triple", serverGame->getClientInfo(0)->getShip()->getLoadoutString());
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       SCOPED_TRACE("i = " + itos(i));
       ASSERT_EQ("Engineer,Repair,Phaser,Bouncer,Triple", clientGames->get(0)->getLocalPlayerShip()->getLoadoutString());
@@ -74,7 +74,7 @@ TEST(GameUserInterfaceTest, Engineer)
    Event::onEvent(clientGame, &EventDownReleased);
    Point endPos = clientGame->getLocalPlayerShip()->getActualPos();
    ASSERT_TRUE(startPos.distSquared(endPos) > 0) << "Ship did not move!!";
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       SCOPED_TRACE("i = " + itos(i));
       ASSERT_TRUE(clientGames->get(0)->getLocalPlayerShip()->isCarryingItem(ResourceItemTypeNumber));
@@ -91,7 +91,7 @@ TEST(GameUserInterfaceTest, Engineer)
    gameUI->onKeyDown(KEY_MOD1);     // Place exit
    GamePair::idle(100, 5);           // Let things mellow
 
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       SCOPED_TRACE("i = " + itos(i));
       Vector<DatabaseObject *> fillVector;

--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -21,9 +21,9 @@ using namespace TNL;
 void parsePoly(const char* lines[], S32 size, Vector<Point> &result)
 {
 	map<char, Point> points;
-	for(S32 i = 0; i < size; i++)
+	for(S32 i = 0; i < size; ++i)
 	{
-		for(S32 j = 0; lines[i][j] != '\0'; j++)
+		for(S32 j = 0; lines[i][j] != '\0'; ++j)
 		{
 			char c = lines[i][j];
 
@@ -37,7 +37,7 @@ void parsePoly(const char* lines[], S32 size, Vector<Point> &result)
 	}
 
 	// maps are sorted by key on insertion
-	for(map<char, Point>::iterator it = points.begin(); it != points.end(); it++)
+	for(map<char, Point>::iterator it = points.begin(); it != points.end(); ++it)
 	{
 		result.push_back((*it).second);
 	}
@@ -97,7 +97,7 @@ TEST(GeomUtilsTest, splitRepeatedlySelfIntersecting)
 	splitSelfIntersectingPolys(polys, result);
 
 	ASSERT_EQ(5, result.size());
-	for(S32 i = 0; i < result.size(); i++)
+	for(S32 i = 0; i < result.size(); ++i)
 	{
 		EXPECT_EQ(4, result[i].size());
 	}
@@ -388,7 +388,7 @@ TEST(GeomUtilsTest, triangulateLongPolygon)
 TEST(GeomUtilsTest, triangulateManyPolygons)
 {
 	Vector<Vector<Point> > polys;
-	for(S32 i = 0; i < 512; i++)
+	for(S32 i = 0; i < 512; ++i)
 	{
 		Vector<Point> poly = createPolygon(Point(i * 120, i * 120), 100, 4, 0);
 		polys.push_back(poly);
@@ -1286,7 +1286,7 @@ TEST(GeomUtilsTest, createPolygonSquare)
    Vector<Point> poly = createPolygon(Point(0, 0), 1.0f, 4, FloatPi / 4.0f);
    ASSERT_EQ(4, poly.size());
    // Each vertex should be at distance 1 from origin
-   for(S32 i = 0; i < poly.size(); i++)
+   for(S32 i = 0; i < poly.size(); ++i)
       EXPECT_NEAR(1.0f, poly[i].len(), 0.001f);
 }
 
@@ -1295,7 +1295,7 @@ TEST(GeomUtilsTest, createPolygonCentered)
    // Polygon centered at (5, 5)
    Vector<Point> poly = createPolygon(Point(5, 5), 3.0f, 6, 0);
    ASSERT_EQ(6, poly.size());
-   for(S32 i = 0; i < poly.size(); i++)
+   for(S32 i = 0; i < poly.size(); ++i)
       EXPECT_NEAR(3.0f, poly[i].distanceTo(Point(5, 5)), 0.001f);
 }
 
@@ -1310,7 +1310,7 @@ TEST(GeomUtilsTest, calcPolygonVerts)
    Vector<Point> pts;
    calcPolygonVerts(Point(0, 0), 8, 5.0f, 0, pts);
    ASSERT_EQ(8, pts.size());
-   for(S32 i = 0; i < pts.size(); i++)
+   for(S32 i = 0; i < pts.size(); ++i)
       EXPECT_NEAR(5.0f, pts[i].len(), 0.001f);
 }
 
@@ -1561,7 +1561,7 @@ TEST(GeomUtilsTest, expandCenterlineToOutlineHorizontal)
    ASSERT_EQ(4, corners.size());
    // Width is 4, so cross-vec is ±2 in y direction
    // All x should be 0 or 10
-   for(S32 i = 0; i < corners.size(); i++)
+   for(S32 i = 0; i < corners.size(); ++i)
    {
       EXPECT_NEAR(2.0f, fabs(corners[i].y), 0.001f);
       EXPECT_TRUE(corners[i].x == 0.0f || corners[i].x == 10.0f);
@@ -1573,7 +1573,7 @@ TEST(GeomUtilsTest, expandCenterlineToOutlineVertical)
    Vector<Point> corners;
    expandCenterlineToOutline(Point(5, 0), Point(5, 10), 4.0f, corners);
    ASSERT_EQ(4, corners.size());
-   for(S32 i = 0; i < corners.size(); i++)
+   for(S32 i = 0; i < corners.size(); ++i)
    {
       EXPECT_NEAR(2.0f, fabs(corners[i].x - 5.0f), 0.001f);
       EXPECT_TRUE(corners[i].y == 0.0f || corners[i].y == 10.0f);

--- a/bitfighter_test/TestIntegration.cpp
+++ b/bitfighter_test/TestIntegration.cpp
@@ -38,7 +38,7 @@ void checkTeleporter(Game *game, const string &geomString, S32 expectedDests)
    ASSERT_EQ(expectedDests, teleporter->getDestCount())  << "Wrong number of destinations";
 
    string actualGeomString = teleporter->getOrigin().toString();
-   for(S32 i = 0; i < teleporter->getDestCount(); i++)
+   for(S32 i = 0; i < teleporter->getDestCount(); ++i)
       actualGeomString +=  joiner + teleporter->getDest(i).toString();
    EXPECT_EQ(geomString, actualGeomString);
    EXPECT_FALSE(teleporter->isEngineered());
@@ -60,7 +60,7 @@ void checkTeleporter(Teleporter *teleporter, Point *pts, S32 pointCount)
    Vector<Point> geom(pts, pointCount);
 
    string str = geom[0].toString();
-   for(S32 i = 1; i < geom.size(); i++)
+   for(S32 i = 1; i < geom.size(); ++i)
       str += joiner + geom[i].toString();
 
    teleporter->doSetGeom(geom);     // When a levelgen changes the geometry, this fn gets called
@@ -72,7 +72,7 @@ void checkTeleporter(Teleporter *teleporter, Point *pts, S32 pointCount)
    }
 
    const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       SCOPED_TRACE("Testing CLIENT game " + itos(i));
       checkTeleporter((Game *) clientGames->get(i), str, pointCount - 1);
@@ -95,7 +95,7 @@ TEST(IntegrationTest, LevelReadingAndItemPropagation)
 
    // Test level item propagation
    // TestItem (placed @ 1,1)
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       SCOPED_TRACE("i = " + itos(i));
       ClientGame *clientGame = clientGames->get(i);
@@ -169,7 +169,7 @@ TEST(IntegrationTest, LevelReadingAndItemPropagation)
          checkTeleporter(serverGame, "30, 50 | 2550, 2550", 1);
       }
 
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
       {
          SCOPED_TRACE("1 ClientGame, after origin move #" + itos(i));
          checkTeleporter(clientGames->get(i), "30, 50 | 2550, 2550", 1);
@@ -200,7 +200,7 @@ TEST(IntegrationTest, LevelReadingAndItemPropagation)
          checkTeleporter(serverGame, "80, 85 | 180, 300 | 50, 60", 2);
       }
 
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
       {
          SCOPED_TRACE("4 ClientGame, after origin move with 2 dests #" + itos(i));
          checkTeleporter(clientGames->get(i), "80, 85 | 180, 300 | 50, 60", 2);
@@ -222,7 +222,7 @@ TEST(IntegrationTest, LevelReadingAndItemPropagation)
          SCOPED_TRACE("addDest() test - ServerGame");
          checkTeleporter(serverGame, "345, 555 | 612, 123 | 19, 99", 2);
       }
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
       {
          SCOPED_TRACE("addDest() test - ClientGame #" + itos(i));
          checkTeleporter(clientGames->get(i), "345, 555 | 612, 123 | 19, 99", 2);
@@ -238,7 +238,7 @@ TEST(IntegrationTest, LevelReadingAndItemPropagation)
          SCOPED_TRACE("delDest() test - ServerGame");
          checkTeleporter(serverGame, "345, 555 | 19, 99", 1);
       }
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
       {
          SCOPED_TRACE("delDest() test - ClientGame #" + itos(i));
          checkTeleporter(clientGames->get(i), "345, 555 | 19, 99", 1);
@@ -254,7 +254,7 @@ TEST(IntegrationTest, LevelReadingAndItemPropagation)
          SCOPED_TRACE("clearDests() test - ServerGame");
          checkTeleporter(serverGame, "345, 555", 0);
       }
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
       {
          // Will be rendered in-game, will not teleport you anywhere... FYI
          SCOPED_TRACE("clearDests() test - ClientGame #" + itos(i));
@@ -264,7 +264,7 @@ TEST(IntegrationTest, LevelReadingAndItemPropagation)
 
    /////
    // Test metadata propagation
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       ClientGame *clientGame = clientGames->get(i);
       SCOPED_TRACE("metadata propagation i = " + itos(i));

--- a/bitfighter_test/TestLevelLoader.cpp
+++ b/bitfighter_test/TestLevelLoader.cpp
@@ -34,7 +34,7 @@ TEST_F(LevelLoaderTest, longLine)
 
    Vector<Point> geom;
    geom.resize(TEST_POINTS);     // Preallocate for speed
-   for(U32 i = 0; i < TEST_POINTS; i++)
+   for(U32 i = 0; i < TEST_POINTS; ++i)
       geom[i].set(i, i % 2);
 
    WallItem wall;

--- a/bitfighter_test/TestLoadoutTracker.cpp
+++ b/bitfighter_test/TestLoadoutTracker.cpp
@@ -55,7 +55,7 @@ TEST_F(LoadoutTrackerTest, ToVector)
 
    Vector<U8> outItems = rubric.toU8Vector();
    ASSERT_EQ(outItems.size(), ShipModuleCount + ShipWeaponCount);
-   for(S32 i = 0; i < outItems.size(); i++)
+   for(S32 i = 0; i < outItems.size(); ++i)
       ASSERT_EQ(outItems[i], items[i]);
 }
 

--- a/bitfighter_test/TestLuaEnvironment.cpp
+++ b/bitfighter_test/TestLuaEnvironment.cpp
@@ -188,7 +188,7 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
    ASSERT_TRUE(bot->runString("function onMsgReceived(msg, player, isGlobal) message = msg end"));
    ASSERT_TRUE(bot->runString("bf:subscribe(Event.MsgReceived)"));
 
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
 
    ASSERT_TRUE(levelgen->runString("levelgen:globalMsg('Test sending global message')"));
 
@@ -204,7 +204,7 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
    ASSERT_TRUE(bot->runString("function onDataReceived(data) message = data.msg; int = data.int; end"));
    ASSERT_TRUE(bot->runString("bot:subscribe(Event.DataReceived)"));
 
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
 
    ASSERT_TRUE(levelgen->runString("levelgen:sendData({msg='Message in a table', int=765})"));
 
@@ -217,7 +217,7 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
    // Sending multiple values
    ASSERT_TRUE(bot->runString("function onDataReceived(param1, param2, param3) p1 = param1; p2 = param2; p3 = param3; end"));
 
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
 
    ASSERT_TRUE(levelgen->runString("bf:sendData(100, 'two hundred', true)"));
 
@@ -232,7 +232,7 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
    ASSERT_TRUE(levelgen->runString("function onDataReceived(a, b, c) ct = ct + 1; aaa = a; bbb=b; ccc= c; end;   ct = 0"));
    ASSERT_TRUE(levelgen->runString("levelgen:subscribe(Event.DataReceived)"));
 
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
 
    ASSERT_TRUE(bot->runString("bot:sendData(1, 2, 4)"));
 
@@ -253,12 +253,12 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
    bot2->prepareEnvironment();
    serverGame->addBot(bot2);
    
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
 
    ASSERT_TRUE(bot2->runString("function onDataReceived(param1, param2, param3) pp1 = param1; pp2 = param2; pp3 = param3; end"));
    ASSERT_TRUE(bot2->runString("bf:subscribe(Event.DataReceived)"));    // We used bot:subscribe for other bot; both should work
 
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
 
    ASSERT_TRUE(bot->runString("bot:sendData(11, 12, 13)"));
 
@@ -278,10 +278,10 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
    ASSERT_TRUE(bot->runString("function onDataReceived(p1, p2, p3) x = p1[1] end"));   // <- script contains crashing bug
    // When the above gets run, it will trigger bot death as the code has an exception
 
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
    ASSERT_TRUE(levelgen->runString("bf:sendData(5, 6, 7)"));
 
-   //for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate to give dead bot time to delete itself
+   //for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate to give dead bot time to delete itself
 
    // We want bot2 to get the data even if bot crashed handling the event
    EXPECT_EQ(5, bot2->getLuaGlobalVar<S32>("pp1"));
@@ -294,7 +294,7 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
    serverGame->addBot(bot);
    ASSERT_TRUE(bot->runString("function onDataReceived(param1, param2, param3) p1 = param1; p2 = param2; p3 = param3; end"));
    ASSERT_TRUE(bot->runString("bot:subscribe(Event.DataReceived)"));
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);   // Marinate
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);   // Marinate
 
 
    ///// Shared table functionality
@@ -365,7 +365,7 @@ TEST_F(LuaEnvironmentTest, scriptCommunication)
 
    ASSERT_TRUE(levelgen->runString("bf:sendData('a', 'b', 'c')"));
 
-   for(U32 i = 0; i < 10; i++) serverGame->idle(10);      // Marinate to give dead bot time to delete itself
+   for(U32 i = 0; i < 10; ++i) serverGame->idle(10);      // Marinate to give dead bot time to delete itself
 
    // We want bot to get the data even if bot2 crashed handling the event
    EXPECT_EQ("a", bot->getLuaGlobalVar<string>("p1"));

--- a/bitfighter_test/TestMapTiling.cpp
+++ b/bitfighter_test/TestMapTiling.cpp
@@ -60,9 +60,11 @@ static F32 wallPolyArea(const WallPoly &wp)
 static F32 totalTiledArea(const Vector<MapTile> &tiles)
 {
    F32 total = 0;
-   for (S32 t = 0; t < tiles.size(); ++t)
-      for (S32 p = 0; p < tiles[t].polys.size(); ++p)
+   for (S32 t = 0; t < tiles.size(); ++t) {
+      S32 polys_sz = tiles[t].polys.size();
+      for (S32 p = 0; p < polys_sz; ++p)
          total += wallPolyArea(tiles[t].polys[p]);
+   }
    return total;
 }
 
@@ -72,11 +74,15 @@ static F32 totalTiledArea(const Vector<MapTile> &tiles)
 static S32 countClipIntroducedEdges(const Vector<MapTile> &tiles)
 {
    S32 count = 0;
-   for (S32 t = 0; t < tiles.size(); ++t)
-      for (S32 p = 0; p < tiles[t].polys.size(); ++p)
-         for (S32 e = 0; e < tiles[t].polys[p].edges.size(); ++e)
+   for (S32 t = 0; t < tiles.size(); ++t) {
+      S32 polys_sz = tiles[t].polys.size();
+      for (S32 p = 0; p < polys_sz; ++p) {
+         S32 edges_sz = tiles[t].polys[p].edges.size();
+         for (S32 e = 0; e < edges_sz; ++e)
             if (tiles[t].polys[p].edges[e] == EdgeStyle::None)
                ++count;
+      }
+   }
 
    return count;
 }
@@ -221,7 +227,8 @@ static void buildEdgeIdMaps(
 
    for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
+      S32 polys_sz = tiles[t].polys.size();
+      for(S32 p = 0; p < polys_sz; ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
@@ -674,7 +681,8 @@ TEST(WallTilingTest, WallEdgeAlignedToComputedTileBoundary)
 
    for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
+      S32 polys_sz = tiles[t].polys.size();
+      for(S32 p = 0; p < polys_sz; ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
@@ -1684,7 +1692,8 @@ TEST(WallTilingTest, MadMaze2ThreeWalls)
       for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
-         for(U32 e = 0; e < wp.edges.size(); ++e)
+         U32 edges_sz = wp.edges.size();
+         for(U32 e = 0; e < edges_sz; ++e)
          {
             if(wp.edges[e] == EdgeStyle::Normal) hasSolid = true;
             if(wp.edges[e] == EdgeStyle::Destructible) hasDashed = true;
@@ -1747,7 +1756,8 @@ TEST(WallTilingTest, MadMaze2DiagDest)
    // Diagnostic: show which None edges are not on tile boundary
    for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
+      S32 polys_sz = tiles[t].polys.size();
+      for(S32 p = 0; p < polys_sz; ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
@@ -1776,7 +1786,8 @@ TEST(WallTilingTest, MadMaze2DiagDest)
       for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
-         for(U32 e = 0; e < wp.edges.size(); ++e)
+         U32 edges_sz = wp.edges.size();
+         for(U32 e = 0; e < edges_sz; ++e)
          {
             if(wp.edges[e] == EdgeStyle::Normal) hasSolid = true;
             if(wp.edges[e] == EdgeStyle::Destructible) hasDashed = true;
@@ -2191,7 +2202,8 @@ TEST(WallTilingTest, PavillionBackwardsLInteriorEdges)
 
    for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
+      S32 polys_sz = tiles[t].polys.size();
+      for(S32 p = 0; p < polys_sz; ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
@@ -2405,7 +2417,8 @@ TEST(WallTilingTest, PavillionDestructibleLeftEdgeBelowHorizontalArmIsRendered)
 
    for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
+      S32 polys_sz = tiles[t].polys.size();
+      for(S32 p = 0; p < polys_sz; ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();

--- a/bitfighter_test/TestMapTiling.cpp
+++ b/bitfighter_test/TestMapTiling.cpp
@@ -76,7 +76,8 @@ static S32 countClipIntroducedEdges(const Vector<MapTile> &tiles)
       for (S32 p = 0; p < tiles[t].polys.size(); ++p)
          for (S32 e = 0; e < tiles[t].polys[p].edges.size(); ++e)
             if (tiles[t].polys[p].edges[e] == EdgeStyle::None)
-               count++;
+               ++count;
+
    return count;
 }
 
@@ -94,7 +95,7 @@ static bool clientHasCollidedProjectile(ClientGame *client)
    Vector<DatabaseObject *> projectiles;
    client->getGameObjDatabase()->findObjects((TestFunc)isProjectileType, projectiles);
 
-   for(S32 i = 0; i < projectiles.size(); i++)
+   for(S32 i = 0; i < projectiles.size(); ++i)
    {
       Projectile *projectile = dynamic_cast<Projectile *>(projectiles[i]);
 
@@ -218,14 +219,14 @@ static void buildEdgeIdMaps(
    // Temporary parallel: map from key to style (only used for visible edges)
    map<EdgeKey, EdgeStyle> keyStyle;
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
 
-      for(U32 e = 0; e < nv; e++)
+      for(U32 e = 0; e < nv; ++e)
          {
             // Include ALL edges (including EdgeStyle::None) so the ID
             // numbering matches the in-game /showedgeids display.
@@ -246,7 +247,8 @@ static void buildEdgeIdMaps(
       keyToId[key] = nextId;
       idToKey[nextId] = key;
       idToStyle[nextId] = keyStyle[key];
-      nextId++;
+      ++nextId;
+
    }
 }
 
@@ -309,7 +311,7 @@ static ExpectedEdges makeExpectedEdges(const std::string &spec)
       {
          const int lo = atoi(token.substr(0, dash).c_str());
          const int hi = atoi(token.substr(dash + 1).c_str());
-         for(int id = lo; id <= hi; id++)
+         for(int id = lo; id <= hi; ++id)
             result[id] = current;
       }
    }
@@ -379,7 +381,8 @@ static void verifyTileEdges(
             << " but edge was not found in tiled output. "
             << "The edge set may have changed — re-run dumpTileEdges to "
             << "get the current edge IDs.";
-         mismatches++;
+         ++mismatches;
+
          continue;
       }
 
@@ -395,7 +398,8 @@ static void verifyTileEdges(
             << key.x2 << "," << key.y2 << ")): "
             << "expected " << edgeStyleName(expectedStyle)
             << " but got " << edgeStyleName(actualStyle);
-         mismatches++;
+         ++mismatches;
+
       }
    }
 
@@ -575,15 +579,15 @@ TEST(WallTilingTest, WallEdgeAlignedToTileBoundary)
     // Find tile 0 (gridX=0). The wall portion in tile 0 should have
     // the right edge (x=256), which was an original wall edge — NOT None.
     bool foundTile0 = false;
-    for(S32 t = 0; t < tiles.size(); t++)
+    for(S32 t = 0; t < tiles.size(); ++t)
     {
        if(tiles[t].tileId == 0)
        {
           foundTile0 = true;
-          for(S32 p = 0; p < tiles[t].polys.size(); p++)
+          for(S32 p = 0; p < tiles[t].polys.size(); ++p)
           {
              const WallPoly &wp = tiles[t].polys[p];
-             for(U32 e = 0; e < wp.edges.size(); e++)
+             for(U32 e = 0; e < wp.edges.size(); ++e)
              {
                 // Get the two endpoints of this edge
                 U32 v0 = e * 2;
@@ -649,13 +653,13 @@ TEST(WallTilingTest, WallEdgeAlignedToComputedTileBoundary)
    // The tile grid must match the design: tile width 200 and origin -35,
    // so the column-2/column-3 boundary is at -35 + 2*200 = 365.
    F32 tileOrigin = F32_MAX;
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
       if(tiles[t].bounds.min.x < tileOrigin)
          tileOrigin = tiles[t].bounds.min.x;
    EXPECT_NEAR(-35.0f, tileOrigin, 0.1f);
 
    bool sawTileWidth200 = false;
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
       F32 w = tiles[t].bounds.getWidth();
       if(std::abs(w - 200.0f) < 0.1f)
@@ -668,13 +672,13 @@ TEST(WallTilingTest, WallEdgeAlignedToComputedTileBoundary)
 
    bool foundAlignedEdge = false;
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
-         for(U32 e = 0; e < nv; e++)
+         for(U32 e = 0; e < nv; ++e)
          {
             U32 v0 = e * 2;
             U32 v1 = ((e + 1) % nv) * 2;
@@ -730,13 +734,13 @@ TEST(WallTilingTest, WallEdgeOnTileBoundaryNotSuppressed)
 
     // Every edge on x=256 should be Normal (not None)
     bool foundBoundaryEdge = false;
-    for(S32 t = 0; t < tiles.size(); t++)
+    for(S32 t = 0; t < tiles.size(); ++t)
     {
        if(tiles[t].tileId != 0) continue;
-       for(S32 p = 0; p < tiles[t].polys.size(); p++)
+       for(S32 p = 0; p < tiles[t].polys.size(); ++p)
        {
           const WallPoly &wp = tiles[t].polys[p];
-          for(U32 e = 0; e < wp.edges.size(); e++)
+          for(U32 e = 0; e < wp.edges.size(); ++e)
           {
              U32 v0 = e * 2;
              U32 v1 = ((e + 1) % wp.numVerts()) * 2;
@@ -1047,7 +1051,7 @@ TEST(WallTilingTest, WallExactlyFillingTile)
    // Should have at least 1 tile; find the one with content (tile 0)
    ASSERT_GE(tiles.size(), 1);
    bool foundTile0 = false;
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
       if(tiles[t].tileId == 0 && tiles[t].polys.size() > 0)
       {
          foundTile0 = true;
@@ -1097,10 +1101,10 @@ TEST(WallTilingTest, TileDeliveryWorldExtents)
    Vector<Vector<Point> > allWalls;
    allWalls.push_back(wall1);
    allWalls.push_back(wall2);
-   for(S32 w = 0; w < allWalls.size(); w++)
+   for(S32 w = 0; w < allWalls.size(); ++w)
    {
       const Vector<Point> &poly = allWalls[w];
-      for(S32 v = 0; v < poly.size(); v++)
+      for(S32 v = 0; v < poly.size(); ++v)
       {
          if(poly[v].x < expectedExtents.min.x) expectedExtents.min.x = poly[v].x;
          if(poly[v].y < expectedExtents.min.y) expectedExtents.min.y = poly[v].y;
@@ -1120,10 +1124,10 @@ TEST(WallTilingTest, TileDeliveryWorldExtents)
    clientExtents.min.set(F32_MAX,  F32_MAX);
    clientExtents.max.set(-F32_MAX, -F32_MAX);
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
       const MapTile &tile = tiles[t];
-      for(S32 p = 0; p < tile.polys.size(); p++)
+      for(S32 p = 0; p < tile.polys.size(); ++p)
       {
          const WallPoly &wp = tile.polys[p];
          for(U32 v = 0; v < wp.verts.size(); v += 2)
@@ -1183,10 +1187,10 @@ TEST(WallTilingTest, WorldExtentsSurvivesPerFrameRecompute)
    tileExtents.min.set(F32_MAX,  F32_MAX);
    tileExtents.max.set(-F32_MAX, -F32_MAX);
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
       const MapTile &tile = tiles[t];
-      for(S32 p = 0; p < tile.polys.size(); p++)
+      for(S32 p = 0; p < tile.polys.size(); ++p)
       {
          const WallPoly &wp = tile.polys[p];
          for(U32 v = 0; v < wp.verts.size(); v += 2)
@@ -1271,7 +1275,7 @@ TEST(WallTilingTest, RebuildTilesAfterAddingWall)
    EXPECT_GT(initialTileCount, 0);
 
    S32 initialPolyCount = 0;
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
       initialPolyCount += tiles[t].polys.size();
    EXPECT_GT(initialPolyCount, 0);
 
@@ -1290,7 +1294,7 @@ TEST(WallTilingTest, RebuildTilesAfterAddingWall)
    // Verify tiles now include the new wall
    tiles = serverGT->getMapTiles();
    S32 newPolyCount = 0;
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
       newPolyCount += tiles[t].polys.size();
 
    EXPECT_GT(newPolyCount, initialPolyCount)
@@ -1356,7 +1360,7 @@ TEST(WallTilingTest, WallAddedOnServerPropagatesToClient)
    // Verify server now has more tile polys
    S32 serverNewPolyCount = 0;
    const Vector<MapTile> &newTiles = serverGT->getMapTiles();
-   for(S32 t = 0; t < newTiles.size(); t++)
+   for(S32 t = 0; t < newTiles.size(); ++t)
       serverNewPolyCount += newTiles[t].polys.size();
 
    // Idle to let the updated tiles propagate to the client
@@ -1412,7 +1416,7 @@ TEST(WallTilingTest, ClientProjectileHitsTileWallWithoutCrash)
    gameUI->onKeyUp(fireKey);
 
    bool sawProjectile = false;
-   for(S32 i = 0; i < 15; i++)
+   for(S32 i = 0; i < 15; ++i)
    {
       GamePair::idle(20, 1);
       if(countClientProjectiles(client) > 0)
@@ -1426,7 +1430,7 @@ TEST(WallTilingTest, ClientProjectileHitsTileWallWithoutCrash)
       << "Client should receive a projectile ghost after firing.";
 
    bool sawCollidedProjectile = false;
-   for(S32 i = 0; i < 40; i++)
+   for(S32 i = 0; i < 40; ++i)
    {
       GamePair::idle(20, 1);
       if(clientHasCollidedProjectile(client))
@@ -1492,10 +1496,11 @@ TEST(WallTilingTest, ShipDestroysDestructibleWall)
    auto countDestEdges = []() -> S32 {
       S32 count = 0;
       const auto &polys = GameType::getTilePolys();
-      for(S32 i = 0; i < polys.size(); i++)
-         for(S32 e = 0; e < polys[i].edges.size(); e++)
+      for(S32 i = 0; i < polys.size(); ++i)
+         for(S32 e = 0; e < polys[i].edges.size(); ++e)
             if(polys[i].edges[e] == EdgeStyle::Destructible)
-               count++;
+               ++count;
+
       return count;
    };
 
@@ -1517,7 +1522,7 @@ TEST(WallTilingTest, ShipDestroysDestructibleWall)
    gameUI->onKeyUp(fireKey);
 
    // Track the projectile step by step
-   for(S32 step = 0; step < 10; step++)
+   for(S32 step = 0; step < 10; ++step)
    {
       Vector<DatabaseObject *> projs;
       gamePair.server->getGameObjDatabase()->findObjects((TestFunc)isProjectileType, projs);
@@ -1549,7 +1554,7 @@ TEST(WallTilingTest, ShipDestroysDestructibleWall)
 
    // Let updated tiles propagate to the client
    S32 destAfter = -1;
-   for(S32 idleCycle = 0; idleCycle < 300; idleCycle++)
+   for(S32 idleCycle = 0; idleCycle < 300; ++idleCycle)
    {
       GamePair::idle(50, 1);
       destAfter = countDestEdges();
@@ -1594,12 +1599,12 @@ TEST(WallTilingTest, MadMaze2DiagonalOverlap)
    // With the combined Union approach, Tile 0 has ONE poly (13 verts).
    // Verify it has both Solid and Dashed edges (from both barrier types).
    bool hasSolid = false, hasDashed = false, hasNone = false;
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
       if(tiles[t].tileId == 0)
-         for(S32 p = 0; p < tiles[t].polys.size(); p++)
+         for(S32 p = 0; p < tiles[t].polys.size(); ++p)
          {
             const WallPoly &wp = tiles[t].polys[p];
-            for(U32 e = 0; e < wp.edges.size(); e++)
+            for(U32 e = 0; e < wp.edges.size(); ++e)
             {
                if(wp.edges[e] == EdgeStyle::Normal) hasSolid = true;
                if(wp.edges[e] == EdgeStyle::Destructible) hasDashed = true;
@@ -1610,10 +1615,10 @@ TEST(WallTilingTest, MadMaze2DiagonalOverlap)
    // ---- Assertions on CLIENT received tiles ----
    const Vector<WallPoly> &clientPolys = GameType::getTilePolys();
    bool clientHasSolid = false, clientHasDashed = false;
-   for(S32 i = 0; i < clientPolys.size(); i++)
+   for(S32 i = 0; i < clientPolys.size(); ++i)
    {
       const WallPoly &wp = clientPolys[i];
-      for(U32 e = 0; e < wp.edges.size(); e++)
+      for(U32 e = 0; e < wp.edges.size(); ++e)
       {
          if(wp.edges[e] == EdgeStyle::Normal) clientHasSolid = true;
          if(wp.edges[e] == EdgeStyle::Destructible) clientHasDashed = true;
@@ -1660,12 +1665,12 @@ TEST(WallTilingTest, MadMaze2ThreeWalls)
 
    // Count polys that have zero visible edges (all None)
    S32 invisiblePolys = 0;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          bool allNone = true;
-         for(U32 e = 0; e < wp.edges.size(); e++)
+         for(U32 e = 0; e < wp.edges.size(); ++e)
             if(wp.edges[e] != EdgeStyle::None) { allNone = false; break; }
          if(allNone) invisiblePolys++;
       }
@@ -1675,11 +1680,11 @@ TEST(WallTilingTest, MadMaze2ThreeWalls)
 
    // Must have both types
    bool hasSolid = false, hasDashed = false;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
-         for(U32 e = 0; e < wp.edges.size(); e++)
+         for(U32 e = 0; e < wp.edges.size(); ++e)
          {
             if(wp.edges[e] == EdgeStyle::Normal) hasSolid = true;
             if(wp.edges[e] == EdgeStyle::Destructible) hasDashed = true;
@@ -1694,10 +1699,10 @@ TEST(WallTilingTest, MadMaze2ThreeWalls)
    EXPECT_GT(clientPolys.size(), 0) << "Client must receive tile polys";
    bool clientHasSolid = false, clientHasDashed = false;
    S32 clientInvisible = 0;
-   for(S32 i = 0; i < clientPolys.size(); i++)
+   for(S32 i = 0; i < clientPolys.size(); ++i)
    {
       bool allNone = true;
-      for(U32 e = 0; e < clientPolys[i].edges.size(); e++)
+      for(U32 e = 0; e < clientPolys[i].edges.size(); ++e)
       {
          if(clientPolys[i].edges[e] == EdgeStyle::Normal) clientHasSolid = true;
          if(clientPolys[i].edges[e] == EdgeStyle::Destructible) clientHasDashed = true;
@@ -1740,9 +1745,9 @@ TEST(WallTilingTest, MadMaze2DiagDest)
    const auto &tiles = gt->getMapTiles();
 
    // Diagnostic: show which None edges are not on tile boundary
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
@@ -1753,12 +1758,12 @@ TEST(WallTilingTest, MadMaze2DiagDest)
 
    // Count polys that have zero visible edges (all None)
    S32 invisiblePolys = 0;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          bool allNone = true;
-         for(U32 e = 0; e < wp.edges.size(); e++)
+         for(U32 e = 0; e < wp.edges.size(); ++e)
             if(wp.edges[e] != EdgeStyle::None) { allNone = false; break; }
          if(allNone) invisiblePolys++;
       }
@@ -1767,11 +1772,11 @@ TEST(WallTilingTest, MadMaze2DiagDest)
 
    // Must have both types
    bool hasSolid = false, hasDashed = false;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
-         for(U32 e = 0; e < wp.edges.size(); e++)
+         for(U32 e = 0; e < wp.edges.size(); ++e)
          {
             if(wp.edges[e] == EdgeStyle::Normal) hasSolid = true;
             if(wp.edges[e] == EdgeStyle::Destructible) hasDashed = true;
@@ -1786,10 +1791,10 @@ TEST(WallTilingTest, MadMaze2DiagDest)
    EXPECT_GT(clientPolys.size(), 0) << "Client must receive tile polys";
    bool clientHasSolid = false, clientHasDashed = false;
    S32 clientInvisible = 0;
-   for(S32 i = 0; i < clientPolys.size(); i++)
+   for(S32 i = 0; i < clientPolys.size(); ++i)
    {
       bool allNone = true;
-      for(U32 e = 0; e < clientPolys[i].edges.size(); e++)
+      for(U32 e = 0; e < clientPolys[i].edges.size(); ++e)
       {
          if(clientPolys[i].edges[e] == EdgeStyle::Normal) clientHasSolid = true;
          if(clientPolys[i].edges[e] == EdgeStyle::Destructible) clientHasDashed = true;
@@ -1833,11 +1838,11 @@ TEST(WallTilingTest, MadMaze2AfterDestruction)
 
    // Must have Solid edges
    bool hasSolid = false;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
-         for(U32 e = 0; e < wp.edges.size(); e++)
+         for(U32 e = 0; e < wp.edges.size(); ++e)
             if(wp.edges[e] == EdgeStyle::Normal) hasSolid = true;
       }
 
@@ -1847,8 +1852,8 @@ TEST(WallTilingTest, MadMaze2AfterDestruction)
    const Vector<WallPoly> &clientPolys = GameType::getTilePolys();
    EXPECT_GT(clientPolys.size(), 0) << "Client must receive tile polys";
    bool clientHasSolid = false;
-   for(S32 i = 0; i < clientPolys.size(); i++)
-      for(U32 e = 0; e < clientPolys[i].edges.size(); e++)
+   for(S32 i = 0; i < clientPolys.size(); ++i)
+      for(U32 e = 0; e < clientPolys[i].edges.size(); ++e)
          if(clientPolys[i].edges[e] == EdgeStyle::Normal) clientHasSolid = true;
    EXPECT_TRUE(clientHasSolid) << "CLIENT: Must have Solid edges";
 }
@@ -1886,16 +1891,16 @@ TEST(WallTilingTest, DestructibleMiterHook)
    constructBarrierPolygon(Point(382.5f, -510.0f), Point(510.0f, -765.0f), dummy, dummy, 10.0f, cleanSeg1);
    F32 expectedArea = area(cleanSeg0) + area(cleanSeg1);
 
-   // for(S32 t = 0; t < tiles.size(); t++)
+   // for(S32 t = 0; t < tiles.size(); ++t)
    // {
-   //    for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   //    for(S32 p = 0; p < tiles[t].polys.size(); ++p)
    //    {
    //       const WallPoly &wp = tiles[t].polys[p];
    //       F32 polyArea = 0;
    //       if(wp.numVerts() >= 3)
    //       {
    //          Vector<Point> ctr;
-   //          for(U32 v = 0; v < wp.numVerts(); v++)
+   //          for(U32 v = 0; v < wp.numVerts(); ++v)
    //             ctr.push_back(Point(wp.verts[v*2], wp.verts[v*2+1]));
    //          polyArea = area(ctr);
    //       }
@@ -1905,16 +1910,16 @@ TEST(WallTilingTest, DestructibleMiterHook)
    // Sum destructible-only poly areas and check no Solid edges (permanent) appear
    F32 totalDestArea = 0;
    bool hasSolid = false;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          bool allDest = true;
-         for(U32 e = 0; e < wp.edges.size(); e++)
+         for(U32 e = 0; e < wp.edges.size(); ++e)
             if(wp.edges[e] == EdgeStyle::Normal) { hasSolid = true; allDest = false; break; }
          if(!allDest) continue;
          Vector<Point> contour;
-         for(U32 v = 0; v < wp.numVerts(); v++)
+         for(U32 v = 0; v < wp.numVerts(); ++v)
             contour.push_back(Point(wp.verts[v*2], wp.verts[v*2+1]));
          totalDestArea += area(contour);
       }
@@ -1947,9 +1952,9 @@ TEST(WallTilingTest, DestructiblePolyWall)
    ASSERT_GT(tiles.size(), 0);
    bool hasDashed = false;
    bool hasSolid = false;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
-         for(U32 e = 0; e < tiles[t].polys[p].edges.size(); e++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
+         for(U32 e = 0; e < tiles[t].polys[p].edges.size(); ++e)
          {
             if(tiles[t].polys[p].edges[e] == EdgeStyle::Destructible) hasDashed = true;
             if(tiles[t].polys[p].edges[e] == EdgeStyle::Normal)  hasSolid  = true;
@@ -1983,9 +1988,9 @@ TEST(WallTilingTest, PermanentPolyWall)
    ASSERT_GT(tiles.size(), 0);
    bool hasDashed = false;
    bool hasSolid = false;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
-         for(U32 e = 0; e < tiles[t].polys[p].edges.size(); e++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
+         for(U32 e = 0; e < tiles[t].polys[p].edges.size(); ++e)
          {
             if(tiles[t].polys[p].edges[e] == EdgeStyle::Destructible) hasDashed = true;
             if(tiles[t].polys[p].edges[e] == EdgeStyle::Normal)  hasSolid  = true;
@@ -2022,13 +2027,13 @@ TEST(WallTilingTest, PavillionDestructibleWallLeftEdge2)
    bool foundDestPoly  = false;
    bool leftEdgeOk     = false;
 
-   for(S32 i = 0; i < clientPolys.size(); i++)
+   for(S32 i = 0; i < clientPolys.size(); ++i)
    {
       const WallPoly &wp = clientPolys[i];
 
       F32 minX = F32_MAX, maxX = -F32_MAX;
       F32 minY = F32_MAX, maxY = -F32_MAX;
-      for(U32 v = 0; v < wp.numVerts(); v++)
+      for(U32 v = 0; v < wp.numVerts(); ++v)
       {
          F32 vx = wp.verts[v * 2];
          F32 vy = wp.verts[v * 2 + 1];
@@ -2042,14 +2047,14 @@ TEST(WallTilingTest, PavillionDestructibleWallLeftEdge2)
          continue;
 
       bool hasDest = false;
-      for(U32 e = 0; e < wp.edges.size(); e++)
+      for(U32 e = 0; e < wp.edges.size(); ++e)
          if(wp.edges[e] == EdgeStyle::Destructible) { hasDest = true; break; }
       if(!hasDest) continue;
 
       foundDestPoly = true;
 
       // Check: any edge near x≈4565 (left wall side) must be visible
-      for(U32 e = 0; e < wp.edges.size(); e++)
+      for(U32 e = 0; e < wp.edges.size(); ++e)
       {
          U32 v0 = e * 2;
          U32 v1 = ((e + 1) % wp.numVerts()) * 2;
@@ -2097,11 +2102,11 @@ TEST(WallTilingTest, PavillionDestructibleWallLeftEdge)
    bool foundDestPoly = false;
    bool leftEdgeOk = false;
 
-   for(S32 i = 0; i < clientPolys.size(); i++)
+   for(S32 i = 0; i < clientPolys.size(); ++i)
    {
       const WallPoly &wp = clientPolys[i];
       F32 minX = F32_MAX, maxX = -F32_MAX, minY = F32_MAX, maxY = -F32_MAX;
-      for(U32 v = 0; v < wp.numVerts(); v++)
+      for(U32 v = 0; v < wp.numVerts(); ++v)
       {
          F32 vx = wp.verts[v * 2], vy = wp.verts[v * 2 + 1];
          if(vx < minX) minX = vx; if(vx > maxX) maxX = vx;
@@ -2111,12 +2116,12 @@ TEST(WallTilingTest, PavillionDestructibleWallLeftEdge)
          continue;
 
       bool hasDest = false;
-      for(U32 e = 0; e < wp.edges.size(); e++)
+      for(U32 e = 0; e < wp.edges.size(); ++e)
          if(wp.edges[e] == EdgeStyle::Destructible) { hasDest = true; break; }
       if(!hasDest) continue;
 
       foundDestPoly = true;
-      for(U32 e = 0; e < wp.edges.size(); e++)
+      for(U32 e = 0; e < wp.edges.size(); ++e)
       {
          U32 v0 = e * 2, v1 = ((e + 1) % wp.numVerts()) * 2;
          F32 x1 = wp.verts[v0], x2 = wp.verts[v1];
@@ -2184,14 +2189,14 @@ TEST(WallTilingTest, PavillionBackwardsLInteriorEdges)
    S32 interiorDestEdges = 0;
    S32 interiorNormalEdges = 0;
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
 
-         for(U32 e = 0; e < nv; e++)
+         for(U32 e = 0; e < nv; ++e)
          {
             U32 v0 = e * 2;
             U32 v1 = ((e + 1) % nv) * 2;
@@ -2212,9 +2217,11 @@ TEST(WallTilingTest, PavillionBackwardsLInteriorEdges)
             if(inOverlap)
             {
                if(wp.edges[e] == EdgeStyle::Destructible)
-                  interiorDestEdges++;
+                  ++interiorDestEdges;
+
                else if(wp.edges[e] == EdgeStyle::Normal)
-                  interiorNormalEdges++;
+                  ++interiorNormalEdges;
+
             }
          }
       }
@@ -2272,21 +2279,21 @@ TEST(WallTilingTest, DiagnosticBackwardsLOverlapStepByStep)
 
    // --- Dump raw input outlines ---
    printf("=== Input: permanent wall (spine 0,-2295 to 0,-1530, w=50) ===\n");
-   for(S32 v = 0; v < outline1.size(); v++)
+   for(S32 v = 0; v < outline1.size(); ++v)
       printf("  v%d: (%8.1f, %8.1f)\n", v, outline1[v].x, outline1[v].y);
 
    printf("=== Input: destructible vertical (spine 4590,-2040 to 4590,-1836, w=50) ===\n");
-   for(S32 v = 0; v < outline2.size(); v++)
+   for(S32 v = 0; v < outline2.size(); ++v)
       printf("  v%d: (%8.1f, %8.1f)\n", v, outline2[v].x, outline2[v].y);
 
    printf("=== Input: destructible horizontal (spine 4437,-1861.5 to 4590,-1861.5, w=50) ===\n");
-   for(S32 v = 0; v < outline3.size(); v++)
+   for(S32 v = 0; v < outline3.size(); ++v)
       printf("  v%d: (%8.1f, %8.1f)\n", v, outline3[v].x, outline3[v].y);
 
    printf("\n=== Clipper2 output (%d tiles, tile size=%d) ===\n",
           tiles.size(), builder.getTileSize());
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
       printf("Tile %d (id=%d, bounds=(%8.1f,%8.1f)-(%8.1f,%8.1f)): %d polys\n",
              t, tiles[t].tileId,
@@ -2294,12 +2301,12 @@ TEST(WallTilingTest, DiagnosticBackwardsLOverlapStepByStep)
              tiles[t].bounds.max.x, tiles[t].bounds.max.y,
              tiles[t].polys.size());
 
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
          printf("  Poly %d: %d verts, %d edges\n", p, nv, wp.edges.size());
-         for(U32 e = 0; e < nv; e++)
+         for(U32 e = 0; e < nv; ++e)
          {
             U32 v0 = e * 2;
             U32 v1 = ((e + 1) % nv) * 2;
@@ -2315,11 +2322,11 @@ TEST(WallTilingTest, DiagnosticBackwardsLOverlapStepByStep)
 
    // --- Assertions: no Destructible edges in overlap region ---
    S32 interiorDestEdges = 0;
-   for(S32 t = 0; t < tiles.size(); t++)
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+   for(S32 t = 0; t < tiles.size(); ++t)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
-         for(U32 e = 0; e < wp.numVerts(); e++)
+         for(U32 e = 0; e < wp.numVerts(); ++e)
          {
             F32 x1 = wp.verts[e * 2];
             F32 y1 = wp.verts[e * 2 + 1];
@@ -2330,7 +2337,8 @@ TEST(WallTilingTest, DiagnosticBackwardsLOverlapStepByStep)
                my > -1886.5f + 0.1f && my < -1836.5f - 0.1f)
             {
                if(wp.edges[e] == EdgeStyle::Destructible)
-                  interiorDestEdges++;
+                  ++interiorDestEdges;
+
             }
          }
       }
@@ -2395,14 +2403,14 @@ TEST(WallTilingTest, PavillionDestructibleLeftEdgeBelowHorizontalArmIsRendered)
    bool foundEdge = false;         // An edge exists on x~4565 covering exposedY
    bool foundRenderedEdge = false; // ...and it is rendered (non-None)
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
 
-         for(U32 e = 0; e < nv; e++)
+         for(U32 e = 0; e < nv; ++e)
          {
             U32 v0 = e * 2;
             U32 v1 = ((e + 1) % nv) * 2;

--- a/bitfighter_test/TestObjects.cpp
+++ b/bitfighter_test/TestObjects.cpp
@@ -176,7 +176,8 @@ TEST_F(ObjectTest, GhostingSanity)
 
    // Check whether the objects created on the server made it onto the client
    const Vector<DatabaseObject *> *objects = clientGame->getGameObjDatabase()->findObjects_fast();
-   for(S32 i = 0; i < objects->size(); ++i)
+   S32 objects_sz = objects->size();
+   for (S32 i = 0; i < objects_sz; ++i)
    {
       BfObject *bfobj = dynamic_cast<BfObject *>((*objects)[i]);
       if(bfobj && bfobj->getClassRep() != NULL)  // Barriers and some other objects might not be ghostable...
@@ -304,7 +305,8 @@ string pointsToLuaList(const Vector<Point> &points, bool asTable)
    if(asTable)
       pointList += "{ ";
 
-   for(S32 i = 0; i < points.size(); ++i)
+   S32 points_sz = points.size();
+   for (S32 i = 0; i < points_sz; ++i)
    {
       pointList += "point.new(" + points[i].toString() + ")";
       if(i < points.size() - 1)

--- a/bitfighter_test/TestObjects.cpp
+++ b/bitfighter_test/TestObjects.cpp
@@ -44,7 +44,7 @@ class ObjectTest : public testing::Test
    public:
       static void process(ServerGame *game, S32 argc, const char **argv)
       {
-         for(S32 j = 1; j <= argc; j++)
+         for(S32 j = 1; j <= argc; ++j)
          {
             game->cleanUp();
             game->processLevelLoadLine(j, 0, argv, game->getGameObjDatabase(), "some_non_existing_filename.level", 1);
@@ -70,7 +70,7 @@ TEST_F(ObjectTest, ProcessArgumentsSanity)
 
    // Substitute the class name for argv[0]
    U32 count = TNL::NetClassRep::getNetClassCount(NetClassGroupGame, NetClassTypeObject);
-   for(U32 i = 0; i < count; i++)
+   for(U32 i = 0; i < count; ++i)
    {
       NetClassRep *netClassRep = TNL::NetClassRep::getClass(NetClassGroupGame, NetClassTypeObject, i);
       argv[0] = netClassRep->getClassName();
@@ -109,7 +109,7 @@ TEST_F(ObjectTest, GhostingSanity)
    U32 classCount = TNL::NetClassRep::getNetClassCount(NetClassGroupGame, NetClassTypeObject);
    Vector<GhostingRecord> ghostingRecords;
    ghostingRecords.resize(classCount);
-   for(U32 i = 0; i < classCount; i++)
+   for(U32 i = 0; i < classCount; ++i)
    {
       ghostingRecords[i].server = false;
       ghostingRecords[i].client = false;
@@ -131,7 +131,7 @@ TEST_F(ObjectTest, GhostingSanity)
    geom_speedZone.push_back(Point(400,1));
 
    // Create one of each type of registered NetClass
-   for(U32 i = 0; i < classCount; i++)
+   for(U32 i = 0; i < classCount; ++i)
    {
       NetClassRep *netClassRep = TNL::NetClassRep::getClass(NetClassGroupGame, NetClassTypeObject, i);
       Object *obj = netClassRep->create();
@@ -160,9 +160,10 @@ TEST_F(ObjectTest, GhostingSanity)
    }
 
    S32 serverGhostableCount = 0;
-   for(U32 i = 0; i < classCount; i++)
+   for(U32 i = 0; i < classCount; ++i)
       if(ghostingRecords[i].server)
-         serverGhostableCount++;
+         ++serverGhostableCount;
+
    ASSERT_GT(serverGhostableCount, 0)
          << "GhostingSanity created no server-side objects to transmit";
 
@@ -175,7 +176,7 @@ TEST_F(ObjectTest, GhostingSanity)
 
    // Check whether the objects created on the server made it onto the client
    const Vector<DatabaseObject *> *objects = clientGame->getGameObjDatabase()->findObjects_fast();
-   for(S32 i = 0; i < objects->size(); i++)
+   for(S32 i = 0; i < objects->size(); ++i)
    {
       BfObject *bfobj = dynamic_cast<BfObject *>((*objects)[i]);
       if(bfobj && bfobj->getClassRep() != NULL)  // Barriers and some other objects might not be ghostable...
@@ -185,7 +186,7 @@ TEST_F(ObjectTest, GhostingSanity)
       }
    }
 
-   for(U32 i = 0; i < classCount; i++)
+   for(U32 i = 0; i < classCount; ++i)
    {
       NetClassRep *netClassRep = TNL::NetClassRep::getClass(NetClassGroupGame, NetClassTypeObject, i);
 
@@ -262,7 +263,7 @@ TEST_F(ObjectTest, LuaSanity)
    lua_State *L = LuaScriptRunner::getL();  // Already initialized by GamePair (includes luavec.lua)
 
    // Create one of each type of registered NetClass
-   for(U32 i = 0; i < classCount; i++)
+   for(U32 i = 0; i < classCount; ++i)
    {
       NetClassRep *netClassRep = TNL::NetClassRep::getClass(NetClassGroupGame, NetClassTypeObject, i);
       Object *obj = netClassRep->create();
@@ -303,7 +304,7 @@ string pointsToLuaList(const Vector<Point> &points, bool asTable)
    if(asTable)
       pointList += "{ ";
 
-   for(S32 i = 0; i < points.size(); i++)
+   for(S32 i = 0; i < points.size(); ++i)
    {
       pointList += "point.new(" + points[i].toString() + ")";
       if(i < points.size() - 1)
@@ -328,7 +329,7 @@ void createVerifyDeleteItem(ServerGame *serverGame, LuaLevelGenerator &levelgen,
    EXPECT_EQ(teamIndex, obj->getTeam());
 
    // Verify actual coordinates of points (getting pretty pedantic here!)
-   for(S32 i = 0; i < obj->getVertCount(); i++)
+   for(S32 i = 0; i < obj->getVertCount(); ++i)
    {
       EXPECT_EQ(geom[i].x, obj->getVert(i).x);
       EXPECT_EQ(geom[i].y, obj->getVert(i).y);

--- a/bitfighter_test/TestPolylineGeometry.cpp
+++ b/bitfighter_test/TestPolylineGeometry.cpp
@@ -29,7 +29,7 @@ TEST_F(PolylineGeometryTest, setGeomTest)
 
    // Any points with NaN coordinates should be ignored
    EXPECT_EQ(newGeom.size(), 3);
-   for(S32 i = 0; i < newGeom.size(); i++)
+   for(S32 i = 0; i < newGeom.size(); ++i)
    {
       EXPECT_EQ(geom[i], newGeom[i]);
    }
@@ -42,7 +42,7 @@ TEST_F(PolylineGeometryTest, setGeomTest)
 
    // Any points with NaN coordinates should be ignored
    EXPECT_EQ(newGeom.size(), 3);
-   for(S32 i = 0; i < newGeom.size(); i++)
+   for(S32 i = 0; i < newGeom.size(); ++i)
    {
       EXPECT_EQ(secondGeom[i], newGeom[i]);
    }
@@ -66,7 +66,7 @@ TEST_F(PolylineGeometryTest, setGeomWithNanPointTest)
 
    // Any points with NaN coordinates should be ignored
    EXPECT_EQ(newGeom.size(), 2);
-   for(S32 i =0; i < newGeom.size(); i++)
+   for(S32 i =0; i < newGeom.size(); ++i)
    {
       // comparing against itself is false with NaN coordinates
       EXPECT_EQ(newGeom[i], newGeom[i]);

--- a/bitfighter_test/TestRenderUtils.cpp
+++ b/bitfighter_test/TestRenderUtils.cpp
@@ -17,7 +17,7 @@ using namespace std;
 	
 static void testThatLinesAreNotLongerThanMax(const Vector<string> &lines, S32 maxLen, S32 fontSize)
 {
-   for(S32 i = 0; i < lines.size(); i++)    
+   for(S32 i = 0; i < lines.size(); ++i)    
    {
       if(getStringWidth(fontSize, lines[i].c_str()) > maxLen)
       {
@@ -37,7 +37,7 @@ static void testThatLinesAreNotLongerThanMax(const Vector<string> &lines, S32 ma
 // Here make sure that just one more character would make the line too long
 static void wouldOneMoreCharMakeTheLineTooLong(const Vector<string> &lines, S32 maxLen, S32 fontSize)
 {
-   for(S32 i = 0; i < lines.size() - 1; i++)    
+   for(S32 i = 0; i < lines.size() - 1; ++i)    
    {
       string line = lines[i] + lines[i + 1][0];    // Add first char of next item
 
@@ -50,7 +50,7 @@ static void wouldOneMoreCharMakeTheLineTooLong(const Vector<string> &lines, S32 
 static void wouldOneMoreWordMakeTheLineTooLong(const Vector<string> &lines, S32 maxLen, S32 fontSize)
 {
    Vector<string> words;
-   for(S32 i = 0; i < lines.size() - 1; i++)
+   for(S32 i = 0; i < lines.size() - 1; ++i)
    {
       parseString(lines[i + 1], words);
       string line = lines[i] + ' ' + words[0];
@@ -98,7 +98,7 @@ TEST(RenderUtilsTest, StringWrappingTests)
    // Forcing the linebreaks where they would normally fall should produce same result
    lines2 = wrapString("One\nlonger\nline that\nwill\nrequire\nwrapping\ndue to\nshort\nlength", 50, 10);
    EXPECT_EQ(lines.size(), lines2.size());
-   for(S32 i = 0; i < lines.size(); i++)
+   for(S32 i = 0; i < lines.size(); ++i)
       EXPECT_EQ(lines[i], lines2[i]) << "Failed on iter " << i << "; \"" << lines[i] << "\" != \"" << lines2[i] << "\"!";
    {
       SCOPED_TRACE("Scenario 1A");
@@ -110,7 +110,7 @@ TEST(RenderUtilsTest, StringWrappingTests)
    lines = wrapString(alphabet, 50, 10);
 
    string line;
-   for(S32 i = 0; i < lines.size(); i++)
+   for(S32 i = 0; i < lines.size(); ++i)
       line += lines[i];
 
    EXPECT_EQ(line, alphabet) << "Merge failed... expected " << alphabet << " got " << line;
@@ -131,10 +131,10 @@ TEST(RenderUtilsTest, StringWrappingTests)
       "Our stern alarums changed to merry meetings, "
       "Our dreadful marches to delightful measures.";
 
-   for(S32 i = 0; i < 50; i++)
+   for(S32 i = 0; i < 50; ++i)
    {
       S32 width = 150 + i * 10;
-      for(S32 j = 0; j < 5; j++)
+      for(S32 j = 0; j < 5; ++j)
       {
          S32 size = 10 + 2 * j;
          lines = wrapString(longLine, 300, 14);

--- a/bitfighter_test/TestRobot.cpp
+++ b/bitfighter_test/TestRobot.cpp
@@ -26,7 +26,7 @@ TEST(RobotTest, addBot)
 
 	gamePair.server->addBot(args, ClientInfo::ClassRobotAddedByAddbots);
 
-	for(U32 i = 0; i < 10; i++)
+	for(U32 i = 0; i < 10; ++i)
 		gamePair.idle(10);
 
 	EXPECT_EQ(1, gamePair.server->getRobotCount());
@@ -46,7 +46,7 @@ TEST(RobotTest, luaRobotNew)
 
 	EXPECT_TRUE(levelgen.runString("bf:addItem(Robot.new())"));
 
-	for(U32 i = 0; i < 10; i++)
+	for(U32 i = 0; i < 10; ++i)
 		gamePair.idle(10);
 
 	EXPECT_EQ(1, gamePair.server->getRobotCount());
@@ -56,7 +56,7 @@ TEST(RobotTest, luaRobotNew)
 
 	// The Lua Robot:removeFromGame implementation queues the object for deletion with
 	// deleteObject(100), so we need a longer delay before the server actually removes the robot.
-	for(U32 i = 0; i < 11; i++)
+	for(U32 i = 0; i < 11; ++i)
 		gamePair.idle(10);
 
 	EXPECT_EQ(0, gamePair.server->getRobotCount());
@@ -82,7 +82,7 @@ TEST(RobotTest, RemoveFromGameDuringInitialOnShipSpawn)
 	Vector<StringTableEntry> args;
 	gamePair.server->getGameType()->addBot(args);
 
-	for(U32 i = 0; i < 10; i++)
+	for(U32 i = 0; i < 10; ++i)
 		gamePair.idle(10);
 
 	EXPECT_TRUE(levelgen.runString("assert(RUN)"));

--- a/bitfighter_test/TestRobotManager.cpp
+++ b/bitfighter_test/TestRobotManager.cpp
@@ -82,28 +82,29 @@ static string getTeams(const GamePair &gamePair)
    Vector<Vector<S32> > teamStrings;
 
    teamStrings.resize(gamePair.server->getTeamCount());
-   for(S32 i = 0; i < teamStrings.size(); i++)
+   for(S32 i = 0; i < teamStrings.size(); ++i)
    {
       teamStrings[i].resize((S32)ClientInfo::ClassCount);
-      for(S32 j = 0; j < teamStrings[i].size(); j++)
+      for(S32 j = 0; j < teamStrings[i].size(); ++j)
          teamStrings[i][j] = 0;
    }
 
    const Vector<RefPtr<ClientInfo> > *clientInfos = gamePair.server->getClientInfos();
 
-   for(S32 i = 0; i < clientInfos->size(); i++)
+   for(S32 i = 0; i < clientInfos->size(); ++i)
    {
       S32 team = clientInfos->get(i)->getTeamIndex();
       S32 cc   = clientInfos->get(i).getPointer()->getClientClass();
 
-      teamStrings[team][cc]++;
+      ++teamStrings[team][cc];
+
    }
 
    string teamDescr = "";
-   for(S32 i = 0; i < teamStrings.size(); i++)
+   for(S32 i = 0; i < teamStrings.size(); ++i)
    {
       S32 total = 0;
-      for(S32 j = 0; j < teamStrings[i].size(); j++)
+      for(S32 j = 0; j < teamStrings[i].size(); ++j)
       {
          S32 count = teamStrings[i][j];
          teamDescr += string(count, getChar(j));
@@ -133,11 +134,11 @@ static void setTeams(GamePair &gamePair, const string &teamConfig)
    S32 teams = words.size();
 
    // Add teams -- a fresh gamePair will have 0 players and 1 team
-   for(S32 i = 1; i < teams; i++)
+   for(S32 i = 1; i < teams; ++i)
       gamePair.server->addTeam(new Team());
 
-   for(S32 i = 0; i < words.size(); i++)           // Iterate over teams
-      for(S32 j = 0; j < words[i].size(); j++)     // Iterate over chars
+   for(S32 i = 0; i < words.size(); ++i)           // Iterate over teams
+      for(S32 j = 0; j < words[i].size(); ++j)     // Iterate over chars
       {
          if(words[i][j] == 'H')
             gamePair.addClient("Human " + itos(i) + " " + itos(j), i);

--- a/bitfighter_test/TestServerGame.cpp
+++ b/bitfighter_test/TestServerGame.cpp
@@ -50,7 +50,7 @@ TEST(ServerGameTest, KillStreakTests)
    S32 iters = (S32)ceil((F32)ServerGame::LevelSwitchTime / (F32)timeDelta) - 1;
 
    // Idle for 4000ms more... in 1000 ms chunks because of timeDelta limitations in ServerGame
-   for(S32 i = 0; i < iters; i++)
+   for(S32 i = 0; i < iters; ++i)
       game->idle(timeDelta);
 
    // New game has begun... kill streak should be reset to 0
@@ -81,7 +81,7 @@ TEST(ServerGameTest, LittleStory)
    ship->setMove(Move(1,0));                  // Length 1 = max speed; moves stay active until replaced
 
    // Test that we can simulate several ticks, and the ship advances every cycle
-   for(S32 i = 0; i < 20; i++)
+   for(S32 i = 0; i < 20; ++i)
    {
       Point prevPos = ship->getPos();
       serverGame->idle(10);                   // when i == 16 this locks up... why?
@@ -96,7 +96,7 @@ TEST(ServerGameTest, LittleStory)
    t->addToGame(serverGame, serverGame->getGameObjDatabase());
 
    bool shipDeleted = false;
-   for(S32 i = 0; i < 100; i++)
+   for(S32 i = 0; i < 100; ++i)
    {
       ship->setMove(Move(0,0));
       serverGame->idle(100);

--- a/bitfighter_test/TestStringUtils.cpp
+++ b/bitfighter_test/TestStringUtils.cpp
@@ -708,7 +708,7 @@ TEST(StringUtilsTest, getFilesFromFolder)
 
    bool foundLevel = false;
    bool foundTxt = false;
-   for(S32 i = 0; i < files.size(); i++)
+   for(S32 i = 0; i < files.size(); ++i)
    {
       if(files[i] == "test1.level") foundLevel = true;
       if(files[i] == "test2.TXT") foundTxt = true;

--- a/bitfighter_test/TestUtils.cpp
+++ b/bitfighter_test/TestUtils.cpp
@@ -100,7 +100,7 @@ void GamePair::initialize(GameSettingsPtr settings, const string &levelCode, S32
 
    server->startHosting();          // This will load levels and wipe out any teams
 
-   for(S32 i = 0; i < clientCount; i++)
+   for(S32 i = 0; i < clientCount; ++i)
       addClient("TestPlayer" + itos(i));
 }
 
@@ -112,7 +112,7 @@ GamePair::~GamePair()
 
    GameManager::getServerGame()->setAutoLeveling(false);    // No need to run this while we're shutting down
 
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
       if(clientGames->get(i)->getConnectionToServer())
          clientGames->get(i)->getConnectionToServer()->disconnect(NetConnection::ReasonSelfDisconnect, "");
 
@@ -130,7 +130,7 @@ GamePair::~GamePair()
 // Idle a pair of games for a specified number of cycles, static method
 void GamePair::idle(U32 timeDelta, U32 cycles)
 {
-   for(U32 i = 0; i < cycles; i++)
+   for(U32 i = 0; i < cycles; ++i)
       GameManager::idle(timeDelta);
 }
 
@@ -189,7 +189,7 @@ void GamePair::removeClient(const string &name)
 
    const Vector<ClientGame *> *clients = GameManager::getClientGames();
 
-   for(S32 i = 0; i < clients->size(); i++)
+   for(S32 i = 0; i < clients->size(); ++i)
    {
       if(clients->get(i)->getClientInfo() && string(clients->get(i)->getClientInfo()->getName().getString()) == name)
       {

--- a/master/DatabaseAccessThread.h
+++ b/master/DatabaseAccessThread.h
@@ -79,7 +79,8 @@ public:
          if(mEntryThread != mEntryEnd)
          {
             mEntry[mEntryThread]->run();
-            mEntryThread++;
+            ++mEntryThread;
+
             if(mEntryThread >= mEntrySize)
                mEntryThread = 0;
          }
@@ -99,7 +100,8 @@ public:
       {
          mEntry[mEntryStart]->finish();
          mEntry[mEntryStart].set(NULL);  // RefPtr, we can just set to NULL and it will delete itself
-         mEntryStart++;
+         ++mEntryStart;
+
 
          if(mEntryStart >= mEntrySize)
             mEntryStart = 0;

--- a/master/GameJoltConnector.cpp
+++ b/master/GameJoltConnector.cpp
@@ -70,7 +70,7 @@ static void updateGameJolt(const MasterSettings *settings, const string &baseUrl
    string urlList = "";
    string otherParamString = otherParams + (otherParams != "" ? "&" : "");
 
-   for(S32 i = 0; i < credentialStrings.size(); i++)
+   for(S32 i = 0; i < credentialStrings.size(); ++i)
    {
       string url = baseUrl + "?" + gameIdString + "&" + otherParamString + credentialStrings[i];
 
@@ -190,7 +190,7 @@ void ping(const MasterSettings *settings, const Vector<MasterServerConnection *>
    string nameList = "";  // Comma separated list of quoted, sanitized names ready to pass to a SQL IN() function
    S32 nameCount = 0;
 
-   for(S32 i = 0; i < clientList->size(); i++)
+   for(S32 i = 0; i < clientList->size(); ++i)
    {
       if(clientList->get(i) && clientList->get(i)->mAuthenticated)
       {
@@ -199,7 +199,8 @@ void ping(const MasterSettings *settings, const Vector<MasterServerConnection *>
             nameList += ", ";
 
          nameList += "'" + name + "'";
-         nameCount++;
+         ++nameCount;
+
       }
    }
 

--- a/master/MasterServerConnection.cpp
+++ b/master/MasterServerConnection.cpp
@@ -42,7 +42,8 @@ MasterServer *MasterServerConnection::mMaster = NULL;
 static S32 getNextId()
 {
    static S32 nextId = 0;
-   nextId++;
+   ++nextId;
+
 
    // Negative range reserved for self-generated IDs, and 0 will never be issued
    if(nextId == S32_MAX)
@@ -80,7 +81,7 @@ MasterServerConnection::~MasterServerConnection()
    {
       const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-      for(S32 i = 0; i < clientList->size(); i++)
+      for(S32 i = 0; i < clientList->size(); ++i)
          if(clientList->get(i)->isInGlobalChat && clientList->get(i) != this)
             clientList->get(i)->m2cPlayerLeftGlobalChat(mPlayerOrServerName);
    }
@@ -266,7 +267,7 @@ void MasterServerConnection::processAutentication(StringTableEntry newName, PHPB
          {
             const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-            for(S32 i = 0; i < clientList->size(); i++)
+            for(S32 i = 0; i < clientList->size(); ++i)
             {
                MasterServerConnection *client = clientList->get(i);
 
@@ -288,7 +289,7 @@ void MasterServerConnection::processAutentication(StringTableEntry newName, PHPB
       else
          m2cSetAuthenticated_019((U32)AuthenticationStatusAuthenticatedName, badges, gamesPlayed, newName.getString());
 
-      for(S32 i = 0; i < master_admins.size(); i++)  // check for master admin
+      for(S32 i = 0; i < master_admins.size(); ++i)  // check for master admin
          if(newName == master_admins[i])
          {
             mIsMasterAdmin = true;
@@ -336,7 +337,7 @@ void MasterServerConnection::c2mQueryServersOption(U32 queryId, bool hostonly)
 
    const Vector<MasterServerConnection *> *serverList = mMaster->getServerList();
 
-   for(S32 i = 0; i < serverList->size(); i++)
+   for(S32 i = 0; i < serverList->size(); ++i)
    {
       // Hide hidden servers
       if(serverList->get(i)->mIsIgnoredFromList)
@@ -418,7 +419,8 @@ bool MasterServerConnection::checkActivityTime(U32 timeDeltaMinimum)
    U32 currentTime = Platform::getRealMilliseconds();
    if(currentTime - mLastActivityTime < timeDeltaMinimum)
    {
-      mStrikeCount++;
+      ++mStrikeCount;
+
       if(mStrikeCount == 3)
       {
          logprintf(LogConsumer::LogConnection, "User %s Disconnect due to flood control set at %i milliseconds",
@@ -428,7 +430,8 @@ bool MasterServerConnection::checkActivityTime(U32 timeDeltaMinimum)
       }
    }
    else if(mStrikeCount > 0)
-      mStrikeCount--;
+      --mStrikeCount;
+
 
    mLastActivityTime = currentTime;
    return true;
@@ -437,7 +440,7 @@ bool MasterServerConnection::checkActivityTime(U32 timeDeltaMinimum)
 
 void MasterServerConnection::removeConnectRequest(GameConnectRequest *gcr)
 {
-   for(S32 j = 0; j < mConnectList.size(); j++)
+   for(S32 j = 0; j < mConnectList.size(); ++j)
    {
       if(gcr == mConnectList[j])
       {
@@ -451,7 +454,7 @@ void MasterServerConnection::removeConnectRequest(GameConnectRequest *gcr)
 GameConnectRequest *MasterServerConnection::findAndRemoveRequest(U32 requestId)
 {
    GameConnectRequest *req = NULL;
-   for(S32 j = 0; j < mConnectList.size(); j++)
+   for(S32 j = 0; j < mConnectList.size(); ++j)
    {
       if(mConnectList[j]->hostQueryId == requestId)
       {
@@ -465,7 +468,7 @@ GameConnectRequest *MasterServerConnection::findAndRemoveRequest(U32 requestId)
 
    if(req->initiator.isValid())
       req->initiator->removeConnectRequest(req);
-   for(S32 j = 0; j < gConnectList.size(); j++)
+   for(S32 j = 0; j < gConnectList.size(); ++j)
    {
       if(gConnectList[j] == req)
       {
@@ -484,7 +487,7 @@ MasterServerConnection *MasterServerConnection::findClient(Nonce &clientId)   //
 
    const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-   for(S32 i = 0; i < clientList->size(); i++)
+   for(S32 i = 0; i < clientList->size(); ++i)
       if(clientList->get(i)->mPlayerId == clientId)
          return clientList->get(i);
 
@@ -526,7 +529,7 @@ void MasterServerConnection::writeClientServerList_JSON()
 
       const Vector<MasterServerConnection *> *serverList = mMaster->getServerList();
 
-      for(S32 i = 0; i < serverList->size(); i++)
+      for(S32 i = 0; i < serverList->size(); ++i)
       {
          MasterServerConnection *server = serverList->get(i);
 
@@ -537,7 +540,8 @@ void MasterServerConnection::writeClientServerList_JSON()
                      first ? "" : ", ", sanitizeForJson(server->mPlayerOrServerName.getString()).c_str(),
                      server->mCSProtocolVersion, server->mLevelName.getString(), server->mLevelType.getString(), server->mPlayerCount);
          playerCount += server->mPlayerCount;
-         serverCount++;
+         ++serverCount;
+
          first = false;
       }
 
@@ -547,7 +551,7 @@ void MasterServerConnection::writeClientServerList_JSON()
 
       const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-      for(S32 i = 0; i < clientList->size(); i++)
+      for(S32 i = 0; i < clientList->size(); ++i)
       {
          if(listClient(clientList->get(i)))
          {
@@ -560,7 +564,7 @@ void MasterServerConnection::writeClientServerList_JSON()
       fprintf(f, "],\n\t\"authenticated\": [");
       first = true;
 
-      for(S32 i = 0; i < clientList->size(); i++)
+      for(S32 i = 0; i < clientList->size(); ++i)
       {
          if(listClient(clientList->get(i)))
          {
@@ -650,11 +654,13 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mRequestArrangedConnection,
    Vector<IPAddress> possibleAddresses;
 
    // The address, but port+1
-   theAddress.port++;
+   ++theAddress.port;
+
    possibleAddresses.push_back(theAddress.toIPAddress());
 
    // The address, with the original port
-   theAddress.port--;
+   --theAddress.port;
+
    possibleAddresses.push_back(theAddress.toIPAddress());
 
    // Or the address the port thinks it's talking to.
@@ -682,10 +688,12 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, s2mAcceptArrangedConnection, 
    Address theAddress = getNetAddress();
    Vector<IPAddress> possibleAddresses;
 
-   theAddress.port++;
+   ++theAddress.port;
+
    possibleAddresses.push_back(theAddress.toIPAddress());
 
-   theAddress.port--;
+   --theAddress.port;
+
    possibleAddresses.push_back(theAddress.toIPAddress());
 
    Address theInternalAddress(internalAddress);
@@ -778,11 +786,11 @@ U16 MasterServerConnection::getGamesPlayed()
 
 void MasterServerConnection::processIsAuthenticated(GameStats *gameStats)
 {
-   for(S32 i = 0; i < gameStats->teamStats.size(); i++)
+   for(S32 i = 0; i < gameStats->teamStats.size(); ++i)
    {
       Vector<PlayerStats> *playerStats = &gameStats->teamStats[i].playerStats;
 
-      for(S32 j = 0; j < playerStats->size(); j++)
+      for(S32 j = 0; j < playerStats->size(); ++j)
       {
          Nonce playerId = playerStats->get(j).nonce;
          MasterServerConnection *client = findClient(playerId);
@@ -968,7 +976,7 @@ struct HighScoresReader : public MasterThreadEntry
    {
       MasterServerConnection::highScores.isBusy = false;
 
-      for(S32 i = 0; i < MasterServerConnection::highScores.waitingClients.size(); i++)
+      for(S32 i = 0; i < MasterServerConnection::highScores.waitingClients.size(); ++i)
          if(MasterServerConnection::highScores.waitingClients[i])
             MasterServerConnection::highScores.waitingClients[i]->m2cSendHighScores(MasterServerConnection::highScores.groupNames,
                                                                                     MasterServerConnection::highScores.names,
@@ -1018,7 +1026,7 @@ struct TotalLevelRatingsReader : public MasterThreadEntry
       totalRating->setRatingMagicValue(rating);  // Because, as noted above, rating could be a magic number
       totalRating->isBusy = false;
 
-      for(S32 i = 0; i < totalRating->waitingClients.size(); i++)
+      for(S32 i = 0; i < totalRating->waitingClients.size(); ++i)
          if(totalRating->waitingClients[i])
             totalRating->waitingClients[i]->m2cSendTotalLevelRating(dbId, rating);
 
@@ -1068,7 +1076,7 @@ struct PlayerLevelRatingsReader : public MasterThreadEntry
       playerRating->receivedUpdateByClientWhileBusy = false;
       playerRating->isBusy = false;
 
-      for(S32 i = 0; i < playerRating->waitingClients.size(); i++)
+      for(S32 i = 0; i < playerRating->waitingClients.size(); ++i)
          if(playerRating->waitingClients[i])
             playerRating->waitingClients[i]->sendPlayerLevelRating(dbId, rating);
 
@@ -1240,7 +1248,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, s2mAcheivementAchieved, (U8 a
 
    const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-   for(S32 i = 0; i < clientList->size(); i++)
+   for(S32 i = 0; i < clientList->size(); ++i)
       if(clientList->get(i)->mPlayerOrServerName == playerNick)
       {
          clientList->get(i)->mBadges = mBadges | BIT(achievementId); // Add to local variable without needing to reload from database
@@ -1336,7 +1344,7 @@ bool ThreadingStruct::isExpired()
 
 void ThreadingStruct::addClientToWaitingList(MasterServerConnection *connection)
 {
-   for(S32 i = 0; i < waitingClients.size(); i++)
+   for(S32 i = 0; i < waitingClients.size(); ++i)
       if(waitingClients[i] == connection)
          return;     // Already on the list!
 
@@ -1446,7 +1454,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, s2mRequestAuthentication, (Ve
 
    const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-   for(S32 i = 0; i < clientList->size(); i++)
+   for(S32 i = 0; i < clientList->size(); ++i)
    {
       MasterServerConnection *client = clientList->get(i);
       if(client->mPlayerId == clientId)
@@ -1602,7 +1610,7 @@ bool MasterServerConnection::readConnectRequest(BitStream *bstream, NetConnectio
          // With 2^64 possibilities, it most likely will be.
          const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-         for(S32 i = 0; i < clientList->size(); i++)
+         for(S32 i = 0; i < clientList->size(); ++i)
             if(clientList->get(i) != this && clientList->get(i)->mPlayerId == mPlayerId)
             {
                logprintf(LogConsumer::LogConnection, "User %s provided duplicate id to %s", mPlayerOrServerName.getString(),
@@ -1620,7 +1628,7 @@ bool MasterServerConnection::readConnectRequest(BitStream *bstream, NetConnectio
          // On clients 017 and older, they completely ignore any disconnect reason once fully connected,
          // so we pause waiting for database instead of fully connecting yet.
 
-         for(S32 i = 0; i < gListAddressHide.size(); i++)
+         for(S32 i = 0; i < gListAddressHide.size(); ++i)
             if(getNetAddress().isEqualAddress(gListAddressHide[i]))
                mIsIgnoredFromList = true;
 
@@ -1723,7 +1731,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mJoinGlobalChat, ())
 
    const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-   for(S32 i = 0; i < clientList->size(); i++)
+   for(S32 i = 0; i < clientList->size(); ++i)
       if(clientList->get(i) != this && clientList->get(i)->isInGlobalChat)
          names.push_back(clientList->get(i)->mPlayerOrServerName);
 
@@ -1739,7 +1747,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mJoinGlobalChat, ())
 
    isInGlobalChat = true;
 
-   for(S32 i = 0; i < clientList->size(); i++)
+   for(S32 i = 0; i < clientList->size(); ++i)
       if(clientList->get(i) != this && clientList->get(i)->isInGlobalChat)
          clientList->get(i)->m2cPlayerJoinedGlobalChat(mPlayerOrServerName);
 }
@@ -1756,7 +1764,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mLeaveGlobalChat, ())
 
    //isInGlobalChat = false;
    //Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
-   //for(S32 i = 0; i < clientList->size(); i++)
+   //for(S32 i = 0; i < clientList->size(); ++i)
    //   if (clientList->get(i) != this && clientList->get(i)->isInGlobalChat)
    //      clientList->get(i)->m2cPlayerLeftGlobalChat(mPlayerOrServerName);
 }
@@ -1791,7 +1799,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mSendChat, (StringPtr messa
 
             const Vector<MasterServerConnection *> *serverList = mMaster->getServerList();
 
-            for(S32 i = 0; i < serverList->size(); i++)
+            for(S32 i = 0; i < serverList->size(); ++i)
             {
                MasterServerConnection *server = serverList->get(i);
 
@@ -1812,7 +1820,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mSendChat, (StringPtr messa
 
             const Vector<MasterServerConnection *> *serverList = mMaster->getServerList();
 
-            for(S32 i = 0; i < serverList->size(); i++)
+            for(S32 i = 0; i < serverList->size(); ++i)
                if(serverList->get(i)->mIsIgnoredFromList)
                {
                   broughtBackServer = true;
@@ -1827,7 +1835,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mSendChat, (StringPtr messa
             bool found = false;
             const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-            for(S32 i = 0; i < clientList->size(); i++)
+            for(S32 i = 0; i < clientList->size(); ++i)
             {
                MasterServerConnection *client = clientList->get(i);
                if(strcmp(words[1].c_str(), client->mPlayerOrServerName.getString()) == 0)
@@ -1847,7 +1855,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mSendChat, (StringPtr messa
             bool found = false;
             const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-            for(S32 i = 0; i < clientList->size(); i++)
+            for(S32 i = 0; i < clientList->size(); ++i)
             {
                MasterServerConnection *client = clientList->get(i);
 
@@ -1898,7 +1906,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mSendChat, (StringPtr messa
          // Now relay the message and only send to client with the specified nick
          const Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-         for(S32 i = 0; i < clientList->size(); i++)
+         for(S32 i = 0; i < clientList->size(); ++i)
          {
             if(stricmp(clientList->get(i)->mPlayerOrServerName.getString(), pmRecipient.c_str()) == 0)
             {
@@ -1932,7 +1940,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, c2mSendChat, (StringPtr messa
    {
       const  Vector<MasterServerConnection *> *clientList = mMaster->getClientList();
 
-      for(S32 i = 0; i < clientList->size(); i++)
+      for(S32 i = 0; i < clientList->size(); ++i)
       {
          if(clientList->get(i) != this)    // ...except self!
             clientList->get(i)->m2cSendChat(mPlayerOrServerName, isPrivate, message);

--- a/master/authenticator.cpp
+++ b/master/authenticator.cpp
@@ -145,11 +145,11 @@ bool Authenticator::isSqlSafe(string s){
 		case 0:
 			return true;
 		case 1:
-			for (unsigned int i=0; i<dangerousCharacters.length(); i++) if (strchr(s.c_str(),dangerousCharacters[i])) return false;
+			for (unsigned int i=0; i<dangerousCharacters.length(); ++i) if (strchr(s.c_str(),dangerousCharacters[i])) return false;
 			return true;
 		case 2:
 		default:
-			for (unsigned int i=0; i<s.length(); i++) if(!isAlNum(s[i])) return false;
+			for (unsigned int i=0; i<s.length(); ++i) if(!isAlNum(s[i])) return false;
 			return true;
 	}
 }

--- a/master/database.cpp
+++ b/master/database.cpp
@@ -98,7 +98,7 @@ void DatabaseWriter::initialize(const char *server, const char *db, const char *
 
 static void insertStatsLoadout(const DbQuery &query, U64 playerId, const Vector<LoadoutStats> loadoutStats)
 {
-   for(S32 i = 0; i < loadoutStats.size(); i++)
+   for(S32 i = 0; i < loadoutStats.size(); ++i)
    {
          string sql = "INSERT INTO stats_player_loadout(stats_player_id, loadout) "
                        "VALUES(" + itos(playerId) + ", " + itos(loadoutStats[i].loadoutHash) + ");";
@@ -110,7 +110,7 @@ static void insertStatsLoadout(const DbQuery &query, U64 playerId, const Vector<
 
 static void insertStatsShots(const DbQuery &query, U64 playerId, const Vector<WeaponStats> weaponStats)
 {
-   for(S32 i = 0; i < weaponStats.size(); i++)
+   for(S32 i = 0; i < weaponStats.size(); ++i)
    {
       if(weaponStats[i].shots > 0)
       {
@@ -171,7 +171,7 @@ static U64 insertStatsTeam(const DbQuery &query, const TeamStats *teamStats, U64
 
    U64 teamId = query.runQuery(sql);
 
-   for(S32 i = 0; i < teamStats->playerStats.size(); i++)
+   for(S32 i = 0; i < teamStats->playerStats.size(); ++i)
       insertStatsPlayer(query, &teamStats->playerStats[i], gameId, itos(teamId));
 
    return teamId;
@@ -189,7 +189,7 @@ static U64 insertStatsGame(const DbQuery &query, const GameStats *gameStats, U64
 
    U64 gameId = query.runQuery(sql);
 
-   for(S32 i = 0; i < gameStats->teamStats.size(); i++)
+   for(S32 i = 0; i < gameStats->teamStats.size(); ++i)
       insertStatsTeam(query, &gameStats->teamStats[i], gameId);
 
    return gameId;
@@ -269,7 +269,7 @@ U64 DatabaseWriter::getServerID(const DbQuery &query, const string &serverName, 
 // the database each time we need to find one.  Server IDs should be unique for a given pair of server name and IP address.
 U64 DatabaseWriter::getServerIDFromCache(const string &serverName, const string &serverIP)
 {
-   for(S32 i = cachedServers.size() - 1; i >= 0; i--)    // Counting backwards to visit newest servers first
+   for(S32 i = cachedServers.size() - 1; i >= 0; --i)    // Counting backwards to visit newest servers first
       if(cachedServers[i].ip == serverIP && cachedServers[i].name == serverName)
          return cachedServers[i].id;
 
@@ -371,14 +371,14 @@ void DatabaseWriter::getTopPlayers(const string &table, const string &col2, S32 
 
    selectHandler(sql, 2, results);
 
-   for(S32 i = 0; i < results.size(); i++)
+   for(S32 i = 0; i < results.size(); ++i)
    {
       names.push_back(results[i][0]);
       scores.push_back(results[i][1]);
    }
 
    // Make sure we have the correct number of responses, even if table doesn't have enough records
-   for(S32 i = results.size(); i < count; i++)
+   for(S32 i = results.size(); i < count; ++i)
    {
       names.push_back("");
       scores.push_back("");
@@ -417,7 +417,7 @@ Vector<string> DatabaseWriter::getGameJoltCredentialStrings(const string &phpbbD
 
    Vector<string> credentialStrings(results.size());
 
-   for(S32 i = 0; i < results.size(); i++)
+   for(S32 i = 0; i < results.size(); ++i)
    {
       if(results[i][0] != "" && results[i][1] != "")
          credentialStrings.push_back("username="   + results[i][0] + "&"
@@ -491,7 +491,7 @@ Int<BADGE_COUNT> DatabaseWriter::getAchievements(const char *name)
 
    S32 badges = 0;
 
-   for(S32 i = 0; i < results.size(); i++)
+   for(S32 i = 0; i < results.size(); ++i)
       badges |= BIT(atoi(results[i][0].c_str()));
 
    return (Int<BADGE_COUNT>)badges;
@@ -528,11 +528,11 @@ void DatabaseWriter::selectHandler(const string &sql, S32 cols, Vector<Vector<st
 
          S32 rows = results.num_rows();
 
-         for(S32 i = 0; i < rows; i++)
+         for(S32 i = 0; i < rows; ++i)
          {
             values.push_back(Vector<string>());     // Add another row
 
-            for(S32 j = 0; j < cols; j++)
+            for(S32 j = 0; j < cols; ++j)
                values[i].push_back(string(results[i][j]));
          }
       }
@@ -551,7 +551,7 @@ void DatabaseWriter::selectHandler(const string &sql, S32 cols, Vector<Vector<st
          {
             values.push_back(Vector<string>());     // Add another row
 
-            for(S32 j = 0; j < cols; j++)
+            for(S32 j = 0; j < cols; ++j)
                values[i].push_back(results[cols + i + j]);
          }
 

--- a/master/master.cpp
+++ b/master/master.cpp
@@ -85,14 +85,14 @@ void MasterSettings::loadSettingsFromINI()
    // Read all settings defined in the new modern manner
    S32 sectionCount = ini.GetNumSections();
 
-   for(S32 i = 0; i < sectionCount; i++)
+   for(S32 i = 0; i < sectionCount; ++i)
    {
       string section = ini.getSectionName(i);
 
       // Enumerate all settings we've defined for [section]
       Vector<AbstractSetting *> settings = mSettings.getSettingsInSection(section);
 
-      for(S32 j = 0; j < settings.size(); j++)
+      for(S32 j = 0; j < settings.size(); ++j)
          settings[j]->setValFromString(ini.GetValue(section, settings[j]->getKey(), settings[j]->getDefaultValueString()));
    }
 
@@ -114,7 +114,7 @@ void MasterSettings::loadSettingsFromINI()
 
    motdClientMap.clear();
 
-   for(S32 i = 0; i < keys.size(); i++)
+   for(S32 i = 0; i < keys.size(); ++i)
    {
       U32 build_version = (U32)atoi(keys[i].c_str());    // Avoid conflicts with std::stoi() which is defined for VC++ 10
       string message = ini.GetValue("motd_clients", keys[i], upgradeMessage);
@@ -350,7 +350,7 @@ void MasterServer::idle(const U32 timeDelta)
    // Process connections -- cycle through them and check if any have timed out
    U32 currentTime = Platform::getRealMilliseconds();
 
-   for(S32 i = MasterServerConnection::gConnectList.size() - 1; i >= 0; i--)
+   for(S32 i = MasterServerConnection::gConnectList.size() - 1; i >= 0; --i)
    {
       GameConnectRequest *request = MasterServerConnection::gConnectList[i];
 
@@ -373,7 +373,7 @@ void MasterServer::idle(const U32 timeDelta)
    }
 
    // Process any delayed disconnects; we use this to avoid repeating and flooding join / leave messages
-   for(S32 i = MasterServerConnection::gLeaveChatTimerList.size() - 1; i >= 0; i--)
+   for(S32 i = MasterServerConnection::gLeaveChatTimerList.size() - 1; i >= 0; --i)
    {
       MasterServerConnection *c = MasterServerConnection::gLeaveChatTimerList[i];
 
@@ -387,7 +387,7 @@ void MasterServer::idle(const U32 timeDelta)
 
             const Vector<MasterServerConnection *> *clientList = getClientList();
 
-            for(S32 j = 0; j < clientList->size(); j++)
+            for(S32 j = 0; j < clientList->size(); ++j)
                if(clientList->get(j) != c && clientList->get(j)->isInGlobalChat)
                   clientList->get(j)->m2cPlayerLeftGlobalChat(c->mPlayerOrServerName);
 

--- a/master/phpbbhash.cpp
+++ b/master/phpbbhash.cpp
@@ -52,7 +52,7 @@ string PHPBB3Password::md5(string data) {
 	md5_process(&state, (const unsigned char *)data.c_str(), data.length());
 	md5_done(&state, hash);
 	string ret;
-	for (int i=0; i<16; i++) ret += hash[i];
+	for (int i=0; i<16; ++i) ret += hash[i];
 	return ret;
 }
 

--- a/tnl/bitStream.cpp
+++ b/tnl/bitStream.cpp
@@ -233,7 +233,8 @@ bool BitStream::writeFlag(bool val)
       *(getBuffer() + (bitNum >> 3)) |= (1 << (bitNum & 0x7));
    else
       *(getBuffer() + (bitNum >> 3)) &= ~(1 << (bitNum & 0x7));
-   bitNum++;
+   ++bitNum;
+
    return (val);
 }
 
@@ -509,7 +510,7 @@ void BitStream::writeString(const char *string, U8 maxLen)     // maxlen default
    if(!string)
       string = "";
    U8 j;
-   for(j = 0; j < maxLen && mStringBuffer[j] == string[j] && string[j];j++)
+   for(j = 0; j < maxLen && mStringBuffer[j] == string[j] && string[j];++j)
       ;  // do nothing
    strncpy(mStringBuffer + j, string + j, maxLen - j);
    mStringBuffer[maxLen] = 0;

--- a/tnl/byteBuffer.cpp
+++ b/tnl/byteBuffer.cpp
@@ -104,7 +104,7 @@ RefPtr<ByteBuffer> ByteBuffer::encodeBase16() const
    U8 *outBuffer = ret->getBuffer();
 
    S32 size = getBufferSize();
-   for(S32 i = 0; i < size; i++)
+   for(S32 i = 0; i < size; ++i)
    {
       U8 b = *buffer++;
       U32 nib1 = b >> 4;
@@ -128,7 +128,7 @@ RefPtr<ByteBuffer> ByteBuffer::decodeBase16() const
    ByteBuffer *ret = new ByteBuffer(outLen);
    const U8 *src = getBuffer();
    U8 *dst = ret->getBuffer();
-   for(U32 i = 0; i < outLen; i++)
+   for(U32 i = 0; i < outLen; ++i)
    {
       U8 out = 0;
       U8 nib1 = *src++;
@@ -172,10 +172,10 @@ U32 ByteBuffer::calculateCRC(U32 start, U32 end, U32 crcVal) const
    {
       U32 val;
 
-      for(S32 i = 0; i < 256; i++)
+      for(S32 i = 0; i < 256; ++i)
       {
          val = i;
-         for(S32 j = 0; j < 8; j++)
+         for(S32 j = 0; j < 8; ++j)
          {
             if(val & 0x01)
                val = 0xedb88320 ^ (val >> 1);
@@ -194,7 +194,7 @@ U32 ByteBuffer::calculateCRC(U32 start, U32 end, U32 crcVal) const
 
    // now calculate the crc
    const U8 * buf = getBuffer();
-   for(U32 i = start; i < end; i++)
+   for(U32 i = start; i < end; ++i)
       crcVal = crcTable[(crcVal ^ buf[i]) & 0xff] ^ (crcVal >> 8);
    return(crcVal);
 }

--- a/tnl/clientPuzzle.cpp
+++ b/tnl/clientPuzzle.cpp
@@ -37,7 +37,7 @@ void ClientPuzzleManager::NonceTable::reset()
    mChunker.freeBlocks();
    mHashTableSize = Random::readI(MinHashTableSize, MaxHashTableSize) * 2 + 1;
    mHashTable = (Entry **) mChunker.alloc(sizeof(Entry *) * mHashTableSize);
-   for(U32 i = 0; i < mHashTableSize; i++)
+   for(U32 i = 0; i < mHashTableSize; ++i)
       mHashTable[i] = NULL;
 }
 
@@ -127,7 +127,8 @@ bool ClientPuzzleManager::checkOneSolution(U32 solution, Nonce &clientNonce, Non
    {
       if(hash[index])
          return false;
-      index++;
+      ++index;
+
       puzzleDifficulty -= 8;
    }
    U8 mask = 0xFF << (8 - puzzleDifficulty);
@@ -161,7 +162,7 @@ bool ClientPuzzleManager::solvePuzzle(U32 *solution, Nonce &clientNonce, Nonce &
    for(;;)
    {
       U32 nextValue = startValue + SolutionFragmentIterations;
-      for(;startValue < nextValue; startValue++)
+      for(;startValue < nextValue; ++startValue)
       {
          if(checkOneSolution(startValue, clientNonce, serverNonce, puzzleDifficulty, clientIdentity))
          {

--- a/tnl/connectionStringTable.cpp
+++ b/tnl/connectionStringTable.cpp
@@ -37,7 +37,7 @@ static ClassChunker<ConnectionStringTable::PacketEntry> packetEntryFreeList(4096
 ConnectionStringTable::ConnectionStringTable(NetConnection *parent)
 {
    mParent = parent;
-   for(U32 i = 0; i < EntryCount; i++)
+   for(U32 i = 0; i < EntryCount; ++i)
    {
       mEntryTable[i].nextHash = NULL;
       mEntryTable[i].nextLink = &mEntryTable[i+1];

--- a/tnl/eventConnection.cpp
+++ b/tnl/eventConnection.cpp
@@ -277,7 +277,8 @@ void EventConnection::packetReceived(PacketNotify *pnotify)
    }
    while(mNotifyEventList && mNotifyEventList->mSeqCount == mLastAckedEventSeq + 1)
    {
-      mLastAckedEventSeq++;
+      ++mLastAckedEventSeq;
+
       EventNote *next = mNotifyEventList->mNextEvent;
       logprintf(LogConsumer::LogEventConnection, "EventConnection %s: NotifyDelivered - %d", getNetAddressString(), mNotifyEventList->mSeqCount);
       mNotifyEventList->mEvent->notifyDelivered(this, true);
@@ -412,8 +413,9 @@ void EventConnection::writePacket(BitStream *bstream, PacketNotify *pnotify)
          {
             TNLAssertV(false, ("%s Packet too big to send, one or more events may be unable to send", ev->mEvent->getDebugName()));
             for(EventNote *walk = ev->mNextEvent; walk; walk = walk->mNextEvent)
-               walk->mSeqCount--;    // removing a GuaranteedOrdered needs to re-order mSeqCount
-            mNextSendEventSeq--;
+               --walk->mSeqCount;    // removing a GuaranteedOrdered needs to re-order mSeqCount
+            --mNextSendEventSeq;
+
 
             // dequeue the event:
             mSendEventQueueHead = ev->mNextEvent;
@@ -509,7 +511,8 @@ void EventConnection::readPacket(BitStream *bstream)
    }
    while(mWaitSeqEvents && mWaitSeqEvents->mSeqCount == mNextRecvEventSeq)
    {
-      mNextRecvEventSeq++;
+      ++mNextRecvEventSeq;
+
       EventNote *temp = mWaitSeqEvents;
       mWaitSeqEvents = temp->mNextEvent;
       

--- a/tnl/ghostConnection.cpp
+++ b/tnl/ghostConnection.cpp
@@ -83,7 +83,7 @@ void GhostConnection::setGhostFrom(bool ghostFrom)
       if(!mGhostLookupTable)
       {
          mGhostLookupTable = new GhostInfo *[GhostLookupTableSize];
-         for(i = 0; i < GhostLookupTableSize; i++)
+         for(i = 0; i < GhostLookupTableSize; ++i)
             mGhostLookupTable[i] = 0;
       }
    }
@@ -200,7 +200,7 @@ void GhostConnection::prepareWritePacket()
 
    if(mGhostFreeIndex > MaxGhostCount - 10)  // almost running out of GhostFreeIndex, free some objects not in scope.
    {
-      for(S32 i = mGhostZeroUpdateIndex; i < mGhostFreeIndex; i++)
+      for(S32 i = mGhostZeroUpdateIndex; i < mGhostFreeIndex; ++i)
       {
          GhostInfo *walk = mGhostArray[i];
          if(!(walk->flags & GhostInfo::ScopeLocalAlways))
@@ -224,11 +224,12 @@ void GhostConnection::prepareWritePacket()
    // If the object has a zero update mask, we wait to remove it until it requests
    // an update.
 
-   for(S32 i = 0; i < mGhostZeroUpdateIndex; i++)
+   for(S32 i = 0; i < mGhostZeroUpdateIndex; ++i)
    {
       // Increment the updateSkip for everyone... it's all good
       GhostInfo *walk = mGhostArray[i];
-      walk->updateSkipCount++;
+      ++walk->updateSkipCount;
+
       if(!(walk->flags & (GhostInfo::ScopeLocalAlways)))
          walk->flags &= ~GhostInfo::InScope;
    }
@@ -269,14 +270,14 @@ void GhostConnection::writePacket(BitStream *bstream, PacketNotify *pnotify)
 
    GhostInfo *walk;
 
-   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0; i--)
+   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0; --i)
    {
       if(!(mGhostArray[i]->flags & GhostInfo::InScope))
          detachObject(mGhostArray[i]);
    }
 
    U32 maxIndex = 0;
-   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0; i--)
+   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0; --i)
    {
       walk = mGhostArray[i];
       if(walk->index > maxIndex)
@@ -304,14 +305,15 @@ void GhostConnection::writePacket(BitStream *bstream, PacketNotify *pnotify)
    if(mGhostZeroUpdateIndex != 0)
       qsort(&mGhostArray[0], mGhostZeroUpdateIndex, sizeof(GhostInfo *), UQECompare);
    // reset the array indices...
-   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0; i--)
+   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0; --i)
       mGhostArray[i]->arrayIndex = i;
 
    U8 sendSize = 0;
    while(maxIndex != 0)
    {
       maxIndex >>= 1;
-      sendSize++;
+      ++sendSize;
+
    }
 
    if(sendSize < ID_BIT_OFFSET)
@@ -321,7 +323,7 @@ void GhostConnection::writePacket(BitStream *bstream, PacketNotify *pnotify)
 
    U32 count = 0;
    bool have_something_to_send = bstream->getBitPosition() >= 256;
-   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0 && !bstream->isFull(); i--)
+   for(S32 i = mGhostZeroUpdateIndex - 1; i >= 0 && !bstream->isFull(); --i)
    {
       GhostInfo *walk = mGhostArray[i];
       if(walk->flags & (GhostInfo::KillingGhost | GhostInfo::Ghosting))
@@ -426,7 +428,8 @@ void GhostConnection::writePacket(BitStream *bstream, PacketNotify *pnotify)
             ghostPushToZero(walk);
          upd->mask = updateMask & ~retMask;
          walk->updateSkipCount = 0;
-         count++;
+         ++count;
+
       }
    }
    // count # of ghosts have been updated,
@@ -647,7 +650,7 @@ bool GhostConnection::validateGhostArray()
       TNLAssert(mGhostArray[i]->arrayIndex == i, "Invalid array index.");
       TNLAssert(mGhostArray[i]->updateMask == 0, "Invalid ghost mask.");
    }
-   for(; i < mGhostArray.size(); i++)
+   for(; i < mGhostArray.size(); ++i)
    {
       TNLAssert(mGhostArray[i]->arrayIndex == i, "Invalid array index.");
    }
@@ -726,7 +729,8 @@ void GhostConnection::activateGhosting()
    if(!doesGhostFrom())    // Leave if we have no objects to ghost to the remote host
       return;
 
-   mGhostingSequence++;
+   ++mGhostingSequence;
+
    logprintf(LogConsumer::LogGhostConnection, "Ghosting activated - %d", mGhostingSequence);
 
    TNLAssert((mGhostFreeIndex == 0) && (mGhostZeroUpdateIndex == 0), "Error: ghosts in the ghost list before activate.");
@@ -786,7 +790,7 @@ void GhostConnection::deleteLocalGhosts()
 
    // just delete all the local ghosts,
    // and delete all the ghosts in the current save list
-   for(S32 i = 0; i < mLocalGhosts.size(); i++)
+   for(S32 i = 0; i < mLocalGhosts.size(); ++i)
    {
       if(mLocalGhosts[i])
       {
@@ -823,7 +827,7 @@ void GhostConnection::clearGhostInfo()
    }
    TNLAssert((mGhostFreeIndex == 0) && (mGhostZeroUpdateIndex == 0), "Invalid indices.");
 
-   for(U32 j = 0; j < U32(mGhostRefs.size()); j++)
+   for(U32 j = 0; j < U32(mGhostRefs.size()); ++j)
       delete mGhostRefs[j];
    mGhostRefs.clear();
    mGhostArray.clear();
@@ -839,7 +843,8 @@ void GhostConnection::resetGhosting()
    mGhosting = false;
    mScoping = false;
    rpcEndGhosting();
-   mGhostingSequence++;
+   ++mGhostingSequence;
+
    clearGhostInfo();
    //TNLAssert(validateGhostArray(), "Invalid ghost array!");
 }

--- a/tnl/huffmanStringProcessor.cpp
+++ b/tnl/huffmanStringProcessor.cpp
@@ -91,7 +91,7 @@ void HuffmanStringProcessor::buildTables()
    mHuffLeaves.resize(256);
    mHuffNodes.reserve(256);
    mHuffNodes.resize(mHuffNodes.size() + 1);
-   for (i = 0; i < 256; i++) {
+   for (i = 0; i < 256; ++i) {
       HuffLeaf& rLeaf = mHuffLeaves[i];
 
       rLeaf.pop    = mCharFreqs[i] + 1;
@@ -103,7 +103,7 @@ void HuffmanStringProcessor::buildTables()
 
    S32 currWraps = 256;
    HuffWrap* pWrap = new HuffWrap[256];
-   for (i = 0; i < 256; i++) {
+   for (i = 0; i < 256; ++i) {
       pWrap[i].set(&mHuffLeaves[i]);
    }
 
@@ -111,7 +111,7 @@ void HuffmanStringProcessor::buildTables()
       U32 min1 = 0xfffffffe, min2 = 0xffffffff;
       S32 index1 = -1, index2 = -1;
 
-      for (i = 0; i < currWraps; i++) {
+      for (i = 0; i < currWraps; ++i) {
          if (pWrap[i].getPop() < min1) {
             min2   = min1;
             index2 = index1;
@@ -139,7 +139,8 @@ void HuffmanStringProcessor::buildTables()
       if (index2 != (currWraps - 1)) {
          pWrap[nukeIndex] = pWrap[currWraps - 1];
       }
-      currWraps--;
+      --currWraps;
+
    }
    TNLAssert(currWraps == 1, "wrong wraps?");
    TNLAssert(pWrap[0].pNode != NULL && pWrap[0].pLeaf == NULL, "Wrong wrap type!");
@@ -199,7 +200,7 @@ bool HuffmanStringProcessor::readHuffBuffer(BitStream* pStream, char* out_pBuffe
 
    if (pStream->readFlag()) {
       U32 len = pStream->readInt(8);
-      for (U32 i = 0; i < len; i++) {
+      for (U32 i = 0; i < len; ++i) {
          S32 index = 0;
          while (true) {
             if (index >= 0) {
@@ -243,7 +244,7 @@ bool HuffmanStringProcessor::writeHuffBuffer(BitStream* pStream, const char* out
 
    U32 numBits = 0;
    U32 i;
-   for (i = 0; i < len; i++)
+   for (i = 0; i < len; ++i)
       numBits += mHuffLeaves[(unsigned char)out_pBuffer[i]].numBits;
 
    if (numBits >= (len * 8)) {
@@ -253,7 +254,7 @@ bool HuffmanStringProcessor::writeHuffBuffer(BitStream* pStream, const char* out
    } else {
       pStream->writeFlag(true);
       pStream->writeInt(len, 8);
-      for (i = 0; i < len; i++) {
+      for (i = 0; i < len; ++i) {
          HuffLeaf& rLeaf = mHuffLeaves[((unsigned char)out_pBuffer[i])];
          pStream->writeBits(rLeaf.numBits, &rLeaf.code);
       }

--- a/tnl/journal.cpp
+++ b/tnl/journal.cpp
@@ -73,13 +73,14 @@ U32 JournalBlockTypeToken::getValue()
       vec.sort(JBTTCompare);
       U32 lastValue = 0;
       const char *lastString = "";
-      for(S32 i = 0; i < vec.size(); i++)
+      for(S32 i = 0; i < vec.size(); ++i)
       {
          if(!strcmp(vec[i]->mString, lastString))
             vec[i]->mValue = lastValue;
          else
          {
-            lastValue++;
+            ++lastValue;
+
             vec[i]->mValue = lastValue;
             lastString = vec[i]->mString;
          }
@@ -102,7 +103,7 @@ JournalEntryRecord::JournalEntryRecord(const char *functionName)
    if(!mEntryVector)
       mEntryVector = new Vector<JournalEntryRecord *>;
 
-   for(i = 0; i < mEntryVector->size(); i++)
+   for(i = 0; i < mEntryVector->size(); ++i)
    {
       if(strcmp((*mEntryVector)[i]->mFunctionName, functionName) < 0)
          break;
@@ -219,7 +220,7 @@ void Journal::callEntry(const char *funcName, Functor *theCall)
    mInsideEntrypoint = true;
 
    S32 entryIndex;
-   for(entryIndex = 0; entryIndex < JournalEntryRecord::mEntryVector->size(); entryIndex++)
+   for(entryIndex = 0; entryIndex < JournalEntryRecord::mEntryVector->size(); ++entryIndex)
    {
       if(!strcmp((*JournalEntryRecord::mEntryVector)[entryIndex]->mFunctionName, funcName))
          break;
@@ -266,7 +267,8 @@ void Journal::beginBlock(U32 blockId, bool writeBlock)
    }
    else
    {
-      mBlockIndex++;
+      ++mBlockIndex;
+
       if(mBreakBlockIndex && mBlockIndex >= mBreakBlockIndex)
          TNL_DEBUGBREAK();
 

--- a/tnl/netBase.cpp
+++ b/tnl/netBase.cpp
@@ -102,10 +102,10 @@ void NetClassRep::initialize()
       
    NetClassRep *walk;
    
-   for(U32 group = 0; group < NetClassGroupCount; group++)
+   for(U32 group = 0; group < NetClassGroupCount; ++group)
    {
       U32 groupMask = 1 << group;
-      for(U32 type = 0; type < NetClassTypeCount; type++)
+      for(U32 type = 0; type < NetClassTypeCount; ++type)
       {
          for(walk = mClassLinkList; walk; walk = walk->mNextClass)
          {
@@ -121,12 +121,12 @@ void NetClassRep::initialize()
          logprintf(LogConsumer::LogNetBase, "Class Group: %d (%s) Class Type: %d (%s)  Count: %d", 
                                             group, NetClassGroupNames[group], type, NetClassTypeNames[type], dynamicTable.size());
 
-         for(S32 i = 0; i < dynamicTable.size(); i++)
+         for(S32 i = 0; i < dynamicTable.size(); ++i)
             logprintf(LogConsumer::LogNetBase, "\tClass %d: %s", i + 1, dynamicTable[i]->getClassName());
 
          mClassTable[group][type] = dynamicTable;
    
-         for(S32 i = 0; i < mClassTable[group][type].size(); i++)
+         for(S32 i = 0; i < mClassTable[group][type].size(); ++i)
             mClassTable[group][type][i]->mClassId[group] = i;
 
          mNetClassBitSize[group][type] = 

--- a/tnl/netConnection.cpp
+++ b/tnl/netConnection.cpp
@@ -191,7 +191,8 @@ bool NetConnection::checkTimeout(U32 time)
          if(mPingSendCount >= timeoutCount)
             return true;
       mLastPingSendTime = time;
-      mPingSendCount++;
+      ++mPingSendCount;
+
       sendPingPacket();
    }
    return false;
@@ -249,7 +250,8 @@ void NetConnection::writeRawPacket(BitStream *bstream, NetPacketType packetType)
    }
    mPacketSendBytesLast = bstream->getBytePosition();
    mPacketSendBytesTotal += mPacketSendBytesLast;
-   mPacketSendCount++;
+   ++mPacketSendCount;
+
 }
 
 void NetConnection::readRawPacket(BitStream *bstream)
@@ -261,7 +263,8 @@ void NetConnection::readRawPacket(BitStream *bstream)
    }
    mPacketRecvBytesLast = bstream->getMaxReadBitPosition() >> 3;
    mPacketRecvBytesTotal += mPacketRecvBytesLast;
-   mPacketRecvCount++;
+   ++mPacketRecvCount;
+
    logprintf(LogConsumer::LogNetConnection, "NetConnection %s: RECV- %d bytes", mNetAddress.toString(), mPacketRecvBytesLast);
 
    mErrorBuffer[0] = 0;
@@ -295,7 +298,8 @@ void NetConnection::writePacketHeader(BitStream *stream, NetPacketType packetTyp
    TNLAssert(ackByteCount <= MaxAckByteCount, "ackByteCount exceeds MaxAckByteCount!");
    
    if(packetType == DataPacket)
-      mLastSendSeq++;
+      ++mLastSendSeq;
+
       
    stream->writeInt(packetType, 2);
    stream->writeInt(mLastSendSeq, 5); // write the first 5 bits of the send sequence
@@ -308,7 +312,7 @@ void NetConnection::writePacketHeader(BitStream *stream, NetPacketType packetTyp
 
    U32 wordCount = (ackByteCount + 3) >> 2;
 
-   for(U32 i = 0; i < wordCount; i++)
+   for(U32 i = 0; i < wordCount; ++i)
       stream->writeInt(mAckMask[i], i == wordCount - 1 ?
          (ackByteCount - (i * 4)) * 8 : 32);
    
@@ -417,7 +421,7 @@ bool NetConnection::readPacketHeader(BitStream *pstream)
    U32 pkAckMask[MaxAckMaskSize];
    U32 pkAckWordCount = (pkAckByteCount + 3) >> 2;
 
-   for(U32 i = 0; i < pkAckWordCount; i++)
+   for(U32 i = 0; i < pkAckWordCount; ++i)
       pkAckMask[i] = pstream->readInt(i == pkAckWordCount - 1 ? 
             (pkAckByteCount - (i * 4)) * 8 : 32);
 
@@ -429,9 +433,10 @@ bool NetConnection::readPacketHeader(BitStream *pstream)
 
    U32 pkSendDelay = (pstream->readInt(8) << 3) + 4;
 
-   for(U32 i = mLastSeqRecvd+1; i < pkSequenceNumber; i++)
+   for(U32 i = mLastSeqRecvd+1; i < pkSequenceNumber; ++i)
    {
-      mPacketRecvDropped++;
+      ++mPacketRecvDropped;
+
       logprintf(LogConsumer::LogConnectionProtocol, "Not recv %d", i);
    }
 
@@ -445,7 +450,7 @@ bool NetConnection::readPacketHeader(BitStream *pstream)
    // if we've missed more than a full word of packets, shift up by words
    while(ackMaskShift > 32)
    {
-      for(S32 i = MaxAckMaskSize - 1; i > 0; i--)
+      for(S32 i = MaxAckMaskSize - 1; i > 0; --i)
          mAckMask[i] = mAckMask[i-1];
       mAckMask[0] = 0;
       ackMaskShift -= 32;
@@ -455,7 +460,7 @@ bool NetConnection::readPacketHeader(BitStream *pstream)
    // 1 if this is a data packet (i.e. not a ping packet or an ack packet)
    U32 upShifted = (pkPacketType == DataPacket) ? 1 : 0; 
 
-   for(U32 i = 0; i < MaxAckMaskSize; i++)
+   for(U32 i = 0; i < MaxAckMaskSize; ++i)
    {
       U32 nextShift = mAckMask[i] >> (32 - ackMaskShift);
       mAckMask[i] = (mAckMask[i] << ackMaskShift) | upShifted;
@@ -464,7 +469,7 @@ bool NetConnection::readPacketHeader(BitStream *pstream)
 
    // do all the notifies...
    U32 notifyCount = pkHighestAck - mHighestAckedSeq;
-   for(U32 i = 0; i < notifyCount; i++) 
+   for(U32 i = 0; i < notifyCount; ++i) 
    {
       U32 notifyIndex = mHighestAckedSeq + i + 1;
 
@@ -634,7 +639,8 @@ void NetConnection::handleNotify(U32 sequence, bool recvd)
          if(cwnd < ssthresh)
          {
             // Slow start strategy
-            cwnd++;
+            ++cwnd;
+
             logprintf(LogConsumer::LogNetConnection, "PKT SSOK - ssthresh = %f     cwnd=%f", ssthresh, cwnd);
 
          } else {
@@ -655,7 +661,8 @@ void NetConnection::handleNotify(U32 sequence, bool recvd)
       {
          // Deal with updating our cwnd and ssthresh...
          ssthresh = (0.5f * ssthresh < 2) ? 2 : (0.5f * ssthresh);
-         cwnd -= 1;
+         --cwnd;
+
          if(cwnd < 2) cwnd = 2;
 
 /*         logprintf(LogConsumer::LogNetConnection, "  * ack=%f   pktDt=%d    time=%f (%d)     seq=%d %d %d %d",
@@ -672,7 +679,8 @@ void NetConnection::handleNotify(U32 sequence, bool recvd)
       }
 
       packetDropped(note);
-      mPacketSendDropped++;
+      ++mPacketSendDropped;
+
    }
    delete note;
 }

--- a/tnl/netInterface.cpp
+++ b/tnl/netInterface.cpp
@@ -53,7 +53,7 @@ NetInterface::NetInterface(const Address &bindAddress) : mSocket(bindAddress)
    Random::read(mRandomHashData, sizeof(mRandomHashData));
 
    mConnectionHashTable.resize(129);
-   for(S32 i = 0; i < mConnectionHashTable.size(); i++)
+   for(S32 i = 0; i < mConnectionHashTable.size(); ++i)
       mConnectionHashTable[i] = NULL;
    mSendPacketList = NULL;
    mCurrentTime = Platform::getRealMilliseconds();
@@ -176,7 +176,7 @@ void NetInterface::addPendingConnection(NetConnection *connection)
 // Search the pending connection list for the specified connection and remove it
 void NetInterface::removePendingConnection(NetConnection *connection)
 {
-   for(S32 i = 0; i < mPendingConnections.size(); i++)
+   for(S32 i = 0; i < mPendingConnections.size(); ++i)
       if(mPendingConnections[i] == connection)
       {
          connection->decRef();
@@ -189,7 +189,7 @@ void NetInterface::removePendingConnection(NetConnection *connection)
 NetConnection *NetInterface::findPendingConnection(const Address &address)
 {
    // Loop through all the pending connections and compare the NetAddresses
-   for(S32 i = 0; i < mPendingConnections.size(); i++)
+   for(S32 i = 0; i < mPendingConnections.size(); ++i)
       if(address == mPendingConnections[i]->getNetAddress())
          return mPendingConnections[i];
    return NULL;
@@ -199,7 +199,7 @@ void NetInterface::findAndRemovePendingConnection(const Address &address)
 {
    // Search through the list by Address and remove any connection
    // that matches.
-   for(S32 i = 0; i < mPendingConnections.size(); i++)
+   for(S32 i = 0; i < mPendingConnections.size(); ++i)
       if(address == mPendingConnections[i]->getNetAddress())
       {
          mPendingConnections[i]->decRef();
@@ -227,7 +227,8 @@ NetConnection *NetInterface::findConnection(const Address &addr)
    {
       if(addr == mConnectionHashTable[hashIndex]->getNetAddress())
          return mConnectionHashTable[hashIndex];
-      hashIndex++;
+      ++hashIndex;
+
       if(hashIndex >= (U32) mConnectionHashTable.size())
          hashIndex = 0;
    }
@@ -236,7 +237,7 @@ NetConnection *NetInterface::findConnection(const Address &addr)
 
 void NetInterface::removeConnection(NetConnection *conn)
 {
-   for(S32 i = 0; i < mConnectionList.size(); i++)
+   for(S32 i = 0; i < mConnectionList.size(); ++i)
    {
       if(mConnectionList[i] == conn)
       {
@@ -249,7 +250,8 @@ void NetInterface::removeConnection(NetConnection *conn)
 
    while(mConnectionHashTable[index] != conn)
    {
-      index++;
+      ++index;
+
       if(index >= (U32) mConnectionHashTable.size())
          index = 0;
       TNLAssert(index != startIndex, "Attempting to remove a connection that is not in the table."); // not in the table
@@ -261,7 +263,8 @@ void NetInterface::removeConnection(NetConnection *conn)
    // rehash all subsequent entries until we find a NULL entry:
    for(;;)
    {
-      index++;
+      ++index;
+
       if(index >= (U32) mConnectionHashTable.size())
          index = 0;
       if(!mConnectionHashTable[index])
@@ -271,7 +274,8 @@ void NetInterface::removeConnection(NetConnection *conn)
       U32 realIndex = rehashConn->getNetAddress().hash() % mConnectionHashTable.size();
       while(mConnectionHashTable[realIndex] != NULL)
       {
-         realIndex++;
+         ++realIndex;
+
          if(realIndex >= (U32) mConnectionHashTable.size())
             realIndex = 0;
       }
@@ -290,15 +294,16 @@ void NetInterface::addConnection(NetConnection *conn)
    if(numConnections > mConnectionHashTable.size() / 2)
    {
       mConnectionHashTable.resize(numConnections * 4 - 1);
-      for(S32 i = 0; i < mConnectionHashTable.size(); i++)
+      for(S32 i = 0; i < mConnectionHashTable.size(); ++i)
          mConnectionHashTable[i] = NULL;
 
-      for(S32 i = 0; i < numConnections; i++)
+      for(S32 i = 0; i < numConnections; ++i)
       {
          U32 index = mConnectionList[i]->getNetAddress().hash() % mConnectionHashTable.size();
          while(mConnectionHashTable[index] != NULL)
          {
-            index++;
+            ++index;
+
             if(index >= (U32) mConnectionHashTable.size())
                index = 0;
          }
@@ -310,7 +315,8 @@ void NetInterface::addConnection(NetConnection *conn)
       U32 index = mConnectionList[numConnections - 1]->getNetAddress().hash() % mConnectionHashTable.size();
       while(mConnectionHashTable[index] != NULL)
       {
-         index++;
+         ++index;
+
          if(index >= (U32) mConnectionHashTable.size())
             index = 0;
       }
@@ -353,7 +359,7 @@ void NetInterface::processConnections()
    }
 
    NetObject::collapseDirtyList(); // collapse all the mask bits...
-   for(S32 i = 0; i < mConnectionList.size(); i++)
+   for(S32 i = 0; i < mConnectionList.size(); ++i)
       mConnectionList[i]->checkPacketSend(false, getCurrentTime());
 
    if(U32(getCurrentTime() - mLastTimeoutCheckTime) > TimeoutCheckInterval)
@@ -413,7 +419,8 @@ void NetInterface::processConnections()
             pending->onConnectTerminated(NetConnection::ReasonTimedOut, "Timeout");
             removePendingConnection(pending);
          }
-         i++;
+         ++i;
+
       }
       mLastTimeoutCheckTime = getCurrentTime();
 
@@ -426,12 +433,13 @@ void NetInterface::processConnections()
             removeConnection(mConnectionList[i]);
          }
          else
-            i++;
+            ++i;
+
       }
    }
 
    // check if we're trying to solve any client connection puzzles
-   for(S32 i = 0; i < mPendingConnections.size(); i++)
+   for(S32 i = 0; i < mPendingConnections.size(); ++i)
    {
       if(mPendingConnections[i]->getConnectionState() == NetConnection::ComputingPuzzleSolution)
       {
@@ -553,7 +561,8 @@ void NetInterface::sendConnectChallengeRequest(NetConnection *conn)
    out.writeFlag(params.mRequestKeyExchange);
    out.writeFlag(params.mRequestCertificate);
 
-   conn->mConnectSendCount++;
+   ++conn->mConnectSendCount;
+
    conn->mConnectLastSendTime = getCurrentTime();
    out.sendto(mSocket, conn->getNetAddress());
 }
@@ -730,7 +739,8 @@ void NetInterface::sendConnectRequest(NetConnection *conn)
       out.hashAndEncrypt(NetConnection::MessageSignatureBytes, encryptPos, &theCipher);
    }
 
-   conn->mConnectSendCount++;
+   ++conn->mConnectSendCount;
+
    conn->mConnectLastSendTime = getCurrentTime();
 
    out.sendto(mSocket, conn->getNetAddress());
@@ -1021,7 +1031,7 @@ void NetInterface::sendPunchPackets(NetConnection *conn)
    SymmetricCipher theCipher(theParams.mArrangedSecret);
    out.hashAndEncrypt(NetConnection::MessageSignatureBytes, encryptPos, &theCipher);
 
-   for(S32 i = 0; i < theParams.mPossibleAddresses.size(); i++)
+   for(S32 i = 0; i < theParams.mPossibleAddresses.size(); ++i)
    {
       out.sendto(mSocket, theParams.mPossibleAddresses[i]);
 
@@ -1030,7 +1040,8 @@ void NetInterface::sendPunchPackets(NetConnection *conn)
          ByteBuffer(theParams.mServerNonce.data, Nonce::NonceSize).encodeBase64()->getBuffer(),
          theParams.mPossibleAddresses[i].toString());
    }
-   conn->mConnectSendCount++;
+   ++conn->mConnectSendCount;
+
    conn->mConnectLastSendTime = getCurrentTime();
 }
 
@@ -1048,7 +1059,7 @@ void NetInterface::handlePunch(const Address &theAddress, BitStream *stream)
 
    U32 streamPos = stream->getBitPosition();
 
-   for(i = 0; i < mPendingConnections.size(); i++)
+   for(i = 0; i < mPendingConnections.size(); ++i)
    {
       conn = mPendingConnections[i];
       ConnectionParameters &theParams = conn->getConnectionParameters();
@@ -1062,7 +1073,7 @@ void NetInterface::handlePunch(const Address &theAddress, BitStream *stream)
 
       // first see if the address is in the possible addresses list:
 
-      for(j = 0; j < theParams.mPossibleAddresses.size(); j++)
+      for(j = 0; j < theParams.mPossibleAddresses.size(); ++j)
          if(theAddress == theParams.mPossibleAddresses[j])
             break;
 
@@ -1071,7 +1082,7 @@ void NetInterface::handlePunch(const Address &theAddress, BitStream *stream)
       // we'll want to send a punch to the address it came from, as long
       // as only the port is not an exact match:
       if(j == theParams.mPossibleAddresses.size())
-         for(j = 0; j < theParams.mPossibleAddresses.size(); j++)
+         for(j = 0; j < theParams.mPossibleAddresses.size(); ++j)
             if(theAddress.isEqualAddress(theParams.mPossibleAddresses[j]))
             {
                // as long as we don't have too many ping addresses,
@@ -1186,7 +1197,8 @@ void NetInterface::sendArrangedConnectRequest(NetConnection *conn)
    SymmetricCipher theCipher(theParams.mArrangedSecret);
    out.hashAndEncrypt(NetConnection::MessageSignatureBytes, encryptPos, &theCipher);
 
-   conn->mConnectSendCount++;
+   ++conn->mConnectSendCount;
+
    conn->mConnectLastSendTime = getCurrentTime();
 
    out.sendto(mSocket, conn->getNetAddress());
@@ -1216,7 +1228,7 @@ void NetInterface::handleArrangedConnectRequest(const Address &theAddress, BitSt
       }
    }
 
-   for(i = 0; i < mPendingConnections.size(); i++)
+   for(i = 0; i < mPendingConnections.size(); ++i)
    {
       conn = mPendingConnections[i];
       ConnectionParameters &theParams = conn->getConnectionParameters();
@@ -1227,7 +1239,7 @@ void NetInterface::handleArrangedConnectRequest(const Address &theAddress, BitSt
       if(nonce != theParams.mNonce)
          continue;
 
-      for(j = 0; j < theParams.mPossibleAddresses.size(); j++)
+      for(j = 0; j < theParams.mPossibleAddresses.size(); ++j)
          if(theAddress.isEqualAddress(theParams.mPossibleAddresses[j]))
             break;
       if(j != theParams.mPossibleAddresses.size())

--- a/tnl/netObject.cpp
+++ b/tnl/netObject.cpp
@@ -152,7 +152,7 @@ void NetObject::collapseDirtyList()
       obj = next;
    }
    mDirtyList = NULL;
-   for(S32 i = 0; i < tempV.size(); i++)
+   for(S32 i = 0; i < tempV.size(); ++i)
    {
       TNLAssert(tempV[i]->mNextDirtyList == NULL && tempV[i]->mPrevDirtyList == NULL && tempV[i]->mDirtyMaskBits == 0, "Error in collapse");
    }

--- a/tnl/netStringTable.cpp
+++ b/tnl/netStringTable.cpp
@@ -105,7 +105,7 @@ U8   sgToLowerTable[256];
 
 void initToLowerTable()
 {
-   for (U32 i = 0; i < 256; i++) {
+   for (U32 i = 0; i < 256; ++i) {
       U8 c = dTolower(i);
       sgToLowerTable[i] = c * c;
    }
@@ -148,14 +148,14 @@ void init()
 {
    mMemPool = new DataChunker;
    mBuckets = (StringTableEntryId *) malloc(InitialHashTableSize * sizeof(StringTableEntryId));
-   for(U32 i = 0; i < InitialHashTableSize; i++)
+   for(U32 i = 0; i < InitialHashTableSize; ++i)
       mBuckets[i] = 0;
 
    mNumBuckets = InitialHashTableSize;
    mItemCount = 0;
 
    mNodeList = (Node **) malloc(InitialNodeListSize * sizeof(Node *));
-   for(U32 i = 1; i < InitialNodeListSize; i++)
+   for(U32 i = 1; i < InitialNodeListSize; ++i)
       mNodeList[i] = (Node *) (size_t)(( (i + 1) << 1) | 1); // see the doco in stringTable.h for how free list entries are coded
 
    mNodeList[InitialNodeListSize - 1] = NULL;
@@ -195,10 +195,11 @@ void validate()
 {
    // count all the nodes in the node list:
    U32 nodeCount = 0;
-   for(U32 i = 0; i < mNodeListSize; i++)
+   for(U32 i = 0; i < mNodeListSize; ++i)
    {
       if(mNodeList[i] && !(StringTableEntryId(mNodeList[i]) & 1))
-        nodeCount++;
+        ++nodeCount;
+
    }
    TNLAssert(nodeCount == mItemCount, "Error!!!");
    U32 freeListCount = 0;
@@ -208,13 +209,14 @@ void validate()
       walk = StringTableEntryId(mNodeList[walk >> 1]);
       if(!((walk >> 1) < mNodeListSize))
          TNLAssert((walk >> 1) < mNodeListSize, "Out of range node index!!!");
-      freeListCount++;
+      ++freeListCount;
+
    }
    TNLAssert(freeListCount + nodeCount == mNodeListSize, "Error!!!!");
    // walk through all the bucket chains...
    // and make sure there are no free entries...
 
-   for(U32 i = 0; i < mNumBuckets; i++)
+   for(U32 i = 0; i < mNumBuckets; ++i)
    {
       StringTableEntryId walk = mBuckets[i];
       while(walk)
@@ -248,7 +250,8 @@ StringTableEntryId insertn(const char* val, U32 len, const bool caseSens)
          (!caseSens && !strnicmp(stringNode->stringData, val, len) && stringNode->stringData[len] == 0) )
       {
          // the string was found, so bump the reference count and return the node id
-         stringNode->refCount++;
+         ++stringNode->refCount;
+
          return *walk;
       }
       // step to the next node in the hash bucket.
@@ -263,7 +266,7 @@ StringTableEntryId insertn(const char* val, U32 len, const bool caseSens)
       U32 oldNodeListSize = mNodeListSize;
       mNodeListSize += InitialNodeListSize;
       mNodeList = (Node **) realloc(mNodeList, mNodeListSize * sizeof(Node *));
-      for(U32 i = oldNodeListSize; i < mNodeListSize; i++)
+      for(U32 i = oldNodeListSize; i < mNodeListSize; ++i)
          mNodeList[i] = (Node *) (size_t) (((i + 1) << 1) | 1);
       mNodeList[mNodeListSize - 1] = 0;
       mNodeListFreeEntry = (size_t) ((oldNodeListSize << 1) | 1);
@@ -284,7 +287,8 @@ StringTableEntryId insertn(const char* val, U32 len, const bool caseSens)
 
    strcpy(stringNode->stringData, val);
    stringNode->stringData[len] = 0;    // Null terminate
-   mItemCount++;
+   ++mItemCount;
+
 
    // Check for hash table resize
    if(mItemCount > 2 * mNumBuckets) {
@@ -342,7 +346,7 @@ void resizeHashTable(const U32 newSize)
    // lists so that case sens strings are always after their
    // corresponding case insens strings
 
-   for(i = 0; i < mNumBuckets; i++) {
+   for(i = 0; i < mNumBuckets; ++i) {
       walk = mBuckets[i];
       while(walk)
       {
@@ -353,7 +357,7 @@ void resizeHashTable(const U32 newSize)
       }
    }
    mBuckets = (StringTableEntryId *) realloc(mBuckets, newSize * sizeof(StringTableEntryId));
-   for(i = 0; i < newSize; i++) {
+   for(i = 0; i < newSize; ++i) {
       mBuckets[i] = 0;
    }
    mNumBuckets = newSize;
@@ -373,7 +377,7 @@ void resizeHashTable(const U32 newSize)
 void compact()
 {
    DataChunker *newData = new DataChunker;
-   for(U32 i = 1; i < mNodeListSize; i++)
+   for(U32 i = 1; i < mNodeListSize; ++i)
    {
       Node *theNode, *newNode;
       theNode = mNodeList[i];
@@ -399,7 +403,8 @@ void compact()
 
 void incRef(StringTableEntryId index)
 {
-    mNodeList[index]->refCount++;
+    ++mNodeList[index]->refCount;
+
 }
 
 void decRef(StringTableEntryId index)
@@ -428,7 +433,8 @@ void decRef(StringTableEntryId index)
 
    if(mFreeStringDataSize > CompactThreshold)
       compact();
-   mItemCount--;
+   --mItemCount;
+
    if(!mItemCount)
       destroy();
 }

--- a/tnl/platform.cpp
+++ b/tnl/platform.cpp
@@ -366,6 +366,9 @@ static void x86UNIXInitTimer()
    }
 }
 
+static bool sg_initialized = false;
+static timeval sg_startTime;
+
 static void x86UNIXTimerInit()
 {
    if (sg_initialized == false) {
@@ -510,8 +513,8 @@ int stricmp(const char *str1, const char *str2)
 {
    while(toUpper(*str1) == toUpper(*str2) && *str1)
    {
-      str1++;
-      str2++;
+      ++str1;
+      ++str2;
    }
    unsigned char c1 = (unsigned char)toUpper(*str1);
    unsigned char c2 = (unsigned char)toUpper(*str2);
@@ -520,7 +523,7 @@ int stricmp(const char *str1, const char *str2)
 
 int strnicmp(const char *str1, const char *str2, unsigned int len)
 {
-   for(unsigned int i = 0; i < len; i++)
+   for(unsigned int i = 0; i < len; ++i)
    {
       unsigned char c1 = (unsigned char)toUpper(str1[i]);
       unsigned char c2 = (unsigned char)toUpper(str2[i]);

--- a/tnl/platform.cpp
+++ b/tnl/platform.cpp
@@ -366,9 +366,6 @@ static void x86UNIXInitTimer()
    }
 }
 
-static bool sg_initialized = false;
-static timeval sg_startTime;
-
 static void x86UNIXTimerInit()
 {
    if (sg_initialized == false) {
@@ -430,6 +427,16 @@ S64 Platform::getHighPrecisionTimerValue()
 F64 Platform::getHighPrecisionMilliseconds(S64 timerDelta)
 {
    return gTimer.convertToMS(timerDelta);
+}
+
+U32 Platform::getRealMilliseconds()
+{
+   return x86UNIXGetTickCount();
+}
+
+U32 Platform::getRealMicroseconds()
+{
+   return x86UNIXGetTickCountMicro();
 }
 
 void Platform::sleep(U32 msCount)
@@ -513,8 +520,10 @@ int stricmp(const char *str1, const char *str2)
 {
    while(toUpper(*str1) == toUpper(*str2) && *str1)
    {
-      str1++;
-      str2++;
+      ++str1;
+
+      ++str2;
+
    }
    unsigned char c1 = (unsigned char)toUpper(*str1);
    unsigned char c2 = (unsigned char)toUpper(*str2);
@@ -523,7 +532,7 @@ int stricmp(const char *str1, const char *str2)
 
 int strnicmp(const char *str1, const char *str2, unsigned int len)
 {
-   for(unsigned int i = 0; i < len; i++)
+   for(unsigned int i = 0; i < len; ++i)
    {
       unsigned char c1 = (unsigned char)toUpper(str1[i]);
       unsigned char c2 = (unsigned char)toUpper(str2[i]);

--- a/tnl/platform.cpp
+++ b/tnl/platform.cpp
@@ -429,16 +429,6 @@ F64 Platform::getHighPrecisionMilliseconds(S64 timerDelta)
    return gTimer.convertToMS(timerDelta);
 }
 
-U32 Platform::getRealMilliseconds()
-{
-   return x86UNIXGetTickCount();
-}
-
-U32 Platform::getRealMicroseconds()
-{
-   return x86UNIXGetTickCountMicro();
-}
-
 void Platform::sleep(U32 msCount)
 {
    usleep(msCount * 1000);
@@ -520,10 +510,8 @@ int stricmp(const char *str1, const char *str2)
 {
    while(toUpper(*str1) == toUpper(*str2) && *str1)
    {
-      ++str1;
-
-      ++str2;
-
+      str1++;
+      str2++;
    }
    unsigned char c1 = (unsigned char)toUpper(*str1);
    unsigned char c2 = (unsigned char)toUpper(*str2);
@@ -532,7 +520,7 @@ int stricmp(const char *str1, const char *str2)
 
 int strnicmp(const char *str1, const char *str2, unsigned int len)
 {
-   for(unsigned int i = 0; i < len; ++i)
+   for(unsigned int i = 0; i < len; i++)
    {
       unsigned char c1 = (unsigned char)toUpper(str1[i]);
       unsigned char c2 = (unsigned char)toUpper(str2[i]);

--- a/tnl/thread.cpp
+++ b/tnl/thread.cpp
@@ -173,7 +173,7 @@ void Semaphore::wait()
 
 void Semaphore::increment(U32 count)
 {
-   for(U32 i = 0; i < count; i++)
+   for(U32 i = 0; i < count; ++i)
       sem_post(&mSemaphore);
 }
 
@@ -278,7 +278,7 @@ U32 ThreadQueue::ThreadQueueThread::run()
 ThreadQueue::ThreadQueue(U32 threadCount)
 {
    mStorage.set((void *) 1);
-   for(U32 i = 0; i < threadCount; i++)
+   for(U32 i = 0; i < threadCount; ++i)
    {
       Thread *theThread = new ThreadQueueThread(this);
       mThreads.push_back(theThread);
@@ -325,7 +325,7 @@ void ThreadQueue::postCall(Functor *theCall)
 void ThreadQueue::dispatchResponseCalls()
 {
    lock();
-   for(S32 i = 0; i < mResponseCalls.size(); i++)
+   for(S32 i = 0; i < mResponseCalls.size(); ++i)
    {
       Functor *c = mResponseCalls[i];
       c->dispatch(this);

--- a/tnl/tnlBitStream.h
+++ b/tnl/tnlBitStream.h
@@ -351,7 +351,8 @@ inline bool BitStream::readFlag()
    }
    S32 mask = 1 << (bitNum & 0x7);
    bool ret = (*(getBuffer() + (bitNum >> 3)) & mask) != 0;
-   bitNum++;
+   ++bitNum;
+
    return ret;
 }
 //extern void logprintf(const char *format, ...);

--- a/tnl/tnlDataChunker.h
+++ b/tnl/tnlDataChunker.h
@@ -108,7 +108,8 @@ public:
    /// Allocates and properly constructs in place a new element.
    T *alloc()
    {
-      numAllocated++;
+      ++numAllocated;
+
       if(freeListHead == NULL)
          return constructInPlace(reinterpret_cast<T*>(DataChunker::alloc(elementSize)));
       T* ret = freeListHead;
@@ -120,7 +121,8 @@ public:
    void free(T* elem)
    {
       destructInPlace(elem);
-      numAllocated--;
+      --numAllocated;
+
       *(reinterpret_cast<T**>(elem)) = freeListHead;
       freeListHead = elem;
    }

--- a/tnl/tnlGhostConnection.h
+++ b/tnl/tnlGhostConnection.h
@@ -294,7 +294,8 @@ inline void GhostConnection::ghostPushNonZero(GhostInfo *info)
       mGhostArray[mGhostZeroUpdateIndex] = info;
       info->arrayIndex = mGhostZeroUpdateIndex;
    }
-   mGhostZeroUpdateIndex++;
+   ++mGhostZeroUpdateIndex;
+
    //TNLAssert(validateGhostArray(), "Invalid ghost array!");
 }
 
@@ -302,7 +303,8 @@ inline void GhostConnection::ghostPushToZero(GhostInfo *info)
 {
    TNLAssert(info->arrayIndex < mGhostZeroUpdateIndex, "Out of range arrayIndex.");
    TNLAssert(mGhostArray[info->arrayIndex] == info, "Invalid array object.");
-   mGhostZeroUpdateIndex--;
+   --mGhostZeroUpdateIndex;
+
    if(info->arrayIndex != mGhostZeroUpdateIndex)
    {
       mGhostArray[mGhostZeroUpdateIndex]->arrayIndex = info->arrayIndex;
@@ -317,7 +319,8 @@ inline void GhostConnection::ghostPushZeroToFree(GhostInfo *info)
 {
    TNLAssert(info->arrayIndex >= mGhostZeroUpdateIndex && info->arrayIndex < mGhostFreeIndex, "Out of range arrayIndex.");
    TNLAssert(mGhostArray[info->arrayIndex] == info, "Invalid array object.");
-   mGhostFreeIndex--;
+   --mGhostFreeIndex;
+
    if(info->arrayIndex != mGhostFreeIndex)
    {
       mGhostArray[mGhostFreeIndex]->arrayIndex = info->arrayIndex;
@@ -339,7 +342,8 @@ inline void GhostConnection::ghostPushFreeToZero(GhostInfo *info)
       mGhostArray[mGhostFreeIndex] = info;
       info->arrayIndex = mGhostFreeIndex;
    }
-   mGhostFreeIndex++;
+   ++mGhostFreeIndex;
+
    //TNLAssert(validateGhostArray(), "Invalid ghost array!");
 }
 

--- a/tnl/tnlMethodDispatch.h
+++ b/tnl/tnlMethodDispatch.h
@@ -208,7 +208,7 @@ namespace Types
          size = s.readInt(VectorSizeBitSize16) + VectorSizeNumberSize;
 
       val->resize(size);
-      for(TNL::S32 i = 0; i < val->size(); i++)
+      for(TNL::S32 i = 0; i < val->size(); ++i)
       {
          TNLAssert(s.isValid(), "Error reading vector");
          if(!s.isValid())      // Error, don't read any more!
@@ -234,7 +234,7 @@ namespace Types
       else
          s.writeInt(val.size(), VectorSizeBitSize8);
 
-      for(TNL::S32 i = 0; i < val.size(); i++)
+      for(TNL::S32 i = 0; i < val.size(); ++i)
          write(s, val[i]);
    }
 
@@ -249,7 +249,7 @@ namespace Types
          size = s.readInt(VectorSizeBitSize16) + VectorSizeNumberSize;
 
       val->resize(size);
-      for(TNL::S32 i = 0; i < val->size(); i++)
+      for(TNL::S32 i = 0; i < val->size(); ++i)
       {
          TNLAssert(s.isValid(), "Error reading vector");
          if(!s.isValid())      // Error, don't read any more!
@@ -274,7 +274,7 @@ namespace Types
       else
          s.writeInt(val.size(), VectorSizeBitSize8);
 
-      for(TNL::S32 i = 0; i < val.size(); i++)
+      for(TNL::S32 i = 0; i < val.size(); ++i)
          write(s, val[i], arg1);
    }
 };

--- a/tnl/tnlNetBase.h
+++ b/tnl/tnlNetBase.h
@@ -244,14 +244,16 @@ public:
    /// Records bits used in the initial update of objects of this class.
    void addInitialUpdate(U32 bitCount)
    {
-      mInitialUpdateCount++;
+      ++mInitialUpdateCount;
+
       mInitialUpdateBitsUsed += bitCount;
    }
 
    /// Records bits used in a partial update of an object of this class.
    void addPartialUpdate(U32 bitCount)
    {
-      mPartialUpdateCount++;
+      ++mPartialUpdateCount;
+
       mPartialUpdateBitsUsed += bitCount;
    }
 
@@ -329,7 +331,7 @@ public:
       mClassType      = classType;
       mClassGroupMask = groupMask;
       mClassVersion   = classVersion;
-      for(U32 i = 0; i < NetClassGroupCount; i++)
+      for(U32 i = 0; i < NetClassGroupCount; ++i)
          mClassId[i] = 0;
 
       // link the class into our global list
@@ -368,12 +370,14 @@ public:
 
    void incRef()
    {
-      mRefCount++;
+      ++mRefCount;
+
    }
 
    void decRef()
    {
-      mRefCount--;
+      --mRefCount;
+
       if(!mRefCount)
          destroySelf();
    }

--- a/tnl/tnlNonce.h
+++ b/tnl/tnlNonce.h
@@ -50,9 +50,9 @@ public:
 
    U8 data[NonceSize];  // 8 bytes, 2^64 possibilities
 
-   Nonce() { for(S32 i = 0; i < NonceSize; i++) data[i] = 0; mValid = false; }    // Constructor, initialize data to all 0s.
+   Nonce() { for(S32 i = 0; i < NonceSize; ++i) data[i] = 0; mValid = false; }    // Constructor, initialize data to all 0s.
    Nonce(const U8 *ptr) { memcpy(data, ptr, NonceSize); mValid = true; }
-   Nonce(const Vector<U8> &bytes) { mValid = (bytes.size() == NonceSize); if(mValid) for(S32 i = 0; i < NonceSize; i++) data[i] = bytes[i]; }
+   Nonce(const Vector<U8> &bytes) { mValid = (bytes.size() == NonceSize); if(mValid) for(S32 i = 0; i < NonceSize; ++i) data[i] = bytes[i]; }
 
    bool operator==(const Nonce &theOtherNonce) const { TNLAssert(mValid && theOtherNonce.mValid, "Nonce not valid"); return mValid && theOtherNonce.mValid && !memcmp(data, theOtherNonce.data, NonceSize); }
    bool operator!=(const Nonce &theOtherNonce) const { TNLAssert(mValid && theOtherNonce.mValid, "Nonce not valid"); return !mValid || !theOtherNonce.mValid || memcmp(data, theOtherNonce.data, NonceSize); }
@@ -62,7 +62,7 @@ public:
    void read(BitStream *stream) { stream->read(NonceSize, data); mValid = true; }
    void write(BitStream *stream) const { stream->write(NonceSize, data); }
    void getRandom() { Random::read(data, NonceSize); mValid = true; }
-   Vector<U8> toVector() { Vector<U8> v; if(mValid) for(S32 i = 0; i < NonceSize; i++) v.push_back(data[i]); return v; }
+   Vector<U8> toVector() { Vector<U8> v; if(mValid) for(S32 i = 0; i < NonceSize; ++i) v.push_back(data[i]); return v; }
    bool isValid() const { return mValid; }
 };
 

--- a/tnl/tnlRPC.h
+++ b/tnl/tnlRPC.h
@@ -58,7 +58,7 @@ TNL_IMPLEMENT_RPC(SimpleEventConnection, rpcPrintString,
    (StringPtr theString, messageCount), (theString, messageCount),
    NetClassGroupGameMask, RPCGuaranteedOrdered, RPCDirAny, 0)
 {
-   for(U32 i = 0; i < messageCount; i++)
+   for(U32 i = 0; i < messageCount; ++i)
       printf("%s", theString.getString());
 }
  

--- a/tnl/tnlString.h
+++ b/tnl/tnlString.h
@@ -82,7 +82,8 @@ public:
    {
       mString = string.mString;
       if(mString)
-         mString->mRefCount++;
+         ++mString->mRefCount;
+
    }
    StringPtr(const std::string &string)
    {
@@ -99,7 +100,8 @@ public:
       decRef();
       mString = ref.mString;
       if(mString)
-         mString->mRefCount++;
+         ++mString->mRefCount;
+
       return *this;
    }
    StringPtr &operator=(const char *string)

--- a/tnl/tnlVector.h
+++ b/tnl/tnlVector.h
@@ -127,7 +127,7 @@ public:
    //    doSomething(row);
    //
    // Equivalent to a traditional loop:
-   // for (S32 i = 0; i < rows.size(); i++)
+   // for (S32 i = 0; i < rows.size(); ++i)
    //    doSomething(rows[i]);
 
    // Note: for Vector<bool>, innerVector is std::vector<S32>, so these iterators
@@ -288,7 +288,7 @@ template<class T> inline void Vector<T>::clear()
 
 template<class T> inline void Vector<T>::deleteAndClear()
 {
-   for(U32 i = 0; i < this->innerVector.size(); i++)
+   for(U32 i = 0; i < this->innerVector.size(); ++i)
       delete this->innerVector[i];
 
    this->innerVector.clear();
@@ -301,7 +301,7 @@ template<class T> inline bool Vector<T>::contains(const T &object) const
 
 template<class T> inline S32 Vector<T>::getIndex(const T &object) const
 {
-   for(U32 i = 0; i < this->innerVector.size(); i++)
+   for(U32 i = 0; i < this->innerVector.size(); ++i)
       if(object == this->innerVector[i])
          return i;
 
@@ -403,7 +403,7 @@ template<class T> inline void Vector<T>::reserve(U32 size)
 // Reverses this Vector's elements in place.
 template<class T> inline void Vector<T>::reverse()
 {
-   for(S32 i = (S32(this->innerVector.size()) >> 1) - 1; i >= 0; i--)
+   for(S32 i = (S32(this->innerVector.size()) >> 1) - 1; i >= 0; --i)
    {
       T temp = this->innerVector[this->innerVector.size() - i - 1];
       this->innerVector[this->innerVector.size() - i - 1] = this->innerVector[i];

--- a/tnl/udp.cpp
+++ b/tnl/udp.cpp
@@ -149,13 +149,15 @@ static bool init()
          logprintf(LogError, "Winsock initialization failed.")
 
 #endif
-   initCount++;
+   ++initCount;
+
    return success;
 }
 
 static void shutdown()
 {
-   initCount--;
+   --initCount;
+
 #ifdef TNL_OS_WIN32
    if(!initCount)
    {
@@ -530,7 +532,7 @@ void Socket::getInterfaceAddresses(Vector<Address> *addressVector)
    // actual data we want
    DWORD dwRetVal;
    if ( (dwRetVal = GetIpAddrTableFn( pIPAddrTable, &dwSize, 0 )) == NO_ERROR ) {
-      for(U32 i = 0; i < pIPAddrTable->dwNumEntries; i++)
+      for(U32 i = 0; i < pIPAddrTable->dwNumEntries; ++i)
       {
          // construct an Address for this interface
          Address a;
@@ -598,7 +600,8 @@ void Socket::getInterfaceAddresses(Vector<Address> *addressVector)
    {
       char *s = buf;
       while(*s == ' ')
-         s++;
+         ++s;
+
       char *end = strchr(s, ':');
       if(!end)
          continue;
@@ -662,7 +665,7 @@ Address::Address(TransportProtocol type, Address::NamedAddress name, U16 aPort)
    }
    else if(transport == IPXProtocol)
    {
-      for(U32 i = 0; i < 4; i++)
+      for(U32 i = 0; i < 4; ++i)
          netNum[i] = 0xFFFFFFFF;
    }
 
@@ -801,7 +804,7 @@ bool Address::set(const char *addressString)
       S32 aPort;
 
       transport = IPXProtocol;
-      for(i = 0; i < 4; i++)
+      for(i = 0; i < 4; ++i)
          netNum[i] = 0xFFFFFFFF;
 
       // it's an IPX string
@@ -830,7 +833,8 @@ bool Address::set(const char *addressString)
          if(count == 10)
          {
             aPort = 0;
-            count++;
+            ++count;
+
          }
          if(count != 11)
          {

--- a/tnl/vector.cpp
+++ b/tnl/vector.cpp
@@ -35,7 +35,8 @@ bool VectorResize(U32 *aSize, U32 *aCount, void **arrayPtr, U32 newCount, U32 el
    if (newCount > 0) {
       U32 blocks = newCount / VectorBlockSize;
       if (newCount % VectorBlockSize)
-         blocks++;
+         ++blocks;
+
       S32 mem_size = blocks * VectorBlockSize * elemSize;
       *arrayPtr = *arrayPtr ? realloc(*arrayPtr,mem_size) :
          malloc(mem_size);

--- a/updater/src/TinyXml/tinystr.cpp
+++ b/updater/src/TinyXml/tinystr.cpp
@@ -128,7 +128,7 @@ void TiXmlString ::operator = (const TiXmlString & copy)
 //bool TiXmlString::isblank () const
 //{
 //    char * lookup;
-//    for (lookup = cstring; * lookup; lookup++)
+//    for (lookup = cstring; * lookup; ++lookup)
 //        if (! isspace (* lookup))
 //            return false;
 //    return true;
@@ -257,7 +257,7 @@ unsigned TiXmlString::find (char tofind, unsigned offset) const
 
     if (offset >= length ())
         return (unsigned) notfound;
-    for (lookup = cstring + offset; * lookup; lookup++)
+    for (lookup = cstring + offset; * lookup; ++lookup)
         if (* lookup == tofind)
             return (unsigned)(lookup - cstring);
     return (unsigned) notfound;

--- a/updater/src/TinyXml/tinyxml.cpp
+++ b/updater/src/TinyXml/tinyxml.cpp
@@ -557,7 +557,7 @@ void TiXmlElement::SetAttribute( const char * name, const char * _value )
 void TiXmlElement::Print( FILE* cfile, int depth ) const
 {
 	int i;
-	for ( i=0; i<depth; i++ )
+	for ( i=0; i<depth; ++i )
 	{
 		fprintf( cfile, "    " );
 	}
@@ -906,7 +906,7 @@ const double  TiXmlAttribute::DoubleValue() const
 
 void TiXmlComment::Print( FILE* cfile, int depth ) const
 {
-	for ( int i=0; i<depth; i++ )
+	for ( int i=0; i<depth; ++i )
 	{
 		fputs( "    ", cfile );
 	}
@@ -1025,7 +1025,7 @@ TiXmlNode* TiXmlDeclaration::Clone() const
 
 void TiXmlUnknown::Print( FILE* cfile, int depth ) const
 {
-	for ( int i=0; i<depth; i++ )
+	for ( int i=0; i<depth; ++i )
 		fprintf( cfile, "    " );
 	fprintf( cfile, "%s", value.c_str() );
 }

--- a/updater/src/TinyXml/tinyxmlparser.cpp
+++ b/updater/src/TinyXml/tinyxmlparser.cpp
@@ -1149,7 +1149,7 @@ const char* TiXmlDeclaration::Parse( const char* p, TiXmlParsingData* data )
 
 bool TiXmlText::Blank() const
 {
-	for ( unsigned i=0; i<value.length(); i++ )
+	for ( unsigned i=0; i<value.length(); ++i )
 		if ( !isspace( value[i] ) )
 			return false;
 	return true;

--- a/updater/src/winmain.cpp
+++ b/updater/src/winmain.cpp
@@ -73,7 +73,7 @@ static bool isInList(const char *token2Find, char *list2Clean) {
 	char word[1024];
 	bool isFileNamePart = false;
 
-	for (int i = 0, j = 0 ;  i <= int(strlen(list2Clean)) ; i++)
+	for (int i = 0, j = 0 ;  i <= int(strlen(list2Clean)) ; ++i)
 	{
 		if ((list2Clean[i] == ' ') || (list2Clean[i] == '\0'))
 		{
@@ -88,7 +88,7 @@ static bool isInList(const char *token2Find, char *list2Clean) {
 					int wordLen = int(strlen(word));
 					int prevPos = i - wordLen;
 
-					for (i = i + 1 ;  i <= int(strlen(list2Clean)) ; i++, prevPos++)
+					for (i = i + 1 ;  i <= int(strlen(list2Clean)) ; ++i, ++prevPos)
 						list2Clean[prevPos] = list2Clean[i];
 
 					list2Clean[prevPos] = '\0';
@@ -117,7 +117,7 @@ static string getParamVal(char c, char *list2Clean) {
 	bool isFileNamePart = false;
 	int pos2Erase = 0;
 
-	for (int i = 0, j = 0 ;  i <= int(strlen(list2Clean)) ; i++)
+	for (int i = 0, j = 0 ;  i <= int(strlen(list2Clean)) ; ++i)
 	{
 		if ((list2Clean[i] == ' ') || (list2Clean[i] == '\0'))
 		{
@@ -127,7 +127,7 @@ static string getParamVal(char c, char *list2Clean) {
 				j = 0;
 				action = false;
 
-				for (i = i + 1 ;  i <= int(strlen(list2Clean)) ; i++, pos2Erase++)
+				for (i = i + 1 ;  i <= int(strlen(list2Clean)) ; ++i, ++pos2Erase)
 					list2Clean[pos2Erase] = list2Clean[i];
 						
 				list2Clean[pos2Erase] = '\0';

--- a/zap/AppIntegrator.cpp
+++ b/zap/AppIntegrator.cpp
@@ -69,7 +69,7 @@ void AppIntegrationController::init()
 #endif
 
    // Run init() on all the integrators
-   for(int i = 0; i < mAppIntegrators.size(); i++)
+   for(int i = 0; i < mAppIntegrators.size(); ++i)
       mAppIntegrators[i]->init();
 
    // Start callback timer
@@ -93,11 +93,11 @@ void AppIntegrationController::idle(U32 deltaTime)
 void AppIntegrationController::shutdown()
 {
    // Run shutdown() on all the integrators
-   for(int i = 0; i < mAppIntegrators.size(); i++)
+   for(int i = 0; i < mAppIntegrators.size(); ++i)
       mAppIntegrators[i]->shutdown();
 
    // Clean up
-   for(int i = 0; i < mAppIntegrators.size(); i++)
+   for(int i = 0; i < mAppIntegrators.size(); ++i)
    {
       AppIntegrator *app = mAppIntegrators[i];
 
@@ -109,7 +109,7 @@ void AppIntegrationController::shutdown()
 
 void AppIntegrationController::runCallbacks()
 {
-   for(int i = 0; i < mAppIntegrators.size(); i++)
+   for(int i = 0; i < mAppIntegrators.size(); ++i)
       mAppIntegrators[i]->runCallbacks();
 }
 
@@ -117,7 +117,7 @@ void AppIntegrationController::runCallbacks()
 void AppIntegrationController::updateState(const string &state, const string &details)
 {
 
-   for(int i = 0; i < mAppIntegrators.size(); i++)
+   for(int i = 0; i < mAppIntegrators.size(); ++i)
    {
       if(state != "")
          mAppIntegrators[i]->updateState(state);

--- a/zap/BanList.cpp
+++ b/zap/BanList.cpp
@@ -124,7 +124,7 @@ bool BanList::processBanListLine(const string &line)
       return false;
 
    // Check to make sure there is at lease one character in each token
-   for (S32 i = 0; i < 4; i++)
+   for (S32 i = 0; i < 4; ++i)
       if(words[i].length() < 1)
          return false;
 
@@ -197,7 +197,7 @@ bool BanList::isBanned(const Address &address, const string &nickname, bool isAu
    string addressString = addressToString(address);
    auto currentTime = cleanTimeNow();
 
-   for (S32 i = 0; i < serverBanList.size(); i++)
+   for (S32 i = 0; i < serverBanList.size(); ++i)
    {
       // Check IP
       if (addressString.compare(serverBanList[i].address) != 0 && serverBanList[i].address.compare("*") != 0)
@@ -261,7 +261,7 @@ S32 BanList::getDefaultBanDuration()
 Vector<string> BanList::banListToString()
 {
    Vector<string> banList;
-   for(S32 i = 0; i < serverBanList.size(); i++)
+   for(S32 i = 0; i < serverBanList.size(); ++i)
       banList.push_back(banItemToString(&serverBanList[i]));
 
    return banList;
@@ -271,7 +271,7 @@ Vector<string> BanList::banListToString()
 void BanList::loadBanList(const Vector<string> &banItemList)
 {
    serverBanList.clear();  // Clear old list for /loadini command.
-   for(S32 i = 0; i < banItemList.size(); i++)
+   for(S32 i = 0; i < banItemList.size(); ++i)
       if(!processBanListLine(banItemList[i]))
          logprintf("Ban list item on line %d is malformed: %s", i+1, banItemList[i].c_str());
       else
@@ -290,7 +290,7 @@ void BanList::kickHost(const Address &address)
 
 bool BanList::isAddressKicked(const Address &address)
 {
-   for(S32 i = 0; i < serverKickList.size(); i++)
+   for(S32 i = 0; i < serverKickList.size(); ++i)
       if(address.isEqualAddress(serverKickList[i].address))
          return true;
 
@@ -307,7 +307,8 @@ void BanList::updateKickList(U32 timeElapsed)
       else
       {
          serverKickList[i].kickTimeRemaining -= timeElapsed;
-         i++;
+         ++i;
+
       }
    }
 }

--- a/zap/BfObject.cpp
+++ b/zap/BfObject.cpp
@@ -184,7 +184,8 @@ F32 EditorObject::getEditorRadius(F32 currentScale)
 static S32 getNextDefaultId()
 {
    static S32 nextId = 0;
-   nextId--;
+   --nextId;
+
    return nextId;
 }
 
@@ -314,7 +315,7 @@ void BfObject::setGeom(lua_State *L, S32 stackIndex)
       // Go through each point
       else
       {
-         for(S32 i = 0; i < points.size(); i++)
+         for(S32 i = 0; i < points.size(); ++i)
          {
             if(points[i] != GeomObject::getOutline()->get(i))
             {
@@ -459,7 +460,7 @@ void BfObject::renderAndLabelHighlightedVertices(F32 currentScale)
    F32 radius = getEditorRadius(currentScale);
 
    // Label and highlight any selected or lit up vertices.  This will also highlight point items.
-   for(S32 i = 0; i < getVertCount(); i++)
+   for(S32 i = 0; i < getVertCount(); ++i)
       if(vertSelected(i) || isVertexLitUp(i) || ((isSelected() || isLitUp())  && getVertCount() == 1))
       {
          const Color *color = (vertSelected(i) || (isSelected() && getGeomType() == geomPoint)) ?
@@ -636,7 +637,7 @@ void BfObject::deleteObject(U32 deleteTimeInterval)  // interval defaults to 0
       LuaScriptRunner *scriptRunner = dynamic_cast<LuaScriptRunner *>(this);
 
       if(scriptRunner)
-         for(S32 i = 0; i < EventManager::EventTypes; i++)
+         for(S32 i = 0; i < EventManager::EventTypes; ++i)
             EventManager::get()->unsubscribeImmediate(scriptRunner, EventManager::EventType(i));
 
       mGame->addToDeleteList(this, deleteTimeInterval);
@@ -780,7 +781,7 @@ S32 BfObject::radiusDamage(Point pos, S32 innerRad, S32 outerRad, TestFunc objec
 
    S32 shipsHit = 0;
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *foundObject = static_cast<BfObject *>(fillVector[i]);
 
@@ -837,7 +838,8 @@ S32 BfObject::radiusDamage(Point pos, S32 innerRad, S32 outerRad, TestFunc objec
          localInfo.damageAmount *= localInfo.damageSelfMultiplier;
 
       if(isShipType(foundObject->getObjectTypeNumber()))
-         shipsHit++;
+         ++shipsHit;
+
 
       foundObject->damageObject(&localInfo);
    }
@@ -894,7 +896,8 @@ BfObject *BfObject::findObjectLOS(TestFunc objectTypeTest, U32 stateIndex, const
 
 void BfObject::onAddedToGame(Game *game)
 {
-   game->mObjectsLoaded++;
+   ++game->mObjectsLoaded;
+
 }
 
 
@@ -980,14 +983,16 @@ void BfObject::renderLayer(S32 layerIndex)
 void BfObject::disableCollision()
 {
    TNLAssert(mDisableCollisionCount < 10, "Too many disabled collisions");
-   mDisableCollisionCount++;
+   ++mDisableCollisionCount;
+
 }
 
 
 void BfObject::enableCollision()
 {
    TNLAssert(mDisableCollisionCount != 0, "Trying to enable collision, already enabled");
-   mDisableCollisionCount--;
+   --mDisableCollisionCount;
+
 }
 
 

--- a/zap/BotNavMeshZone.cpp
+++ b/zap/BotNavMeshZone.cpp
@@ -117,7 +117,7 @@ const Vector<Point> *BotNavMeshZone::getCollisionPoly() const
 // Returns index of neighboring zone, or -1 if zone is not a neighbor
 S32 BotNavMeshZone::getNeighborIndex(S32 zoneID)
 {
-   for(S32 i = 0; i < mNeighbors.size(); i++)
+   for(S32 i = 0; i < mNeighbors.size(); ++i)
       if(mNeighbors[i].zoneID == zoneID)
          return i;
 
@@ -178,7 +178,7 @@ bool BotNavMeshZone::buildConnectionsRecastStyle(const Vector<BotNavMeshZone *> 
       return false;
    }
 
-   for(int i = 0; i < mesh.nverts; i++)
+   for(int i = 0; i < mesh.nverts; ++i)
       firstEdge[i] = RC_MESH_NULL_IDX;
 
    // First process edges where 1st node < 2nd node
@@ -210,7 +210,7 @@ bool BotNavMeshZone::buildConnectionsRecastStyle(const Vector<BotNavMeshZone *> 
             nextEdge[edgeCount] = firstEdge[v0];        // Next edge on the previous vert now points to whatever was in firstEdge previously
             firstEdge[v0] = (unsigned short)edgeCount;  // First edge of this vert
 
-            edgeCount++;                           // edgeCount never resets -- each edge gets a unique id
+            ++edgeCount;                           // edgeCount never resets -- each edge gets a unique id
          }
       }
    }
@@ -254,7 +254,7 @@ bool BotNavMeshZone::buildConnectionsRecastStyle(const Vector<BotNavMeshZone *> 
    NeighboringZone neighbor;
 
    // Now create our neighbor data
-   for(int i = 0; i < edgeCount; i++)
+   for(int i = 0; i < edgeCount; ++i)
    {
       const rcEdge& e = edges[i];
 
@@ -327,7 +327,7 @@ static BotNavMeshZone *findZoneTouchingCircle(const GridDatabase *botZoneDatabas
    Point c;
 
    // Pick the first zone within our radius
-   for(S32 i = 0; i < zones.size(); i++)
+   for(S32 i = 0; i < zones.size(); ++i)
    {
       BotNavMeshZone *zone = static_cast<BotNavMeshZone *>(zones[i]);
       poly = zone->getOutline();
@@ -353,7 +353,7 @@ void BotNavMeshZone::populateZoneList(GridDatabase *botZoneDatabase, Vector<BotN
 
    allZones->resize(objects->size());
 
-   for(S32 i = 0; i < objects->size(); i++)
+   for(S32 i = 0; i < objects->size(); ++i)
       allZones->get(i) = static_cast<BotNavMeshZone *>(objects->get(i));
 }
 
@@ -368,13 +368,13 @@ static void linkConnectionsTeleporters(const GridDatabase *botZoneDatabase,
 
    F32 triggerRadius = F32(Teleporter::TELEPORTER_RADIUS - Ship::CollisionRadius);
 
-   for(S32 i = 0; i < teleporterData.size(); i++)
+   for(S32 i = 0; i < teleporterData.size(); ++i)
    {
       origin = teleporterData[i].first;
       BotNavMeshZone *origZone = findZoneTouchingCircle(botZoneDatabase, origin, triggerRadius);
 
       if(origZone != NULL)
-      for(S32 j = 0; j < teleporterData[i].second->size(); j++)     // Review each teleporter destination
+      for(S32 j = 0; j < teleporterData[i].second->size(); ++j)     // Review each teleporter destination
       {
          dest = teleporterData[i].second->get(j);
          BotNavMeshZone *destZone = findZoneTouchingCircle(botZoneDatabase, dest, triggerRadius);
@@ -431,7 +431,7 @@ static BfObject* findFirstCollision(const GridDatabase *gameObjDatabase, F32 &co
    BfObject *collisionObject = NULL;
    F32 closestCollisionFraction = F32_MAX;
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *foundObject = static_cast<BfObject *>(fillVector[i]);
 
@@ -495,7 +495,7 @@ static void linkConnectionsSpeedZones(const GridDatabase *gameObjDatabase,
    Point source, dest; // Source and destination points for the current travelling vector
 
    // Go through each known SpeedZone
-   for(S32 i = 0; i < speedZoneList.size(); i++)
+   for(S32 i = 0; i < speedZoneList.size(); ++i)
    {
       SpeedZone *speedZone = static_cast<SpeedZone *>(speedZoneList[i]);
       const Vector<Point> &szBufferedPoly = speedZonePolygons[i];  // Aligned with speedZoneList
@@ -633,7 +633,7 @@ static void linkConnectionsSpeedZones(const GridDatabase *gameObjDatabase,
       // Now go through all known bot zones under speedzones
       // allZones should be a list of BotNavMeshZone ordered by their zoneId
       // We know ahead of time what ID zones below SpeedZone start at
-      for(S32 j = szBotZoneStartId; j < allZones->size(); j++)
+      for(S32 j = szBotZoneStartId; j < allZones->size(); ++j)
       {
          BotNavMeshZone *origZone = allZones->get(j);
          origin = origZone->getCenter();
@@ -717,7 +717,7 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
    Vector<pair<Point, const Vector<Point> *> > teleporterData(fillVector.size());
    pair<Point, const Vector<Point> *> teldat;
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       Teleporter *teleporter = static_cast<Teleporter *>(fillVector[i]);
 
@@ -794,7 +794,7 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
    }
 
    // Add turrets
-   for (S32 i = 0; i < turretList.size(); i++)
+   for (S32 i = 0; i < turretList.size(); ++i)
    {
       if(turretList[i]->getObjectTypeNumber() != TurretTypeNumber)
          continue;
@@ -806,7 +806,7 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
    }
 
    // Add forcefield projectors
-   for (S32 i = 0; i < forceFieldProjectorList.size(); i++)
+   for (S32 i = 0; i < forceFieldProjectorList.size(); ++i)
    {
       if(forceFieldProjectorList[i]->getObjectTypeNumber() != ForceFieldProjectorTypeNumber)
          continue;
@@ -828,7 +828,7 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
    // Increase buffer radius a little to handle the spinning corners
    F32 coreBufferRadius = BufferRadius + 5;
 
-   for (S32 i = 0; i < coreList.size(); i++)
+   for (S32 i = 0; i < coreList.size(); ++i)
    {
       CoreItem *core = static_cast<CoreItem *>(coreList[i]);
 
@@ -839,7 +839,7 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
    // Add SpeedZones - they are one-way like areas
    Vector<Vector<Point> > speedZonePolygons;
 
-   for (S32 i = 0; i < speedZoneList.size(); i++)
+   for (S32 i = 0; i < speedZoneList.size(); ++i)
    {
       SpeedZone *speedZone = static_cast<SpeedZone *>(speedZoneList[i]);
 
@@ -855,11 +855,11 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
    Vector<Vector<Point> > nonStandardPolygons = blockingPolygons;
 
    if(hasCores)
-      for(S32 i = 0; i < corePolygons.size(); i++)
+      for(S32 i = 0; i < corePolygons.size(); ++i)
          nonStandardPolygons.push_back(corePolygons[i]);
 
    if(hasSpeedZones)
-      for(S32 i = 0; i < speedZonePolygons.size(); i++)
+      for(S32 i = 0; i < speedZonePolygons.size(); ++i)
          nonStandardPolygons.push_back(speedZonePolygons[i]);
 
 
@@ -979,7 +979,7 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
    polyToZoneMap.resize(mesh.npolys);
 
    // Generate BotNavMeshZone objects for each valid polygon
-   for(S32 i = 0; i < mesh.npolys; i++)
+   for(S32 i = 0; i < mesh.npolys; ++i)
    {
       S32 j = 0;
       botzone = NULL;
@@ -1013,7 +1013,8 @@ bool BotNavMeshZone::buildBotMeshZones(GridDatabase *botZoneDatabase, GridDataba
          }
 
          botzone->addVert(Point(vert[0] - mesh.offsetX, vert[1] - mesh.offsetY));
-         j++;
+         ++j;
+
       }
 
       if(botzone != NULL)
@@ -1106,7 +1107,7 @@ Vector<Point> AStar::findPath(const Vector<BotNavMeshZone *> *zones, S32 startZo
    // more efficient for the zone counts we typically see in Bitfighter levels.
    if(onClosedList > U16_MAX - 3 ) // Reset whichList when we've run out of headroom
    {
-      for(S32 i = 0; i < MAX_ZONES; i++)
+      for(S32 i = 0; i < MAX_ZONES; ++i)
          whichList[i] = 0;
       onClosedList = 0;
    }
@@ -1142,7 +1143,8 @@ Vector<Point> AStar::findPath(const Vector<BotNavMeshZone *> *zones, S32 startZo
          }
 
          whichList[parentZone] = onClosedList;   // add the item to the closed list
-         numberOfOpenListItems--;
+         --numberOfOpenListItems;
+
 
          //   Open List = Binary Heap: Delete this item from the open list, which
          // is maintained as a binary heap. For more information on binary heaps, see:
@@ -1190,7 +1192,7 @@ Vector<Point> AStar::findPath(const Vector<BotNavMeshZone *> *zones, S32 startZo
 
          Vector<NeighboringZone> neighboringZones = zones->get(parentZone)->mNeighbors;
 
-         for(S32 a = 0; a < neighboringZones.size(); a++)
+         for(S32 a = 0; a < neighboringZones.size(); ++a)
          {
             NeighboringZone zone = neighboringZones[a];
             S32 zoneID = zone.zoneID;
@@ -1229,7 +1231,8 @@ Vector<Point> AStar::findPath(const Vector<BotNavMeshZone *> *zones, S32 startZo
 
                // Finally, put zone on the open list
                whichList[zoneID] = onOpenList;
-               numberOfOpenListItems++;
+               ++numberOfOpenListItems;
+
             }
 
             // If zone is already on the open list, check to see if this
@@ -1253,7 +1256,7 @@ Vector<Point> AStar::findPath(const Vector<BotNavMeshZone *> *zones, S32 startZo
                   // recorded F cost and its position on the open list to make
                   // sure that we maintain a properly ordered open list.
 
-                  for(S32 i = 1; i <= numberOfOpenListItems; i++) // Look for the item in the heap
+                  for(S32 i = 1; i <= numberOfOpenListItems; ++i) // Look for the item in the heap
                   {
                      if(openZone[openList[i]] == zoneID)
                      {

--- a/zap/CTFGame.cpp
+++ b/zap/CTFGame.cpp
@@ -70,7 +70,7 @@ void CTFGameType::shipTouchFlag(Ship *theShip, FlagItem *theFlag)
       else     // Flag is at home
       {
          // Check if this client has an enemy flag mounted
-         for(S32 i = 0; i < theShip->getMountedItemCount(); i++)
+         for(S32 i = 0; i < theShip->getMountedItemCount(); ++i)
          {
             MountableItem *mountedItem = theShip->getMountedItem(i);
 
@@ -140,7 +140,7 @@ void CTFGameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clie
 
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 
@@ -174,7 +174,7 @@ void CTFGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) cons
 
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 
@@ -303,7 +303,7 @@ void CTFGameType::onGameOver()
       bool tiedGame = false;
       bool secondPlaceIsMinusOne = false;
 
-      for(S32 i = 1; i < getGame()->getTeamCount(); i++)
+      for(S32 i = 1; i < getGame()->getTeamCount(); ++i)
       {
          // Skip ourselves
          if(i == mPossibleLastWinBadgeAchiever->getTeamIndex())

--- a/zap/ChatCheck.cpp
+++ b/zap/ChatCheck.cpp
@@ -60,7 +60,7 @@ bool ChatCheck::checkMessage(const char *message, U32 mode)
       return false;
 
    U32 chatPrevMessageSum = 0;
-   for(S32 i = 0; message[i] != 0; i++)
+   for(S32 i = 0; message[i] != 0; ++i)
       chatPrevMessageSum += U32(message[i]) * (i + 0x4EC691);
 
    if(chatPrevMessageSum == mChatPrevMessageSum && mChatPrevMessageMode >= mode && mode <= 1 && mChatTimer != 0)

--- a/zap/ChatCommands.cpp
+++ b/zap/ChatCommands.cpp
@@ -214,7 +214,7 @@ void mapLevelHandler(ClientGame *game, const Vector<string> &words)
 
       // We could have sent in multiple words for a level name
       string levelName = "";
-      for(S32 i = 1; i < words.size(); i++)
+      for(S32 i = 1; i < words.size(); ++i)
       {
          if(i != 1)
             levelName = levelName + " ";
@@ -224,7 +224,7 @@ void mapLevelHandler(ClientGame *game, const Vector<string> &words)
 
       // Find our level index...  very inefficient; not sure how to do this
       // differently without a large refactor
-      for(S32 i = 0; i < gameConnection->mLevelInfos.size(); i++)
+      for(S32 i = 0; i < gameConnection->mLevelInfos.size(); ++i)
       {
          // This finds the first level with the name..  so don't have duplicate-named levels!
          if(stricmp(levelName.c_str(), gameConnection->mLevelInfos[i].mLevelName.getString()) == 0)
@@ -275,7 +275,7 @@ void shutdownServerHandler(ClientGame *game, const Vector<string> &words)
       }
 
       S32 first = timefound ? 2 : 1;
-      for(S32 i = first; i < words.size(); i++)
+      for(S32 i = first; i < words.size(); ++i)
       {
          if(i != first)
             reason = reason + " ";
@@ -505,7 +505,7 @@ void idleHandler(ClientGame *game, const Vector<string> &words)
 
 void showPresetsHandler(ClientGame *game, const Vector<string> &words)
 {
-   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; i++)
+   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; ++i)
    {
       string display;
 
@@ -810,7 +810,7 @@ void announceHandler(ClientGame *game, const Vector<string> &words)
    {
       // Rebuild our announcement from the split up vector
       string message = "";
-      for(S32 i = 1; i < words.size(); i++)
+      for(S32 i = 1; i < words.size(); ++i)
       {
          if(i != 1)
             message = message + " ";
@@ -832,7 +832,7 @@ void addBotHandler(ClientGame *game, const Vector<string> &words)
    {
       // Build args by skipping first word (the command)
       Vector<StringTableEntry> args;
-      for(S32 i = 1; i < words.size(); i++)
+      for(S32 i = 1; i < words.size(); ++i)
          args.push_back(StringTableEntry(words[i]));
 
       if(!fixupArgs(game, args))    // Reorder args for c2sAddBot, translate team names to indices, and do a little checking
@@ -865,7 +865,7 @@ void addBotsHandler(ClientGame *game, const Vector<string> &words)
 
       // Build args by skipping first two words (the command, and count)
       Vector<StringTableEntry> args;
-      for(S32 i = 2; i < words.size(); i++)
+      for(S32 i = 2; i < words.size(); ++i)
          args.push_back(StringTableEntry(words[i]));
 
       if(!fixupArgs(game, args))        // Reorder args for c2sAddBot translate team names to indices
@@ -1104,7 +1104,7 @@ void rateMapHandler(ClientGame *game, const Vector<string> &args)
    LevelDatabaseRateThread::LevelRating ratingEnum = LevelDatabaseRateThread::UnknownRating;
 
    if(args.size() >= 2)
-      for(S32 i = 0; i < LevelDatabaseRateThread::RatingsCount; i++)
+      for(S32 i = 0; i < LevelDatabaseRateThread::RatingsCount; ++i)
          if(args[1] == LevelDatabaseRateThread::RatingStrings[i])
          {
             ratingEnum = LevelDatabaseRateThread::getLevelRatingEnum(args[1]);
@@ -1116,7 +1116,7 @@ void rateMapHandler(ClientGame *game, const Vector<string> &args)
       string msg = "!!! You must specify a rating (";
 
       // Enumerate all valid ratings strings
-      for(S32 i = 0; i < LevelDatabaseRateThread::RatingsCount; i++)
+      for(S32 i = 0; i < LevelDatabaseRateThread::RatingsCount; ++i)
       {
          msg += "\"" + LevelDatabaseRateThread::RatingStrings[i] + "\"";
          if(i < LevelDatabaseRateThread::RatingsCount - 2)
@@ -1144,7 +1144,7 @@ void commentMapHandler(ClientGame *game, const Vector<string> &words)
 
    // Start at first word and concatenate all the others to rebuild the comment
    string comment = words[1];
-   for(S32 i = 2; i < words.size(); i++)
+   for(S32 i = 2; i < words.size(); ++i)
       comment = comment + " " + words[i];
 
    // Comment is too small

--- a/zap/ChatDisplay.cpp
+++ b/zap/ChatDisplay.cpp
@@ -93,11 +93,13 @@ void ChatDisplay::idle(U32 timeDelta)
 
 void ChatDisplay::advanceFirst()
 {
-   mFirst++;
+   ++mFirst;
+
 
    if(mLast % mMessages.size() == mFirst % mMessages.size())
    {
-      mLast++;
+      ++mLast;
+
       mFull = true;
    }
 }
@@ -105,12 +107,14 @@ void ChatDisplay::advanceFirst()
 
 void ChatDisplay::advanceLast()
 {
-   mLast++;
+   ++mLast;
+
 
    U32 id = mMessages[mLast % mMessages.size()].groupId;
 
    while(mMessages[(mLast + 1) % mMessages.size()].groupId == id && mFirst > mLast)
-      mLast++;
+      ++mLast;
+
 
    mFull = false;
 
@@ -124,13 +128,14 @@ void ChatDisplay::onChatMessageReceived(const Color &msgColor, const string &msg
    Vector<string> lines = wrapString(substituteVars(msg), mWrapWidth, mFontSize, "      ");
    FontManager::popFontContext();
 
-   for(S32 i = 0; i < lines.size(); i++)
+   for(S32 i = 0; i < lines.size(); ++i)
    {
       advanceFirst();
       mMessages[mFirst % mMessages.size()].set(lines[i], msgColor, mNextGroupId);
    }
 
-   mNextGroupId++;
+   ++mNextGroupId;
+
 
    mDisplayChatMessageTimer.reset();
 
@@ -147,7 +152,7 @@ string ChatDisplay::substituteVars(const string &str)
    std::size_t startPos = 0;
    std::size_t endPos = 0;
 
-   for(std::size_t i = 0; i < s.length(); i++)
+   for(std::size_t i = 0; i < s.length(); ++i)
    {
       if(s[i] == '%')
       {
@@ -213,14 +218,15 @@ void ChatDisplay::render(S32 anchorPos, bool helperVisible, bool announcementAct
    if(announcementActive)
    {
       if(!mExpire && mFirst >= (U32)mMessages.size() - 1)
-         last++;
+         ++last;
+
 
       y -= lineHeight;
    }
 
    FontManager::pushFontContext(ChatMessageContext);
 
-   for(U32 i = mFirst; i != last - renderExtra; i--)
+   for(U32 i = mFirst; i != last - renderExtra; --i)
    {
       U32 index = i % (U32)mMessages.size();
 

--- a/zap/ChatHelper.cpp
+++ b/zap/ChatHelper.cpp
@@ -232,7 +232,7 @@ void ChatHelper::render()
          (F32)xPos,            top + BOX_HEIGHT
    };
 
-   for(S32 i = 1; i >= 0; i--)
+   for(S32 i = 1; i >= 0; --i)
    {
       renderer.setColor(baseColor, i ? .25f : .4f);
       renderer.renderVertexArray(vertices, ARRAYSIZE(vertices) / 2, i ? RenderType::TriangleFan : RenderType::LineLoop);
@@ -256,7 +256,7 @@ void ChatHelper::render()
 
       if(words.size() > 0)
       {
-         for(S32 i = 0; i < chatCmdSize; i++)
+         for(S32 i = 0; i < chatCmdSize; ++i)
          {
             const char *cmd = words[0].c_str();
 
@@ -305,7 +305,7 @@ static void makePlayerNameList(Game *game, Vector<string> &nameCandidateList)
 {
    nameCandidateList.clear();
 
-   for(S32 i = 0; i < game->getClientCount(); i++)
+   for(S32 i = 0; i < game->getClientCount(); ++i)
       nameCandidateList.push_back(((Game *)game)->getClientInfo(i)->getName().getString());
 }
 
@@ -314,7 +314,7 @@ static void makeTeamNameList(const Game *game, Vector<string> &nameCandidateList
 {
    nameCandidateList.clear();
 
-   for(S32 i = 0; i < game->getTeamCount(); i++)
+   for(S32 i = 0; i < game->getTeamCount(); ++i)
       nameCandidateList.push_back(game->getTeamName(i).getString());
 }
 
@@ -330,7 +330,7 @@ static void makeLevelNameList(Game *game, Vector<string> &nameCandidateList)
    if(!gameConnection)
       return;
 
-   for(S32 i = 0; i < gameConnection->mLevelInfos.size(); i++)
+   for(S32 i = 0; i < gameConnection->mLevelInfos.size(); ++i)
       nameCandidateList.push_back(gameConnection->mLevelInfos[i].mLevelName.getString());
 }
 
@@ -408,7 +408,8 @@ void ChatHelper::upArrowPressed()
    if(mHistoryIndex > 0)
    {
       mHistory[mHistoryIndex] = mLineEditor.getString();       // Save any edits we've made to this line
-      mHistoryIndex--;
+      --mHistoryIndex;
+
       mLineEditor.setString(mHistory[mHistoryIndex]);
    }
 }
@@ -420,7 +421,8 @@ void ChatHelper::downArrowPressed()
    if(mHistoryIndex < mHistory.size() - 1)
    {
       mHistory[mHistoryIndex] = mLineEditor.getString();      // Save any edits we've made to this line
-      mHistoryIndex++;
+      ++mHistoryIndex;
+
       mLineEditor.setString(mHistory[mHistoryIndex]);
    }
 }
@@ -492,7 +494,7 @@ bool ChatHelper::completeChatCmd()
       S32 end = lastArgIsEmpty ? arg - 1 : arg;
 
       string newPartial = words[commandInfo->cmdArgCount];
-      for (S32 i = commandInfo->cmdArgCount + 1; i <= end; i++)
+      for (S32 i = commandInfo->cmdArgCount + 1; i <= end; ++i)
          newPartial = newPartial + " " + words[i];
 
       // Set the arg to what it should be with the multiple words
@@ -587,7 +589,7 @@ const char *ChatHelper::getChatMessage() const
 
 static void makeCommandCandidateList()
 {
-   for(S32 i = 0; i < ChatHelper::chatCmdSize; i++)
+   for(S32 i = 0; i < ChatHelper::chatCmdSize; ++i)
       commandCandidateList.push_back(chatCmds[i].cmdName);
 
    commandCandidateList.sort(alphaSort);
@@ -643,7 +645,7 @@ void ChatHelper::issueChat()
 
 CommandInfo *ChatHelper::getCommandInfo(const char *command)
 {
-   for(S32 i = 0; i < ChatHelper::chatCmdSize; i++)
+   for(S32 i = 0; i < ChatHelper::chatCmdSize; ++i)
       if(!stricmp(chatCmds[i].cmdName.c_str(), command))
          return &chatCmds[i];
 
@@ -670,7 +672,7 @@ void ChatHelper::runCommand(ClientGame *game, const char *input)
       return;
    }
 
-   for(U32 i = 0; i < ARRAYSIZE(chatCmds); i++)
+   for(U32 i = 0; i < ARRAYSIZE(chatCmds); ++i)
       if(lcase(words[0]) == chatCmds[i].cmdName)
       {
          (*(chatCmds[i].cmdCallback))(game, words);
@@ -691,7 +693,7 @@ void ChatHelper::serverCommandHandler(ClientGame *game, const Vector<string> &wo
 {
    Vector<StringPtr> args;
 
-   for(S32 i = 1; i < words.size(); i++)
+   for(S32 i = 1; i < words.size(); ++i)
       args.push_back(StringPtr(words[i]));
 
    game->sendCommand(StringTableEntry(words[0], false), args);

--- a/zap/ChatMessageDisplayer.cpp
+++ b/zap/ChatMessageDisplayer.cpp
@@ -91,11 +91,13 @@ void ChatMessageDisplayer::idle(U32 timeDelta)
 
 void ChatMessageDisplayer::advanceFirst()
 {
-   mFirst++;
+   ++mFirst;
+
 
    if(mLast % mMessages.size() == mFirst % mMessages.size())
    {
-      mLast++;
+      ++mLast;
+
       mFull = true;
    }
 }
@@ -103,12 +105,14 @@ void ChatMessageDisplayer::advanceFirst()
 
 void ChatMessageDisplayer::advanceLast()
 {
-   mLast++;
+   ++mLast;
+
 
    U32 id = mMessages[mLast % mMessages.size()].groupId;
 
    while(mMessages[(mLast + 1) % mMessages.size()].groupId == id && mFirst > mLast)
-      mLast++;
+      ++mLast;
+
 
    mFull = false;
 
@@ -122,13 +126,14 @@ void ChatMessageDisplayer::onChatMessageReceived(const Color &msgColor, const st
    Vector<string> lines = wrapString(substituteVars(msg), mWrapWidth, mFontSize, "      ");
    FontManager::popFontContext();
 
-   for(S32 i = 0; i < lines.size(); i++)
+   for(S32 i = 0; i < lines.size(); ++i)
    {
       advanceFirst();
       mMessages[mFirst % mMessages.size()].set(lines[i], msgColor, mNextGroupId);
    }
 
-   mNextGroupId++;
+   ++mNextGroupId;
+
 
    mDisplayChatMessageTimer.reset();
 
@@ -145,7 +150,7 @@ string ChatMessageDisplayer::substituteVars(const string &str)
    std::size_t startPos = 0;
    std::size_t endPos = 0;
 
-   for(std::size_t i = 0; i < s.length(); i++)
+   for(std::size_t i = 0; i < s.length(); ++i)
    {
       if(s[i] == '%')
       {
@@ -211,14 +216,15 @@ void ChatMessageDisplayer::render(S32 anchorPos, bool helperVisible, bool announ
    if(announcementActive)
    {
       if(!mExpire && mFirst >= (U32)mMessages.size() - 1)
-         last++;
+         ++last;
+
 
       y -= lineHeight;
    }
 
    FontManager::pushFontContext(ChatMessageContext);
 
-   for(U32 i = mFirst; i != last - renderExtra; i--)
+   for(U32 i = mFirst; i != last - renderExtra; --i)
    {
       U32 index = i % (U32)mMessages.size();
 

--- a/zap/ClientGame.cpp
+++ b/zap/ClientGame.cpp
@@ -47,10 +47,10 @@ static void initializeHelpItemForObjects()
    if(initialized)
       return;
 
-   for(S32 i = 0; i < TypesNumbers; i++)
+   for(S32 i = 0; i < TypesNumbers; ++i)
       hasHelpItemForObjects[i] = false;
 
-   for(S32 i = 0; i < HelpItemCount; i++)
+   for(S32 i = 0; i < HelpItemCount; ++i)
    {
       U8 objectType = HelpItemManager::getAssociatedObjectType(HelpItem(i));
       if(objectType != UnknownTypeNumber)
@@ -72,7 +72,7 @@ ClientGame::ClientGame(const Address &bindAddress, GameSettingsPtr settings, UIM
    // TODO: Make this a ref instead of a pointer
    mClientInfo = new FullClientInfo(this, NULL, mSettings->getPlayerName(), ClientInfo::ClassHuman);  // Deleted in destructor
 
-   for(S32 i = 0; i < SDL_CONTROLLER_AXIS_MAX; i++)
+   for(S32 i = 0; i < SDL_CONTROLLER_AXIS_MAX; ++i)
       normalizedAxesValues[i] = 0;
 
    initializeHelpItemForObjects();
@@ -820,7 +820,7 @@ void ClientGame::idle(U32 timeDelta)
          const Vector<DatabaseObject *> *gameObjects = mGameObjDatabase->findObjects_fast();
 
          // Visit each game object, handling moves and running its idle method
-         for(S32 i = gameObjects->size() - 1; i >= 0; i--)
+         for(S32 i = gameObjects->size() - 1; i >= 0; --i)
          {
             BfObject *obj = static_cast<BfObject *>((*gameObjects)[i]);
 
@@ -857,7 +857,7 @@ void ClientGame::idle(U32 timeDelta)
             mGameObjDatabase->findObjects((TestFunc)hasRelatedHelpItem, fillVector, searchRect);
 
             if(getUIManager()->isShowingInGameHelp())
-               for(S32 i = 0; i < fillVector.size(); i++)
+               for(S32 i = 0; i < fillVector.size(); ++i)
                {
                   BfObject *obj = static_cast<BfObject *>(fillVector[i]);
                   addInlineHelpItem(obj->getObjectTypeNumber(), obj->getTeam(), localPlayerShip->getTeam());
@@ -1405,7 +1405,7 @@ void ClientGame::addToMuteList(const string &name)
 void ClientGame::removeFromMuteList(const string &name)
 {
 
-   for(S32 i = 0; i < mMuteList.size(); i++)
+   for(S32 i = 0; i < mMuteList.size(); ++i)
       if(mMuteList[i] == name)
       {
          mMuteList.erase_fast(i);
@@ -1416,7 +1416,7 @@ void ClientGame::removeFromMuteList(const string &name)
 
 bool ClientGame::isOnMuteList(const string &name)
 {
-   for(S32 i = 0; i < mMuteList.size(); i++)
+   for(S32 i = 0; i < mMuteList.size(); ++i)
       if(mMuteList[i] == name)
          return true;
 
@@ -1433,7 +1433,7 @@ void ClientGame::addToVoiceMuteList(const string &name)
 void ClientGame::removeFromVoiceMuteList(const string &name)
 {
 
-   for(S32 i = 0; i < mVoiceMuteList.size(); i++)
+   for(S32 i = 0; i < mVoiceMuteList.size(); ++i)
       if(mVoiceMuteList[i] == name)
       {
          mVoiceMuteList.erase_fast(i);
@@ -1444,7 +1444,7 @@ void ClientGame::removeFromVoiceMuteList(const string &name)
 
 bool ClientGame::isOnVoiceMuteList(const string &name)
 {
-   for(S32 i = 0; i < mVoiceMuteList.size(); i++)
+   for(S32 i = 0; i < mVoiceMuteList.size(); ++i)
       if(mVoiceMuteList[i] == name)
          return true;
 
@@ -1562,7 +1562,7 @@ bool ClientGame::checkName(string &name)
    S32 potentials = 0;
    string correctedName = name;
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       StringTableEntry n = Parent::getClientInfo(i)->getName();
 
@@ -1571,7 +1571,8 @@ bool ClientGame::checkName(string &name)
 
       else if(!stricmp(n.getString(), name.c_str()))     // Case insensitive match
       {
-         potentials++;
+         ++potentials;
+
          correctedName = n.getString();
       }
    }
@@ -1746,7 +1747,8 @@ bool ClientGame::processPseudoItem(S32 argc, const char **argv, const string &le
    {
       if(database == getGameObjDatabase())
       {
-         mObjectsLoaded++;
+         ++mObjectsLoaded;
+
          return true;
       }
 
@@ -1768,7 +1770,8 @@ bool ClientGame::processPseudoItem(S32 argc, const char **argv, const string &le
    {
       if(database == getGameObjDatabase())
       {
-         mObjectsLoaded++;
+         ++mObjectsLoaded;
+
          return true;
       }
 
@@ -1809,7 +1812,7 @@ bool ClientGame::processPseudoItem(S32 argc, const char **argv, const string &le
       // full-fledged objects on the server (instead of pseudoItems here).
       string robotLine = "";
 
-      for(S32 i = 0; i < argc; i++)
+      for(S32 i = 0; i < argc; ++i)
       {
          if(i > 0)
             robotLine.append(" ");

--- a/zap/ClientInfo.cpp
+++ b/zap/ClientInfo.cpp
@@ -388,7 +388,7 @@ void ClientInfo::endOfGameScoringHandler()
 }
 
 
-void ClientInfo::incrementKillStreak() { mCurrentKillStreak++;   }
+void ClientInfo::incrementKillStreak() { ++mCurrentKillStreak;   }
 void ClientInfo::clearKillStreak()     { mCurrentKillStreak = 0; }
 
 

--- a/zap/ClientInfo.cpp
+++ b/zap/ClientInfo.cpp
@@ -250,10 +250,10 @@ void::ClientInfo::updateLoadout(bool useOnDeck, bool engineerAllowed, bool silen
       // second 16 bits to weapons.  The integer created might look like so:
       //    00000000000001110000000000000011
       U32 loadoutHash = 0;
-      for(S32 i = 0; i < ShipModuleCount; i++)
+      for(S32 i = 0; i < ShipModuleCount; ++i)
          loadoutHash |= BIT(loadout.hasModule(ShipModule(i)) ? 1 : 0);
 
-      for(S32 i = 0; i < ShipWeaponCount; i++)
+      for(S32 i = 0; i < ShipWeaponCount; ++i)
          loadoutHash |= BIT(loadout.hasWeapon(WeaponType(i)) ? 1 : 0) << 16;
 
       getStatistics()->addLoadout(loadoutHash);
@@ -457,13 +457,15 @@ bool ClientInfo::sEngineerDeployObject(U32 objectType)
          case EngineeredTurret:
             e.push_back("turret");
             responseEvent = EngineerEventTurretBuilt;
-            stats->mTurretsEngineered++;
+            ++stats->mTurretsEngineered;
+
             break;
 
          case EngineeredForceField:
             e.push_back("force field");
             responseEvent = EngineerEventForceFieldBuilt;
-            stats->mFFsEngineered++;
+            ++stats->mFFsEngineered;
+
             break;
 
          case EngineeredTeleporterEntrance:
@@ -474,7 +476,8 @@ bool ClientInfo::sEngineerDeployObject(U32 objectType)
          case EngineeredTeleporterExit:
             e.push_back("teleport exit");
             responseEvent = EngineerEventTeleporterExitBuilt;
-            stats->mTeleportersEngineered++;
+            ++stats->mTeleportersEngineered;
+
             break;
 
          default:
@@ -514,7 +517,7 @@ void ClientInfo::setEngineeringTeleporter(bool engineeringTeleporter)
    setIsEngineeringTeleporter(engineeringTeleporter);
 
    // Tell everyone that a particular client is engineering a teleport
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       GameType *gameType = mGame->getGameType();
 
@@ -595,7 +598,8 @@ Nonce *ClientInfo::getId()
 // Server only
 void ClientInfo::addKill()
 {
-   mCurrentKillStreak++;
+   ++mCurrentKillStreak;
+
    mStatistics.addKill(mCurrentKillStreak);
 }
 
@@ -647,7 +651,7 @@ void FullClientInfo::setAuthenticated(bool isAuthenticated, Int<BADGE_COUNT> bad
 
    // Broadcast new connection status to all clients, except the client that is authenticated.  Presumably they already know.
    if(mGame->isServer())
-      for(S32 i = 0; i < mGame->getClientCount(); i++)
+      for(S32 i = 0; i < mGame->getClientCount(); ++i)
          if(mGame->getClientInfo(i)->getName() != mName && mGame->getClientInfo(i)->getConnection())
             mGame->getClientInfo(i)->getConnection()->s2cSetAuthenticated(mName, isAuthenticated, badges, gamesPlayed);
 }

--- a/zap/ConnectionStatsRenderer.cpp
+++ b/zap/ConnectionStatsRenderer.cpp
@@ -57,7 +57,8 @@ void ConnectionStatsRenderer::idle(U32 timeDelta, GameConnection *conn)
       mSendSize[mCurrentIndex] = conn->mPacketSendBytesTotal;
       mRecvSize[mCurrentIndex] = conn->mPacketRecvBytesTotal;
 
-      mCurrentIndex++;
+      ++mCurrentIndex;
+
       if(mCurrentIndex >= ArraySize)
          mCurrentIndex = 0;
    }
@@ -117,13 +118,13 @@ void ConnectionStatsRenderer::render(GameConnection *conn) const
       const U32 ArraySizeGraph = ArraySize - 1;
 
       F32 graphs[ArraySizeGraph * 2];
-      for(U32 i = 0; i < ArraySizeGraph; i++)
+      for(U32 i = 0; i < ArraySizeGraph; ++i)
          graphs[i * 2] = F32(i * (x2 - x1)) / (ArraySizeGraph - 1) + x1;
 
       U32 i1 = mCurrentIndex;
       U32 i2 = i1 + 1 >= ArraySize ? 0 : i1 + 1;
       U32 max = 0;
-      for(U32 x = 0; x < ArraySizeGraph; x++)
+      for(U32 x = 0; x < ArraySizeGraph; ++x)
       {
          if(mSendSize[i2] - mSendSize[i1] > max)
             max = mSendSize[i2] - mSendSize[i1];
@@ -135,7 +136,7 @@ void ConnectionStatsRenderer::render(GameConnection *conn) const
 
       i1 = mCurrentIndex;
       i2 = i1 + 1 >= ArraySize ? 0 : i1 + 1;
-      for(U32 x = 0; x < ArraySizeGraph; x++)
+      for(U32 x = 0; x < ArraySizeGraph; ++x)
       {
          graphs[x * 2 + 1] = (y + y_size) - F32(mSendSize[i2] - mSendSize[i1]) * y_size / max;
          i1 = i2;
@@ -148,7 +149,7 @@ void ConnectionStatsRenderer::render(GameConnection *conn) const
 
       i1 = mCurrentIndex;
       i2 = i1+1 >= ArraySize ? 0 : i1+1;
-      for(U32 x = 0; x < ArraySizeGraph; x++)
+      for(U32 x = 0; x < ArraySizeGraph; ++x)
       {
          graphs[x * 2 + 1] = (y + y_size) - F32(mRecvSize[i2] - mRecvSize[i1]) * y_size / max;
          i1 = i2;

--- a/zap/CoreGame.cpp
+++ b/zap/CoreGame.cpp
@@ -97,7 +97,7 @@ void CoreGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) con
       return;
    }
 
-   for(S32 i = mCores.size() - 1; i >= 0; i--)
+   for(S32 i = mCores.size() - 1; i >= 0; --i)
    {
       CoreItem *coreItem = mCores[i];
       if(coreItem)  // Core may have been destroyed
@@ -112,7 +112,7 @@ void CoreGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) con
 
 bool CoreGameType::isTeamCoreBeingAttacked(S32 teamIndex) const
 {
-   for(S32 i = mCores.size() - 1; i >= 0; i--)
+   for(S32 i = mCores.size() - 1; i >= 0; --i)
    {
       CoreItem *coreItem = mCores[i];
 
@@ -155,7 +155,7 @@ Vector<string> CoreGameType::getGameParameterMenuKeys()
    Vector<string> items = Parent::getGameParameterMenuKeys();
 
    // Replace "Win Score" as that's not needed here -- win score is determined by the number of cores
-   for(S32 i = 0; i < items.size(); i++)
+   for(S32 i = 0; i < items.size(); ++i)
       if(items[i] == "Win Score")
       {
          items[i] = CoreGameTeamRedistKey;
@@ -170,7 +170,7 @@ shared_ptr<MenuItem> CoreGameType::getMenuItem(const string &key)
 {
    Vector<string> opts;
 
-   for(S32 i = 0; i < RedistCount; i++)
+   for(S32 i = 0; i < RedistCount; ++i)
       opts.push_back(CoreGameRedistNames[i]);
 
    if(key == CoreGameTeamRedistKey)
@@ -239,10 +239,11 @@ void CoreGameType::updateScore(ClientInfo *player, S32 team, ScoringEvent event,
 
       S32 numberOfTeamsHaveSomeCores = 0;
       // Count up the teams that still have Cores
-      for(S32 i = 0; i < getGame()->getTeamCount(); i++)
+      for(S32 i = 0; i < getGame()->getTeamCount(); ++i)
       {
          if(((Team *)getGame()->getTeam(i))->getScore() != 0)
-            numberOfTeamsHaveSomeCores++;
+            ++numberOfTeamsHaveSomeCores;
+
       }
 
       // Handle losing team redistribution
@@ -252,7 +253,7 @@ void CoreGameType::updateScore(ClientInfo *player, S32 team, ScoringEvent event,
       {
          // Get players on this (losing) team
          Vector<ClientInfo*> players;
-         for(S32 i = 0; i < getGame()->getClientCount(); i++)
+         for(S32 i = 0; i < getGame()->getClientCount(); ++i)
          {
             ClientInfo *info = getGame()->getClientInfo(i);
 
@@ -392,7 +393,7 @@ void CoreGameType::handleRedistribution(Vector<ClientInfo*> &players)
    S32 teamsCount = getGame()->getTeamCount();
 
    // Check to make sure at least one team has at least one player...
-   for(S32 i = 0; i < teamsCount; i++)
+   for(S32 i = 0; i < teamsCount; ++i)
    {
       // Add teams to list if they still have Cores
       Team *team = (Team *)getGame()->getTeam(i);
@@ -419,7 +420,7 @@ void CoreGameType::handleRedistribution(Vector<ClientInfo*> &players)
          // Duplicate and sort by the balancing algorithm
          Vector<Team*> balancedSortedTeams(remainingTeams);
 
-         for(S32 i = 0; i < players.size(); i++)
+         for(S32 i = 0; i < players.size(); ++i)
          {
             // Update mTeams, must be run before anything that calls Team::getPlayerCount()
             getGame()->countTeamPlayers();
@@ -441,7 +442,7 @@ void CoreGameType::handleRedistribution(Vector<ClientInfo*> &players)
 
       case RedistRandom:
       {
-         for(S32 i = 0; i < players.size(); i++)
+         for(S32 i = 0; i < players.size(); ++i)
          {
             // Randomly grab a team index
             S32 randomIndex = TNL::Random::readI(0, remainingTeams.size() - 1);
@@ -458,7 +459,7 @@ void CoreGameType::handleRedistribution(Vector<ClientInfo*> &players)
       {
          Team *receivingTeam = remainingTeams.first();  // Losers at index 0
 
-         for(S32 i = 0; i < players.size(); i++)
+         for(S32 i = 0; i < players.size(); ++i)
          {
             ClientInfo *clientInfo = players[i];
             // Send player to new team
@@ -471,7 +472,7 @@ void CoreGameType::handleRedistribution(Vector<ClientInfo*> &players)
       {
          Team *receivingTeam = remainingTeams.last();  // Winners at last index
 
-         for(S32 i = 0; i < players.size(); i++)
+         for(S32 i = 0; i < players.size(); ++i)
          {
             ClientInfo *clientInfo = players[i];
             // Send player to new team
@@ -490,7 +491,7 @@ void CoreGameType::handleRedistribution(Vector<ClientInfo*> &players)
    // Send server message to players that they've been moved
    if(playersMoved)
    {
-      for(S32 i = 0; i < players.size(); i++)
+      for(S32 i = 0; i < players.size(); ++i)
       {
          ClientInfo *clientInfo = players[i];
          if(!clientInfo->isRobot())
@@ -507,7 +508,7 @@ void CoreGameType::handleNewClient(ClientInfo *clientInfo)
 
    // Find if any teams have already lost
    bool hasLostTeam = false;
-   for(S32 i = 0; i < teamsCount; i++)
+   for(S32 i = 0; i < teamsCount; ++i)
    {
       // Add teams to list if they still have Cores
       Team *team = (Team *)getGame()->getTeam(i);
@@ -777,7 +778,7 @@ void CoreItem::damageObject(DamageInfo *theInfo)
    if(theInfo->damageAmount < 0)
    {
       // Heal each damaged core if it is in range
-      for(S32 i = 0; i < CORE_PANELS; i++)
+      for(S32 i = 0; i < CORE_PANELS; ++i)
          if(isPanelDamaged(i))
             if(isPanelInRepairRange(theInfo->damagingObject->getPos(), i))
             {
@@ -840,7 +841,7 @@ void CoreItem::damageObject(DamageInfo *theInfo)
    if(mPanelHealth[hit] == 0)
    {
       coreDestroyed = true;
-      for(S32 i = 0; i < CORE_PANELS; i++)
+      for(S32 i = 0; i < CORE_PANELS; ++i)
          if(mPanelHealth[i] > 0)
          {
             coreDestroyed = false;
@@ -917,7 +918,8 @@ void CoreItem::doExplosion(const Point &pos)
    game->emitBlast(blastPoint, 600 - 100 * mCurrentExplosionNumber);
    game->emitExplosion(blastPoint, 4.f - F32(mCurrentExplosionNumber), CoreExplosionColors, ARRAYSIZE(CoreExplosionColors));
 
-   mCurrentExplosionNumber++;
+   ++mCurrentExplosionNumber;
+
 }
 #endif
 
@@ -941,14 +943,14 @@ void CoreItem::fillPanelGeom(const Point &pos, U32 time, PanelGeom &panelGeom)
 
    F32 angles[CORE_PANELS];
 
-   for(S32 i = 0; i < CORE_PANELS; i++)
+   for(S32 i = 0; i < CORE_PANELS; ++i)
       angles[i] = i * PANEL_ANGLE + angle;
 
-   for(S32 i = 0; i < CORE_PANELS; i++)
+   for(S32 i = 0; i < CORE_PANELS; ++i)
       panelGeom.vert[i].set(pos.x + cos(angles[i]) * size, pos.y + sin(angles[i]) * size);
 
    Point start, end, mid;
-   for(S32 i = 0; i < CORE_PANELS; i++)
+   for(S32 i = 0; i < CORE_PANELS; ++i)
    {
       start = panelGeom.vert[i];
       end   = panelGeom.vert[(i + 1) % CORE_PANELS];      // Next point, with wrap-around
@@ -986,7 +988,7 @@ void CoreItem::doPanelDebris(S32 panelIndex)
 
    Point chunkPos, chunkVel;           // Reusable containers
 
-   for(S32 i = 0; i < num; i++)
+   for(S32 i = 0; i < num; ++i)
    {
       static const S32 MAX_CHUNK_LENGTH = 10;
       points[1].set(0, Random::readF() * MAX_CHUNK_LENGTH);
@@ -1007,7 +1009,7 @@ void CoreItem::doPanelDebris(S32 panelIndex)
 
    // Draw debris for the panel health 'stake'
    num = Random::readI(5, 15);
-   for(S32 i = 0; i < num; i++)
+   for(S32 i = 0; i < num; ++i)
    {
       points.erase(1);
       points.push_back(Point(0, Random::readF() * 10));
@@ -1078,7 +1080,7 @@ void CoreItem::idle(BfObject::IdleCallPath path)
    {
       Point cross, dir;
 
-      for(S32 i = 0; i < CORE_PANELS; i++)
+      for(S32 i = 0; i < CORE_PANELS; ++i)
       {
          // Panel is dead (ensured by damageObject() )
          if(mPanelHealth[i] == 0)
@@ -1109,7 +1111,7 @@ void CoreItem::setStartingHealth(F32 health)
    mStartingPanelHealth = mStartingHealth / CORE_PANELS;
 
    // Core's total health is divided evenly amongst its panels
-   for(S32 i = 0; i < 10; i++)
+   for(S32 i = 0; i < 10; ++i)
       mPanelHealth[i] = mStartingPanelHealth;
 }
 
@@ -1124,7 +1126,7 @@ F32 CoreItem::getTotalCurrentHealth() const
 {
    F32 total = 0;
 
-   for(S32 i = 0; i < CORE_PANELS; i++)
+   for(S32 i = 0; i < CORE_PANELS; ++i)
       total += mPanelHealth[i];
 
    return total;
@@ -1159,7 +1161,7 @@ Vector<Point> CoreItem::getRepairLocations(const Point &repairOrigin)
 
    PanelGeom *panelGeom = getPanelGeom();
 
-   for(S32 i = 0; i < CORE_PANELS; i++)
+   for(S32 i = 0; i < CORE_PANELS; ++i)
       if(isPanelDamaged(i))
          if(isPanelInRepairRange(repairOrigin, i))
             repairLocations.push_back(panelGeom->repair[i]);
@@ -1221,7 +1223,7 @@ U32 CoreItem::packUpdate(GhostConnection *connection, U32 updateMask, BitStream 
    if(!mHasExploded)
    {
       // Don't bother with health report if we've exploded
-      for(S32 i = 0; i < CORE_PANELS; i++)
+      for(S32 i = 0; i < CORE_PANELS; ++i)
       {
          if(stream->writeFlag(updateMask & (PanelDamagedMask << i))) // go through each bit mask
          {
@@ -1256,7 +1258,7 @@ void CoreItem::unpackUpdate(GhostConnection *connection, BitStream *stream)
 
    if(stream->readFlag())     // Exploding!  Take cover!!
    {
-      for(S32 i = 0; i < CORE_PANELS; i++)
+      for(S32 i = 0; i < CORE_PANELS; ++i)
          mPanelHealth[i] = 0;
 
       if(!mHasExploded)    // Just exploded!
@@ -1268,7 +1270,7 @@ void CoreItem::unpackUpdate(GhostConnection *connection, BitStream *stream)
    }
    else                             // Haven't exploded, getting health
    {
-      for(S32 i = 0; i < CORE_PANELS; i++)
+      for(S32 i = 0; i < CORE_PANELS; ++i)
       {
          if(stream->readFlag())                    // Panel damaged
          {

--- a/zap/Cursor.cpp
+++ b/zap/Cursor.cpp
@@ -155,7 +155,7 @@ void Cursor::reverseBits()
 
    TNLAssert(ARRAYSIZE(bits) == ARRAYSIZE(maskBits), "Mask is not the same size as the bits!");
 
-   for(U32 i = 0; i < ARRAYSIZE(bits); i++)
+   for(U32 i = 0; i < ARRAYSIZE(bits); ++i)
    {
       bits[i] = U8(((bits[i] * 0x0802LU & 0x22110LU) | (bits[i] * 0x8020LU & 0x88440LU)) * 0x10101LU >> 16);
       maskBits[i] = U8(((maskBits[i] * 0x0802LU & 0x22110LU) | (maskBits[i] * 0x8020LU & 0x88440LU)) * 0x10101LU >> 16);

--- a/zap/DebugOverlayRenderer.cpp
+++ b/zap/DebugOverlayRenderer.cpp
@@ -48,7 +48,7 @@ void DebugOverlayRenderer::appendBotPaths(ClientGame *game, Vector<BfObject *> &
    ServerGame *serverGame = game->getServerGame();
 
    if(serverGame)
-      for(S32 i = 0; i < serverGame->getBotCount(); i++)
+      for(S32 i = 0; i < serverGame->getBotCount(); ++i)
          renderObjects.push_back(serverGame->getBot(i));
 }
 
@@ -63,7 +63,7 @@ void DebugOverlayRenderer::populateRenderZones(ClientGame *game, const Rect *ext
       game->getBotZoneDatabase()->findObjects(BotNavMeshZoneTypeNumber, mRawRenderObjects);
 
    mRenderZones.clear();
-   for(S32 i = 0; i < mRawRenderObjects.size(); i++)
+   for(S32 i = 0; i < mRawRenderObjects.size(); ++i)
       mRenderZones.push_back(static_cast<BotNavMeshZone *>(mRawRenderObjects[i]));
 }
 
@@ -110,7 +110,7 @@ void DebugOverlayRenderer::renderObjectIds(const ClientGame *game) const
 
    const Vector<DatabaseObject *> *objects = Game::getServerGameObjectDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objects->size(); i++)
+   for(S32 i = 0; i < objects->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objects->get(i));
       static const S32 height = 13;
@@ -137,7 +137,7 @@ void DebugOverlayRenderer::renderObjectIds(const ClientGame *game) const
 
 void DebugOverlayRenderer::renderMeshZones(S32 layer) const
 {
-   for(S32 i = 0; i < mRenderZones.size(); i++)
+   for(S32 i = 0; i < mRenderZones.size(); ++i)
       mRenderZones[i]->renderLayer(layer);
 }
 
@@ -161,7 +161,7 @@ void DebugOverlayRenderer::renderMapTiles(const ClientGame *game) const
    // Collect unique grid coordinates from all tile bounds.
    // All tiles are the same size, so sorting and deduping gives the grid lines.
    Vector<F32> gridX, gridY;
-   for(S32 i = 0; i < tiles.size(); i++)
+   for(S32 i = 0; i < tiles.size(); ++i)
    {
       gridX.push_back(tiles[i].bounds.min.x);
       gridX.push_back(tiles[i].bounds.max.x);
@@ -173,25 +173,25 @@ void DebugOverlayRenderer::renderMapTiles(const ClientGame *game) const
 
    // Dedup within a small epsilon
    Vector<F32> uniqX, uniqY;
-   for(S32 i = 0; i < gridX.size(); i++)
+   for(S32 i = 0; i < gridX.size(); ++i)
       if(i == 0 || gridX[i] > gridX[i-1] + 0.1f)
          uniqX.push_back(gridX[i]);
 
-   for(S32 i = 0; i < gridY.size(); i++)
+   for(S32 i = 0; i < gridY.size(); ++i)
       if(i == 0 || gridY[i] > gridY[i-1] + 0.1f)
          uniqY.push_back(gridY[i]);
 
    // Draw the grid as horizontal and vertical lines (each edge once)
    r.setColor(Colors::cyan, 0.35f);
    r.setLineWidth(1);
-   for(S32 i = 0; i < uniqX.size(); i++)
+   for(S32 i = 0; i < uniqX.size(); ++i)
    {
       Vector<Point> line;
       line.push_back(Point(uniqX[i], uniqY[0]));
       line.push_back(Point(uniqX[i], uniqY[uniqY.size()-1]));
       r.renderPointVector(&line, RenderType::Lines);
    }
-   for(S32 i = 0; i < uniqY.size(); i++)
+   for(S32 i = 0; i < uniqY.size(); ++i)
    {
       Vector<Point> line;
       line.push_back(Point(uniqX[0], uniqY[i]));
@@ -204,17 +204,17 @@ void DebugOverlayRenderer::renderMapTiles(const ClientGame *game) const
    //   red    = clip-introduced edge (outline == false, normally hidden)
    // Batch all edges into two vectors for fewer draw calls
    Vector<Point> origEdges, clipEdges;
-   for(S32 i = 0; i < tiles.size(); i++)
+   for(S32 i = 0; i < tiles.size(); ++i)
    {
       const MapTile &tile = tiles[i];
-      for(S32 j = 0; j < tile.polys.size(); j++)
+      for(S32 j = 0; j < tile.polys.size(); ++j)
       {
          const WallPoly &wp = tile.polys[j];
          const U32 numVerts = wp.numVerts();
          if(numVerts < 3)
             continue;
 
-         for(U32 k = 0; k < numVerts; k++)
+         for(U32 k = 0; k < numVerts; ++k)
          {
             const U32 v0 = k * 2;
             const U32 v1 = ((k + 1) % numVerts) * 2;
@@ -235,7 +235,7 @@ void DebugOverlayRenderer::renderMapTiles(const ClientGame *game) const
       r.renderPointVector(&clipEdges, RenderType::Lines);
 
    // Draw tile ID labels centered in each tile
-   for(S32 i = 0; i < tiles.size(); i++)
+   for(S32 i = 0; i < tiles.size(); ++i)
    {
       const MapTile &tile = tiles[i];
       F32 cx = (tile.bounds.min.x + tile.bounds.max.x) / 2;
@@ -296,14 +296,14 @@ void DebugOverlayRenderer::renderEdgeIds(const ClientGame *game) const
    std::set<EdgeKey> keys;
    std::map<EdgeKey, Point> keyMidpoints;  // midpoint for label placement
 
-   for(S32 t = 0; t < tiles.size(); t++)
+   for(S32 t = 0; t < tiles.size(); ++t)
    {
-      for(S32 p = 0; p < tiles[t].polys.size(); p++)
+      for(S32 p = 0; p < tiles[t].polys.size(); ++p)
       {
          const WallPoly &wp = tiles[t].polys[p];
          U32 nv = wp.numVerts();
 
-         for(U32 e = 0; e < nv; e++)
+         for(U32 e = 0; e < nv; ++e)
          {
             // Include ALL edges — including EdgeStyle::None (tile boundary /
             // interior overlap edges).  This is so /showedgeids shows every
@@ -380,7 +380,8 @@ void DebugOverlayRenderer::renderEdgeIds(const ClientGame *game) const
 
       r.setColor(col);
       drawStringf(labelX, labelY, fontSize, "%d", nextId);
-      nextId++;
+      ++nextId;
+
    }
 }
 

--- a/zap/EditorPlugin.cpp
+++ b/zap/EditorPlugin.cpp
@@ -97,7 +97,7 @@ bool EditorPlugin::runGetArgsMenu(string &menuTitle, Vector<shared_ptr<MenuItem>
       // based on what we've found so far. This lets scripts using the new
       // system to put the returned values in a human-readable order, while
       // maintaining backwards-compatibility with old plugins.
-      for(S32 i = 1; i <= numResults; i++)
+      for(S32 i = 1; i <= numResults; ++i)
       {
          if(lua_istable(L, i))
          {
@@ -321,7 +321,7 @@ S32 EditorPlugin::lua_getSelectedObjects(lua_State *L)
    const Vector<DatabaseObject *> *objects = mGridDatabase->findObjects_fast();
    map<U32, BfObject*> orderedSelectedItems;
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objects->get(i));
 
@@ -338,11 +338,11 @@ S32 EditorPlugin::lua_getSelectedObjects(lua_State *L)
    S32 pushed = 0;
 
    map<U32, BfObject*>::iterator it;
-   for(it = orderedSelectedItems.begin(); it != orderedSelectedItems.end(); it++)
+   for(it = orderedSelectedItems.begin(); it != orderedSelectedItems.end(); ++it)
    {
       BfObject *obj = (*it).second;
       obj->push(L);
-      pushed++;         // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;         // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 
@@ -367,12 +367,12 @@ S32 EditorPlugin::lua_getAllObjects(lua_State *L)
 
    S32 pushed = 0;
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objects->get(i));
 
       obj->push(L);
-      pushed++;         // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;         // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 

--- a/zap/EngineeredItem.cpp
+++ b/zap/EngineeredItem.cpp
@@ -214,7 +214,7 @@ bool EngineerModuleDeployer::canCreateObjectAtLocation(const GridDatabase *gameO
    fillVector.clear();
    gameObjectDatabase->findObjects(ForceFieldProjectorTypeNumber, fillVector, queryRect);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       ForceFieldProjector *ffp = static_cast<ForceFieldProjector *>(fillVector[i]);
 
@@ -237,7 +237,7 @@ bool EngineerModuleDeployer::canCreateObjectAtLocation(const GridDatabase *gameO
       // Reusable containers for holding geom of any forcefields we might need to check for intersection with our candidate
       Point start, end;
 
-      for(S32 i = 0; i < fillVector.size(); i++)
+      for(S32 i = 0; i < fillVector.size(); ++i)
       {
          ForceFieldProjector *proj = static_cast<ForceFieldProjector *>(fillVector[i]);
 
@@ -288,7 +288,7 @@ bool EngineerModuleDeployer::canCreateObjectAtLocation(const GridDatabase *gameO
    // Search for wall segments within query
    gameObjectDatabase->findObjects(isWallType, fillVector, queryRect);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       // Exclude the end segment from our search
       if(terminatingWallObject && terminatingWallObject == fillVector[i])
@@ -315,7 +315,7 @@ bool EngineerModuleDeployer::canCreateObjectAtLocation(const GridDatabase *gameO
    fillVector.clear();
    gameObjectDatabase->findObjects(TurretTypeNumber, fillVector, queryRect);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       Turret *turret = static_cast<Turret *>(fillVector[i]);
 
@@ -895,7 +895,7 @@ bool EngineeredItem::checkDeploymentPosition(const Vector<Point> &thisBounds, co
    Rect queryRect(thisBounds);
    gb->findObjects((TestFunc) isForceFieldCollideableType, foundObjects, queryRect);
 
-   for(S32 i = 0; i < foundObjects.size(); i++)
+   for(S32 i = 0; i < foundObjects.size(); ++i)
    {
       const Vector<Point> *foundObjectBounds = static_cast<BfObject *>(foundObjects[i])->getCollisionPoly();
       if(polygonsIntersect(thisBounds, *foundObjectBounds))     // Do they intersect?
@@ -2087,7 +2087,7 @@ bool Turret::processArguments(S32 argc2, const char **argv2, Game *game)
 {
    S32 argc1 = 0;
    const char *argv1[32];
-   for(S32 i = 0; i < argc2; i++)
+   for(S32 i = 0; i < argc2; ++i)
    {
       const char *token = argv2[i];
       unsigned char firstChar = token[0];
@@ -2123,7 +2123,8 @@ bool Turret::processArguments(S32 argc2, const char **argv2, Game *game)
          if(argc1 < 32)
          {
             argv1[argc1] = token;
-            argc1++;
+            ++argc1;
+
          }
       }
 
@@ -2286,7 +2287,7 @@ void Turret::idle(IdleCallPath path)
    Point bestDelta;
 
    Point delta;
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       if(isShipType(fillVector[i]->getObjectTypeNumber()))
       {

--- a/zap/Event.cpp
+++ b/zap/Event.cpp
@@ -60,7 +60,7 @@ void Event::inputCodeUp(UserInterface *currentUI, InputCode inputCode)
       currentUI->onKeyUp(inputCode);
 
    const Vector<UserInterface *> *uis = currentUI->getUIManager()->getPrevUIs();
-   for(S32 i = 0; i < uis->size(); i++)
+   for(S32 i = 0; i < uis->size(); ++i)
       uis->get(i)->onKeyUp(inputCode);
 }
 

--- a/zap/EventManager.cpp
+++ b/zap/EventManager.cpp
@@ -149,7 +149,7 @@ void EventManager::unsubscribe(LuaScriptRunner *subscriber, EventType eventType)
 
 void EventManager::removeFromPendingSubscribeList(LuaScriptRunner *subscriber, EventType eventType)
 {
-   for(S32 i = 0; i < pendingSubscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < pendingSubscriptions[eventType].size(); ++i)
       if(pendingSubscriptions[eventType][i].subscriber == subscriber)
       {
          pendingSubscriptions[eventType].erase_fast(i);
@@ -160,7 +160,7 @@ void EventManager::removeFromPendingSubscribeList(LuaScriptRunner *subscriber, E
 
 void EventManager::removeFromPendingUnsubscribeList(LuaScriptRunner *subscriber, EventType eventType)
 {
-   for(S32 i = 0; i < pendingUnsubscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < pendingUnsubscriptions[eventType].size(); ++i)
       if(pendingUnsubscriptions[eventType][i] == subscriber)
       {
          pendingUnsubscriptions[eventType].erase_fast(i);
@@ -171,7 +171,7 @@ void EventManager::removeFromPendingUnsubscribeList(LuaScriptRunner *subscriber,
 
 void EventManager::removeFromSubscribedList(LuaScriptRunner *subscriber, EventType eventType)
 {
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
       if(subscriptions[eventType][i].subscriber == subscriber)
       {
          subscriptions[eventType].erase_fast(i);
@@ -192,7 +192,7 @@ void EventManager::unsubscribeImmediate(LuaScriptRunner *subscriber, EventType e
 // Check if we're subscribed to an event
 bool EventManager::isSubscribed(LuaScriptRunner *subscriber, EventType eventType)
 {
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
       if(subscriptions[eventType][i].subscriber == subscriber)
          return true;
 
@@ -202,7 +202,7 @@ bool EventManager::isSubscribed(LuaScriptRunner *subscriber, EventType eventType
 
 bool EventManager::isPendingSubscribed(LuaScriptRunner *subscriber, EventType eventType)
 {
-   for(S32 i = 0; i < pendingSubscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < pendingSubscriptions[eventType].size(); ++i)
       if(pendingSubscriptions[eventType][i].subscriber == subscriber)
          return true;
 
@@ -212,7 +212,7 @@ bool EventManager::isPendingSubscribed(LuaScriptRunner *subscriber, EventType ev
 
 bool EventManager::isPendingUnsubscribed(LuaScriptRunner *subscriber, EventType eventType)
 {
-   for(S32 i = 0; i < pendingUnsubscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < pendingUnsubscriptions[eventType].size(); ++i)
       if(pendingUnsubscriptions[eventType][i] == subscriber)
          return true;
 
@@ -225,15 +225,15 @@ void EventManager::update()
 {
    if(anyPending)
    {
-      for(S32 i = 0; i < EventTypes; i++)
-         for(S32 j = 0; j < pendingUnsubscriptions[i].size(); j++)     // Unsubscribing first means less searching!
+      for(S32 i = 0; i < EventTypes; ++i)
+         for(S32 j = 0; j < pendingUnsubscriptions[i].size(); ++j)     // Unsubscribing first means less searching!
             removeFromSubscribedList(pendingUnsubscriptions[i][j], (EventType) i);
 
-      for(S32 i = 0; i < EventTypes; i++)
-         for(S32 j = 0; j < pendingSubscriptions[i].size(); j++)
+      for(S32 i = 0; i < EventTypes; ++i)
+         for(S32 j = 0; j < pendingSubscriptions[i].size(); ++j)
             subscriptions[i].push_back(pendingSubscriptions[i][j]);
 
-      for(S32 i = 0; i < EventTypes; i++)
+      for(S32 i = 0; i < EventTypes; ++i)
       {
          pendingSubscriptions[i].clear();
          pendingUnsubscriptions[i].clear();
@@ -254,7 +254,7 @@ void EventManager::fireEvent(EventType eventType)
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       bool error = fire(L, subscriptions[eventType][i].subscriber, eventDefs[eventType].function, 0, subscriptions[eventType][i].context);
 
@@ -264,7 +264,8 @@ void EventManager::fireEvent(EventType eventType)
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -277,13 +278,14 @@ void EventManager::fireEvent(EventType eventType, U32 deltaT)
       return;
 
    if(eventType == TickEvent)
-      mStepCount--;
+      --mStepCount;
+
 
    lua_State *L = LuaScriptRunner::getL();
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       lua_pushinteger(L, deltaT);   // -- deltaT
       bool error = fire(L, subscriptions[eventType][i].subscriber, eventDefs[eventType].function, 1, subscriptions[eventType][i].context);
@@ -294,7 +296,8 @@ void EventManager::fireEvent(EventType eventType, U32 deltaT)
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -310,7 +313,7 @@ void EventManager::fireEvent(EventType eventType, CoreItem *core)
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       core->push(L);                // -- core
       bool error = fire(L, subscriptions[eventType][i].subscriber, eventDefs[eventType].function, 1, subscriptions[eventType][i].context);
@@ -321,7 +324,8 @@ void EventManager::fireEvent(EventType eventType, CoreItem *core)
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -337,7 +341,7 @@ void EventManager::fireEvent(EventType eventType, Ship *ship)
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       ship->push(L);                // -- ship
       bool error = fire(L, subscriptions[eventType][i].subscriber, eventDefs[eventType].function, 1, subscriptions[eventType][i].context);
@@ -348,7 +352,8 @@ void EventManager::fireEvent(EventType eventType, Ship *ship)
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -364,7 +369,7 @@ void EventManager::fireEvent(EventType eventType, Ship *ship, BfObject *damaging
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       ship->push(L);                // -- ship
 
@@ -386,7 +391,8 @@ void EventManager::fireEvent(EventType eventType, Ship *ship, BfObject *damaging
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -404,7 +410,7 @@ void EventManager::fireEvent(LuaScriptRunner *sender, EventType eventType, const
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       if(sender == subscriptions[eventType][i].subscriber)    // Don't alert sender about own message!
          continue;
@@ -426,7 +432,8 @@ void EventManager::fireEvent(LuaScriptRunner *sender, EventType eventType, const
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 
@@ -451,7 +458,7 @@ void EventManager::fireEvent(LuaScriptRunner *sender, EventType eventType)
    // we need to make a copy of them first so we can add them back for subsequent calls.
 
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       if(sender == subscriptions[eventType][i].subscriber)    // Don't alert sender about own message!
          continue;
@@ -459,7 +466,7 @@ void EventManager::fireEvent(LuaScriptRunner *sender, EventType eventType)
       Subscription subscription = subscriptions[eventType][i];
 
       // Duplicate the first argCount items on the stack
-      for(S32 j = 1; j <= argCount; j++)
+      for(S32 j = 1; j <= argCount; ++j)
          lua_pushvalue(L, j);
 
       bool error = fire(L, subscription.subscriber, eventDefs[eventType].function, argCount, subscription.context);
@@ -474,7 +481,8 @@ void EventManager::fireEvent(LuaScriptRunner *sender, EventType eventType)
          // subscription.subscriber is getting deleted in the bowels of fire()
          //unsubscribeImmediate(subscription.subscriber, eventType);  /// <===== WHy does this break tests????
          lua_settop(L, argCount);
-         i--;
+         --i;
+
       }
 
       TNLAssert(lua_gettop(L) == argCount, "Expect args to still be on the stack!");
@@ -494,7 +502,7 @@ void EventManager::fireEvent(LuaScriptRunner *player, EventType eventType, LuaPl
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       if(player == subscriptions[eventType][i].subscriber)    // Don't trouble player with own joinage or leavage!
          continue;
@@ -508,7 +516,8 @@ void EventManager::fireEvent(LuaScriptRunner *player, EventType eventType, LuaPl
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -524,7 +533,7 @@ void EventManager::fireEvent(EventType eventType, Ship *ship, Zone *zone)
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       // Passing ship, zone, zoneType, zoneId
       ship->push(L);                                     // -- ship
@@ -540,7 +549,8 @@ void EventManager::fireEvent(EventType eventType, Ship *ship, Zone *zone)
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -556,7 +566,7 @@ void EventManager::fireEvent(EventType eventType, MoveObject *object, Zone *zone
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       // Passing object, zone, zoneType, zoneId
       object->push(L);                                   // -- object
@@ -572,7 +582,8 @@ void EventManager::fireEvent(EventType eventType, MoveObject *object, Zone *zone
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }
@@ -588,7 +599,7 @@ void EventManager::fireEvent(EventType eventType, S32 score, S32 team, LuaPlayer
 
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack dirty!");
 
-   for(S32 i = 0; i < subscriptions[eventType].size(); i++)
+   for(S32 i = 0; i < subscriptions[eventType].size(); ++i)
    {
       lua_pushinteger(L, score);   // -- score
       lua_pushinteger(L, team);    // -- score, team
@@ -606,7 +617,8 @@ void EventManager::fireEvent(EventType eventType, S32 score, S32 team, LuaPlayer
       if(error)
       {
          clearStack(L);
-         i--;
+         --i;
+
       }
    }
 }

--- a/zap/FontManager.cpp
+++ b/zap/FontManager.cpp
@@ -70,7 +70,7 @@ BfFont::BfFont(const string &fontFile, GameSettings *settings)
       return;
    }
 
-   for(U32 i = 0; i < sizeof(SystemFontDirectories) / sizeof(SystemFontDirectories[0]) && mStashFontId <= 0; i++) {
+   for(U32 i = 0; i < sizeof(SystemFontDirectories) / sizeof(SystemFontDirectories[0]) && mStashFontId <= 0; ++i) {
       string file = string(SystemFontDirectories[i]) + getFileSeparator() + fontFile;
       mStashFontId = sth_add_font(FontManager::getStash(), file.c_str());
    }
@@ -130,7 +130,7 @@ bool FontManager::mUsingExternalFonts = true;
 
 FontManager::FontManager()
 {
-   for(S32 i = 0; i < FontCount; i++)
+   for(S32 i = 0; i < FontCount; ++i)
       fontList[i] = NULL;
 }
 
@@ -176,7 +176,7 @@ void FontManager::reinitialize(GameSettings *settings)
 
 void FontManager::cleanup()
 {
-   for(S32 i = 0; i < FontCount; i++)
+   for(S32 i = 0; i < FontCount; ++i)
    {
       delete fontList[i];
       fontList[i] = NULL;
@@ -253,7 +253,7 @@ void FontManager::getStrokeCharacterPoints(const SFG_StrokeChar *schar, F32 xOff
    const SFG_StrokeStrip *strip = schar->Strips;
    U32 arrayOffset = 0;
 
-   for(S32 i = 0; i < schar->Number; i++, strip++)
+   for(S32 i = 0; i < schar->Number; ++i, ++strip)
    {
       // Get first point
       F32 lastX = strip->Vertices[0].X;
@@ -261,7 +261,7 @@ void FontManager::getStrokeCharacterPoints(const SFG_StrokeChar *schar, F32 xOff
 
       // Construct individual lines from the strip. This allows us to render the character using a
       // single GL call with GL_LINES.
-      for(S32 j = 1; j < strip->Number; j++)
+      for(S32 j = 1; j < strip->Number; ++j)
       {
          U32 arrayIndex = arrayOffset + (j - 1) * 4;
 
@@ -304,7 +304,7 @@ void FontManager::renderStrokedString(F32 size, const char *string)
    U32 totalPointCount = 0;
    F32 nextXOffset = 0;
 
-   for(S32 i = 0; (string[i] != 0) && (i < MAX_STRING_LENGTH); i++)
+   for(S32 i = 0; (string[i] != 0) && (i < MAX_STRING_LENGTH); ++i)
    {
       if(!(string[i] > 0))
          continue;

--- a/zap/FpsRenderer.cpp
+++ b/zap/FpsRenderer.cpp
@@ -112,7 +112,8 @@ void FpsRenderer::render(S32 canvasWidth) const
       // Count wall vertices visible on screen as a measure of geometry complexity.
       // On the client, walls arrive as tiled WallPoly fragments, not Barrier objects.
       const Vector<WallPoly> &tilePolys = GameType::getTilePolys();
-      for(S32 i = 0; i < tilePolys.size(); ++i)
+      S32 tilePolys_sz = tilePolys.size();
+      for (S32 i = 0; i < tilePolys_sz; ++i)
       {
          const WallPoly &wp = tilePolys[i];
          U32 nv = wp.numVerts();

--- a/zap/FpsRenderer.cpp
+++ b/zap/FpsRenderer.cpp
@@ -39,7 +39,7 @@ FpsRenderer::FpsRenderer(ClientGame *game)
 
    mFrameIndex = 0;
 
-   for(S32 i = 0; i < FPS_AVG_COUNT; i++)
+   for(S32 i = 0; i < FPS_AVG_COUNT; ++i)
    {
       mIdleTimeDelta[i] = 50;
       mPing[i] = 100;
@@ -64,7 +64,7 @@ void FpsRenderer::idle(U32 timeDelta)
       {
          U32 sum = 0, sumping = 0;
 
-         for(S32 i = 0; i < FPS_AVG_COUNT; i++)
+         for(S32 i = 0; i < FPS_AVG_COUNT; ++i)
          {
             sum += mIdleTimeDelta[i];
             sumping += mPing[i];
@@ -85,7 +85,8 @@ void FpsRenderer::idle(U32 timeDelta)
    if(mGame->getConnectionToServer())
       mPing[index] = (U32)mGame->getConnectionToServer()->getRoundTripTime();
 
-   mFrameIndex++;
+   ++mFrameIndex;
+
 }
 
 
@@ -111,7 +112,7 @@ void FpsRenderer::render(S32 canvasWidth) const
       // Count wall vertices visible on screen as a measure of geometry complexity.
       // On the client, walls arrive as tiled WallPoly fragments, not Barrier objects.
       const Vector<WallPoly> &tilePolys = GameType::getTilePolys();
-      for(S32 i = 0; i < tilePolys.size(); i++)
+      for(S32 i = 0; i < tilePolys.size(); ++i)
       {
          const WallPoly &wp = tilePolys[i];
          U32 nv = wp.numVerts();

--- a/zap/GameManager.cpp
+++ b/zap/GameManager.cpp
@@ -100,7 +100,7 @@ void GameManager::addClientGame(ClientGame *clientGame)
 void GameManager::idleClientGames(U32 timeDelta)
 {
 #ifndef ZAP_DEDICATED
-   for(S32 i = 0; i < mClientGames.size(); i++)
+   for(S32 i = 0; i < mClientGames.size(); ++i)
       mClientGames[i]->idle(timeDelta);
 #endif
 }

--- a/zap/GameRecorder.cpp
+++ b/zap/GameRecorder.cpp
@@ -120,7 +120,7 @@ static void gameRecorderScoping(GameRecorderServer *conn, Game *game)
 
 
    const Vector<DatabaseObject *> &gameObjects = *(game->getGameObjDatabase()->findObjects_fast());
-   for(S32 i=0; i < gameObjects.size(); i++)
+   for(S32 i=0; i < gameObjects.size(); ++i)
    {
       BfObject *obj = dynamic_cast<BfObject *>(gameObjects[i]);
       if(obj && obj->isGhostable())
@@ -137,7 +137,7 @@ static string newRecordingFileName(const string &dir, const string &levelName, c
    getFilesFromFolder(dir, files);
 
    S32 max_id = 0;
-   for(S32 i = 0; i < files.size(); i++)
+   for(S32 i = 0; i < files.size(); ++i)
    {
       S32 id = atoi(files[i].c_str()); // do not use stoi unless using inside throw/cactch, stoi throws errors, if unhandled it kills program.
       if(max_id < id && id < S32_MAX)

--- a/zap/GameRecorderPlayback.cpp
+++ b/zap/GameRecorderPlayback.cpp
@@ -33,7 +33,7 @@ static void idleObjects(ClientGame *game, U32 timeDelta)
    const Vector<DatabaseObject *> *gameObjects = game->getGameObjDatabase()->findObjects_fast();
 
    // Visit each game object, handling moves and running its idle method
-   for(S32 i = gameObjects->size() - 1; i >= 0; i--)
+   for(S32 i = gameObjects->size() - 1; i >= 0; --i)
    {
       BfObject *obj = static_cast<BfObject *>((*gameObjects)[i]);
 
@@ -56,7 +56,7 @@ static void resetRenderState(ClientGame *game)
 {
    const Vector<DatabaseObject *> *gameObjects = game->getGameObjDatabase()->findObjects_fast();
 
-   for(S32 i = gameObjects->size() - 1; i >= 0; i--)
+   for(S32 i = gameObjects->size() - 1; i >= 0; --i)
    {
       BfObject *obj = static_cast<BfObject *>((*gameObjects)[i]);
 
@@ -157,7 +157,7 @@ void GameRecorderPlayback::addPendingMove(Move *theMove)
 void GameRecorderPlayback::changeSpectate(S32 n)
 {
    const Vector<RefPtr<ClientInfo> > &infos = *(mGame->getClientInfos());
-   for(S32 i = 0; i < infos.size(); i++)
+   for(S32 i = 0; i < infos.size(); ++i)
       if(infos[i].getPointer() == mClientInfoSpectating.getPointer())
       {
          n += i;
@@ -226,7 +226,8 @@ void GameRecorderPlayback::processMoreData(U32 MilliSeconds)
       {
          mPacketRecvBytesLast = mSizeToRead;
          mPacketRecvBytesTotal += mSizeToRead;
-         mPacketRecvCount++;
+         ++mPacketRecvCount;
+
 
          if(fread(data, 1, mSizeToRead, mFile) == mSizeToRead)
          {
@@ -307,7 +308,7 @@ void PlaybackSelectUserInterface::onActivate()
    else
       mLevels.sort(alphaNumberSort);
 
-   for(S32 i = 0; i < mLevels.size(); i++)
+   for(S32 i = 0; i < mLevels.size(); ++i)
    {
       addMenuItem(new MenuItem(i, mLevels[i].c_str(), processPlaybackSelectionCallback, ""));
    }
@@ -410,7 +411,7 @@ void PlaybackServerDownloadUserInterface::receivedLevelList(const Vector<string>
 {
    mLevels = levels;
    clearMenuItems();
-   for(S32 i = 0; i < mLevels.size(); i++)
+   for(S32 i = 0; i < mLevels.size(); ++i)
    {
       addMenuItem(new MenuItem(i, mLevels[i].c_str(), processPlaybackDownloadCallback, ""));
    }

--- a/zap/GameSettings.cpp
+++ b/zap/GameSettings.cpp
@@ -692,19 +692,20 @@ Vector<string> GameSettings::getLevelList(const string &levelDir, bool ignoreCmd
 
 
    // Now, remove any levels listed in the skip list from levelList.  Not foolproof!
-   for(S32 i = 0; i < levelList.size(); i++)
+   for(S32 i = 0; i < levelList.size(); ++i)
    {
       // Make sure we have the right extension
       string filename_i = lcase(levelList[i]);
       if(filename_i.find(".level") == string::npos)
          filename_i += ".level";
 
-      for(S32 j = 0; j < mLevelSkipList.size(); j++)
+      for(S32 j = 0; j < mLevelSkipList.size(); ++j)
          if(filename_i == mLevelSkipList[j])
          {
             logprintf(LogConsumer::ServerFilter, "Loader skipping level %s listed in LevelSkipList (see INI file)", levelList[i].c_str());
             levelList.erase(i);
-            i--;
+            --i;
+
             break;
          }
    }
@@ -787,7 +788,7 @@ static S32 getParams(ParamRequirements argsRequired, const S32 paramPtr, const S
       if(!hasAdditionalArg)
          parameterError(errorMsg);
 
-      for(S32 j = argPtr; j < argc; j++)
+      for(S32 j = argPtr; j < argc; ++j)
          params.push_back(argv[j]);
 
       return argc;
@@ -813,7 +814,7 @@ void GameSettings::readCmdLineParams(const Vector<string> &argv)
       if(arg.substr(0, 2) == "--")
          arg = arg.substr(1);
 
-      argPtr++;      // Advance argPtr to location of first parameter argument
+      ++argPtr;      // Advance argPtr to location of first parameter argument
 
       // Mac adds on a 'Process Serial Number' to every application launched from a .app bundle
       // we should just ignore it and not exit the game
@@ -826,7 +827,7 @@ void GameSettings::readCmdLineParams(const Vector<string> &argv)
 #endif
 
       // Scan through the possible params
-      for(U32 i = 0; i < ARRAYSIZE(paramDefs); i++)
+      for(U32 i = 0; i < ARRAYSIZE(paramDefs); ++i)
       {
          if(arg == "-" + paramDefs[i].paramName)
          {
@@ -840,7 +841,7 @@ void GameSettings::readCmdLineParams(const Vector<string> &argv)
       // Didn't find a matching parameter... let's try the commands
       if(!found)
       {
-         for(U32 i = 0; i < ARRAYSIZE(directiveDefs); i++)
+         for(U32 i = 0; i < ARRAYSIZE(directiveDefs); ++i)
          {
             if(arg == "-" + directiveDefs[i].paramName)
             {
@@ -871,7 +872,7 @@ void GameSettings::readCmdLineParams(const Vector<string> &argv)
 // If any directives were specified on the cmd line, run them
 void GameSettings::runCmdLineDirectives()
 {
-   for(S32 i = 0; i < S32(ARRAYSIZE(directiveDefs)); i++)
+   for(S32 i = 0; i < S32(ARRAYSIZE(directiveDefs)); ++i)
    {
       if(mCmdLineParams[directiveDefs[i].paramId].size() > 0)
       {
@@ -1058,7 +1059,7 @@ static string makePad(U32 len)
 {
    string padding = "";
 
-   for(U32 i = 0; i < len; i++)
+   for(U32 i = 0; i < len; ++i)
       padding += " ";
 
    return padding;
@@ -1163,13 +1164,13 @@ static void printHelpEntry(const string &paramName, const string &paramString, c
 
 void GameSettings::showHelp(GameSettings *settings, const Vector<string> &words)
 {
-   for(S32 i = 0; i < S32(ARRAYSIZE(helpTitles)); i++)
+   for(S32 i = 0; i < S32(ARRAYSIZE(helpTitles)); ++i)
    {
       // Make an initial sweep through to check on the sizes of things, to ensure we get the indentation right
       // This first chunk just determies the longest command to figure out how much padding is needed.
       U32 maxSize = 0;
 
-      for(S32 j = 0; j < S32(ARRAYSIZE(paramDefs)); j++)
+      for(S32 j = 0; j < S32(ARRAYSIZE(paramDefs)); ++j)
          if(paramDefs[j].docLevel == i)
          {
             U32 len = (U32) makeParamStr(paramDefs[j].paramName, paramDefs[j].paramString).length();
@@ -1178,7 +1179,7 @@ void GameSettings::showHelp(GameSettings *settings, const Vector<string> &words)
                maxSize = len;
          }
 
-      for(S32 j = 0; j < S32(ARRAYSIZE(directiveDefs)); j++)
+      for(S32 j = 0; j < S32(ARRAYSIZE(directiveDefs)); ++j)
          if(directiveDefs[j].docLevel == i)
          {
             U32 len = (U32) makeParamStr(directiveDefs[j].paramName, directiveDefs[j].paramString).length();
@@ -1189,7 +1190,7 @@ void GameSettings::showHelp(GameSettings *settings, const Vector<string> &words)
 
       bool firstInSection = true;
 
-      for(S32 j = 0; j < S32(ARRAYSIZE(paramDefs)); j++)
+      for(S32 j = 0; j < S32(ARRAYSIZE(paramDefs)); ++j)
       {
          if(paramDefs[j].docLevel != i)
             continue;
@@ -1200,7 +1201,7 @@ void GameSettings::showHelp(GameSettings *settings, const Vector<string> &words)
          firstInSection = false;
       }
 
-      for(S32 j = 0; j < S32(ARRAYSIZE(directiveDefs)); j++)
+      for(S32 j = 0; j < S32(ARRAYSIZE(directiveDefs)); ++j)
       {
          if(directiveDefs[j].docLevel != i)
             continue;
@@ -1279,7 +1280,7 @@ void GameSettings::deleteServerPassword(const string &serverName)
 
 bool GameSettings::isLevelOnSkipList(const string &filename) const
 {
-   for(S32 i = 0; i < mLevelSkipList.size(); i++)
+   for(S32 i = 0; i < mLevelSkipList.size(); ++i)
       if(mLevelSkipList[i] == filename)    // Already on our list!
          return true;
 
@@ -1296,7 +1297,7 @@ void GameSettings::addLevelToSkipList(const string &filename)
 
 void GameSettings::removeLevelFromSkipList(const string &filename)
 {
-   for(S32 i = 0; i < mLevelSkipList.size(); i++)
+   for(S32 i = 0; i < mLevelSkipList.size(); ++i)
       if(mLevelSkipList[i] == filename)
       {
          mLevelSkipList.erase(i);

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -1423,13 +1423,17 @@ void unpackPolygons(const Vector<Vector<Point> > &solution, Vector<Point> &lineS
 
       for(S32 j = 1; j < sol_sz; ++j)
       {
-         lineSegmentPoints[index++] = solution[i][j - 1];
-         lineSegmentPoints[index++] = solution[i][j];
+         lineSegmentPoints[index] = solution[i][j - 1];
+         ++index;
+         lineSegmentPoints[index] = solution[i][j];
+         ++index;
       }
 
       // Close the loop
-      lineSegmentPoints[index++] = solution[i][sol_sz - 1];
-      lineSegmentPoints[index++] = solution[i][0];
+      lineSegmentPoints[index] = solution[i][sol_sz - 1];
+      ++index;
+      lineSegmentPoints[index] = solution[i][0];
+      ++index;
    }
 }
 

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -991,9 +991,10 @@ Paths upscaleClipperPoints(const Vector<Vector<Point> > &inputPolygons)
 
    for(S32 i = 0; i < inputPolygons.size(); ++i)
    {
-      outputPolygons[i].resize(inputPolygons[i].size());
+      S32 polys_sz = inputPolygons[i].size();
+      outputPolygons[i].resize(polys_sz);
 
-      for(S32 j = 0; j < inputPolygons[i].size(); ++j)
+      for(S32 j = 0; j < polys_sz; ++j)
          outputPolygons[i][j] = IntPoint(S64(inputPolygons[i].get(j).x * CLIPPER_SCALE_FACT), S64(inputPolygons[i].get(j).y * CLIPPER_SCALE_FACT));
    }
 
@@ -1332,10 +1333,11 @@ bool polyganize(const Vector<Vector<Point> > &input, Vector<Vector<Point> > &out
 
    for(S32 i = 0; i < input.size(); ++i)
    {
-      if(input[i].size() != 3)
+      S32 input_sz = input[i].size();
+      if(input_sz != 3)
          continue;
 
-      for(S32 j = 0; j < input[i].size(); ++j)
+      for(S32 j = 0; j < input_sz; ++j)
       {
          triangles.push_back(input[i][j]);
       }
@@ -1415,17 +1417,18 @@ void unpackPolygons(const Vector<Vector<Point> > &solution, Vector<Point> &lineS
 
    for(S32 i = 0; i < solution.size(); ++i)
    {
-      if(solution[i].size() == 0)
+      S32 sol_sz = solution[i].size();
+      if(sol_sz == 0)
          continue;
 
-      for(S32 j = 1; j < solution[i].size(); ++j)
+      for(S32 j = 1; j < sol_sz; ++j)
       {
          lineSegmentPoints[index++] = solution[i][j - 1];
          lineSegmentPoints[index++] = solution[i][j];
       }
 
       // Close the loop
-      lineSegmentPoints[index++] = solution[i][solution[i].size() - 1];
+      lineSegmentPoints[index++] = solution[i][sol_sz - 1];
       lineSegmentPoints[index++] = solution[i][0];
    }
 }

--- a/zap/GeomUtils.cpp
+++ b/zap/GeomUtils.cpp
@@ -71,7 +71,7 @@ void calcPolygonVerts(const Point &center, S32 sides, F32 radius, F32 angle, Vec
    F32 theta = 0;
    F32 dTheta = FloatTau / sides;
 
-   for(S32 i = 0; i < sides; i++)
+   for(S32 i = 0; i < sides; ++i)
    {
       F32 x = center.x + cos(theta + angle) * radius;
       F32 y = center.y + sin(theta + angle) * radius;
@@ -98,7 +98,7 @@ bool polygonContainsPoint(const Point *vertices, S32 vertexCount, const Point &p
 
    // loop through all edges of the polygon
    S32 nextIndex;
-   for (S32 i = 0; i < vertexCount; i++)
+   for (S32 i = 0; i < vertexCount; ++i)
    {
       nextIndex = (i+1)%vertexCount;
       if (vertices[i].y <= point.y)
@@ -132,7 +132,7 @@ static bool PolygonContains2p2t(p2t::Point **vertices, int vertexCount, const p2
 
    // loop through all edges of the polygon
    S32 nextIndex;
-   for (S32 i = 0; i < vertexCount; i++)
+   for (S32 i = 0; i < vertexCount; ++i)
    {
       nextIndex = (i+1)%vertexCount;
       if (vertices[i]->y <= point->y)
@@ -157,22 +157,24 @@ static bool PolygonContains2p2t(p2t::Point **vertices, int vertexCount, const p2
 void removeCollinearPoints(Vector<Point> &points, bool isPolygon)
 {
    // Check for duplicate points
-   for(S32 i = 1; i < (S32)points.size(); i++)
+   for(S32 i = 1; i < (S32)points.size(); ++i)
       if(points[i-1] == points[i])
       {
          points.erase(i);
-         i--;
+         --i;
+
       }
 
    if(points.size() < 3)
       return;
 
-   for(S32 i = 1; i < points.size() - 1; i++)
+   for(S32 i = 1; i < points.size() - 1; ++i)
    {
       if((points[i] - points[i-1]).ATAN2() == (points[i+1] - points[i]).ATAN2())
       {
          points.erase(i);
-         i--;
+         --i;
+
       }
    }
 
@@ -259,7 +261,7 @@ bool isConvex(const Vector<Point> *verts)
       return true;
 
    double sign = 0;
-   for(int i = 0; i < n; i++)
+   for(int i = 0; i < n; ++i)
    {
       const Point &p1 = verts->get(i);
       const Point &p2 = verts->get((i + 1) % n);
@@ -364,7 +366,7 @@ bool polygonIntersectsSegment(const Vector<Point> &points, const Point &start, c
    const Point *pointPrev = &points[points.size() - 1];
    F32 ct;
 
-   for(S32 i = 0; i < points.size(); i++)
+   for(S32 i = 0; i < points.size(); ++i)
    {
       if(segmentsIntersect(start, end, *pointPrev, points[i], ct))
          return true;
@@ -386,13 +388,13 @@ bool polygonsIntersect(const Vector<Point> &p1, const Vector<Point> &p2)
    F32 ct;
    const Point *rp1 = &p1[p1.size() - 1];
 
-   for(S32 i = 0; i < p1.size(); i++)
+   for(S32 i = 0; i < p1.size(); ++i)
    {
       const Point *rp2 = &p1[i];
 
       const Point *cp1 = &p2[p2.size() - 1];
 
-      for(S32 j = 0; j < p2.size(); j++)
+      for(S32 j = 0; j < p2.size(); ++j)
       {
          const Point *cp2 = &p2[j];
          if(segmentsIntersect(*rp1, *rp2, *cp1, *cp2, ct))
@@ -673,7 +675,7 @@ S32 findClosestPoint(const Point &point, const Vector<Point> &points)
    F32 dist = F32_MAX;
    S32 closest = -1;
 
-   for(S32 i = 0; i < points.size(); i++)
+   for(S32 i = 0; i < points.size(); ++i)
    {
       F32 d = points[i].distSquared(point);
 
@@ -700,7 +702,7 @@ bool zonesTouch(const Vector<Point> *zone1, const Vector<Point> *zone2, F32 scal
    const Point *pi1, *pi2, *pj1, *pj2;
 
    // Now, do we actually touch?  Let's look, segment by segment
-   for(S32 i = 0; i < zone1->size(); i++)
+   for(S32 i = 0; i < zone1->size(); ++i)
    {
       pi1 = &zone1->get(i);
       if(i == zone1->size() - 1)
@@ -708,7 +710,7 @@ bool zonesTouch(const Vector<Point> *zone1, const Vector<Point> *zone2, F32 scal
       else
          pi2 = &zone1->get(i + 1);
 
-      for(S32 j = 0; j < zone2->size(); j++)
+      for(S32 j = 0; j < zone2->size(); ++j)
       {
          pj1 = &zone2->get(j);
          if(j == zone2->size() - 1)
@@ -866,7 +868,7 @@ bool Triangulate::Snip(const Vector<Point> &contour, int u, int v, int w, int n,
 
   if ( EPSILON > (((Bx-Ax)*(Cy-Ay)) - ((By-Ay)*(Cx-Ax))) ) return false;
 
-  for (p=0;p<n;p++)
+  for (p=0;p<n;++p)
   {
     if( (p == u) || (p == v) || (p == w) ) continue;
     Px = contour[V[p]].x;
@@ -892,10 +894,10 @@ bool Triangulate::Process(const Vector<Point> &contour, Vector<Point> &result)
    /* we want a counter-clockwise polygon in V */
 
    if(area(contour) > 0)
-      for (int v=0; v < n; v++)
+      for (int v=0; v < n; ++v)
          V[v] = v;
    else
-      for(int v = 0; v < n; v++)
+      for(int v = 0; v < n; ++v)
          V[v] = (n-1)-v;
 
    int nv = n;
@@ -938,13 +940,15 @@ bool Triangulate::Process(const Vector<Point> &contour, Vector<Point> &result)
          result.push_back( contour[b] );
          result.push_back( contour[c] );
 
-         m++;
+         ++m;
+
 
          /* remove v from remaining polygon */
-         for(s = v, t = v+1; t < nv; s++, t++)
+         for(s = v, t = v+1; t < nv; ++s, ++t)
             V[s] = V[t];
 
-         nv--;
+         --nv;
+
 
          /* reset error detection counter */
          count = 2*nv;
@@ -966,11 +970,11 @@ Paths upscaleClipperPoints(const Vector<const Vector<Point> *> &inputPolygons)
 
    outputPolygons.resize(inputPolygons.size());
 
-   for(S32 i = 0; i < inputPolygons.size(); i++)
+   for(S32 i = 0; i < inputPolygons.size(); ++i)
    {
       outputPolygons[i].resize(inputPolygons[i]->size());
 
-      for(S32 j = 0; j < inputPolygons[i]->size(); j++)
+      for(S32 j = 0; j < inputPolygons[i]->size(); ++j)
          outputPolygons[i][j] = IntPoint(S64(inputPolygons[i]->get(j).x * CLIPPER_SCALE_FACT), S64(inputPolygons[i]->get(j).y * CLIPPER_SCALE_FACT));
    }
 
@@ -985,11 +989,11 @@ Paths upscaleClipperPoints(const Vector<Vector<Point> > &inputPolygons)
 
    outputPolygons.resize(inputPolygons.size());
 
-   for(S32 i = 0; i < inputPolygons.size(); i++)
+   for(S32 i = 0; i < inputPolygons.size(); ++i)
    {
       outputPolygons[i].resize(inputPolygons[i].size());
 
-      for(S32 j = 0; j < inputPolygons[i].size(); j++)
+      for(S32 j = 0; j < inputPolygons[i].size(); ++j)
          outputPolygons[i][j] = IntPoint(S64(inputPolygons[i].get(j).x * CLIPPER_SCALE_FACT), S64(inputPolygons[i].get(j).y * CLIPPER_SCALE_FACT));
    }
 
@@ -1003,11 +1007,11 @@ Vector<Vector<Point> > downscaleClipperPoints(const Paths &inputPolygons)
 
    outputPolygons.resize((U32)inputPolygons.size());
 
-   for(U32 i = 0; i < inputPolygons.size(); i++)
+   for(U32 i = 0; i < inputPolygons.size(); ++i)
    {
       outputPolygons[i].resize((U32)inputPolygons[i].size());
 
-      for(U32 j = 0; j < inputPolygons[i].size(); j++)
+      for(U32 j = 0; j < inputPolygons[i].size(); ++j)
          outputPolygons[i][j] = Point(F32(inputPolygons[i][j].X) * CLIPPER_SCALE_FACT_INVERSE, F32(inputPolygons[i][j].Y) * CLIPPER_SCALE_FACT_INVERSE);
    }
 
@@ -1064,11 +1068,11 @@ void polyMeshToPolygons(const rcPolyMesh &mesh, Vector<Vector<Point> > &result)
 {
    result.clear();
    result.reserve(mesh.npolys);
-   for(S32 i = 0; i < mesh.npolys; i++)
+   for(S32 i = 0; i < mesh.npolys; ++i)
    {
       Vector<Point> poly;
       poly.reserve(mesh.nvp);
-      for(S32 j = 0; j < mesh.nvp; j++)
+      for(S32 j = 0; j < mesh.nvp; ++j)
       {
          // index of the next vertex
          U16 vertIndex = mesh.polys[i * mesh.nvp + j];
@@ -1259,10 +1263,10 @@ static void splitSelfIntersectingPoly(const Vector<Point> input, Vector<Vector<P
 
    bool polyWasSplit = false;
    // for each segment as i
-   for(U32 i = 0; i < size && !polyWasSplit; i++)
+   for(U32 i = 0; i < size && !polyWasSplit; ++i)
    {
       // for each segment after after i as j
-      for(U32 j = i + 2; j < size && !polyWasSplit; j++)
+      for(U32 j = i + 2; j < size && !polyWasSplit; ++j)
       {
          // exclude segments adjacent to i
          if(i == 0 && j == size - 1)
@@ -1309,7 +1313,7 @@ static void splitSelfIntersectingPoly(const Vector<Point> input, Vector<Vector<P
  */
 void splitSelfIntersectingPolys(const Vector<Vector<Point> > input, Vector<Vector<Point> > &result)
 {
-   for(S32 i = 0; i < input.size(); i++)
+   for(S32 i = 0; i < input.size(); ++i)
    {
       splitSelfIntersectingPoly(input[i], result);
    }
@@ -1326,12 +1330,12 @@ bool polyganize(const Vector<Vector<Point> > &input, Vector<Vector<Point> > &out
    rcPolyMesh mesh;
    Vector<Point> triangles;
 
-   for(S32 i = 0; i < input.size(); i++)
+   for(S32 i = 0; i < input.size(); ++i)
    {
       if(input[i].size() != 3)
          continue;
 
-      for(S32 j = 0; j < input[i].size(); j++)
+      for(S32 j = 0; j < input[i].size(); ++j)
       {
          triangles.push_back(input[i][j]);
       }
@@ -1402,19 +1406,19 @@ void unpackPolygons(const Vector<Vector<Point> > &solution, Vector<Point> &lineS
    // Precomputing list size improves performance dramatically
    S32 segments = 0;
 
-   for(S32 i = 0; i < solution.size(); i++)
+   for(S32 i = 0; i < solution.size(); ++i)
       segments += solution[i].size();
 
    lineSegmentPoints.resize(segments * 2);      // 2 points per line segment
 
    S32 index = 0;
 
-   for(S32 i = 0; i < solution.size(); i++)
+   for(S32 i = 0; i < solution.size(); ++i)
    {
       if(solution[i].size() == 0)
          continue;
 
-      for(S32 j = 1; j < solution[i].size(); j++)
+      for(S32 j = 1; j < solution[i].size(); ++j)
       {
          lineSegmentPoints[index++] = solution[i][j - 1];
          lineSegmentPoints[index++] = solution[i][j];
@@ -1557,7 +1561,7 @@ bool isWoundClockwise(const Vector<Point>& inputPoly)
    F64 finalSum = 0;
    S32 i_prev = inputPoly.size() - 1;
 
-   for(S32 i = 0; i < inputPoly.size(); i++)
+   for(S32 i = 0; i < inputPoly.size(); ++i)
    {
       // (x2-x1)(y2+y1)
       finalSum += (F64(inputPoly[i].x) - inputPoly[i_prev].x) * (F64(inputPoly[i].y) + inputPoly[i_prev].y);
@@ -1620,7 +1624,7 @@ bool Triangulate::processComplex(Vector<Point> &outputTriangles, const Rect& bou
       {
          // Build up this polyline in poly2tri's format (downscale Clipper points)
          Vector<p2t::Point*> polyline;
-         for(U32 j = 0; j < currentNode->Contour.size(); j++)
+         for(U32 j = 0; j < currentNode->Contour.size(); ++j)
             polyline.push_back(new p2t::Point(F64(currentNode->Contour[j].X), F64(currentNode->Contour[j].Y)));
 
          polylinesRegistry.push_back(polyline);  // Memory
@@ -1629,12 +1633,12 @@ bool Triangulate::processComplex(Vector<Point> &outputTriangles, const Rect& bou
          p2t::CDT* cdt = new p2t::CDT(polyline.getStlVector());
          cdtRegistry.push_back(cdt);
 
-         for(U32 j = 0; j < currentNode->Childs.size(); j++)
+         for(U32 j = 0; j < currentNode->Childs.size(); ++j)
          {
             PolyNode *childNode = currentNode->Childs[j];
 
             Vector<p2t::Point*> hole;
-            for(U32 k = 0; k < childNode->Contour.size(); k++)
+            for(U32 k = 0; k < childNode->Contour.size(); ++k)
                hole.push_back(new p2t::Point(F64(childNode->Contour[k].X), F64(childNode->Contour[k].Y)));
 
             holesRegistry.push_back(hole);  // Memory
@@ -1658,7 +1662,7 @@ bool Triangulate::processComplex(Vector<Point> &outputTriangles, const Rect& bou
 
          // Copy our data to TNL::Point and to our output Vector
          p2t::Triangle *currentTriangle;
-         for(U32 j = 0; j < currentOutput.size(); j++)
+         for(U32 j = 0; j < currentOutput.size(); ++j)
          {
             currentTriangle = currentOutput[j];
             outputTriangles.push_back(Point(currentTriangle->GetPoint(0)->x * CLIPPER_SCALE_FACT_INVERSE, currentTriangle->GetPoint(0)->y * CLIPPER_SCALE_FACT_INVERSE));
@@ -1674,18 +1678,18 @@ bool Triangulate::processComplex(Vector<Point> &outputTriangles, const Rect& bou
    // Clean up memory used with poly2tri
    //
    // Clean-up workers
-   for(S32 i = 0; i < cdtRegistry.size(); i++)
+   for(S32 i = 0; i < cdtRegistry.size(); ++i)
       delete cdtRegistry[i];
 
    // Free the polylines
-   for(S32 i = 0; i < polylinesRegistry.size(); i++)
+   for(S32 i = 0; i < polylinesRegistry.size(); ++i)
    {
       Vector<p2t::Point*> &polyline = polylinesRegistry[i];
       polyline.deleteAndClear();
    }
 
    // Free the holes
-   for(S32 i = 0; i < holesRegistry.size(); i++)
+   for(S32 i = 0; i < holesRegistry.size(); ++i)
    {
       Vector<p2t::Point*> &hole = holesRegistry[i];
       hole.deleteAndClear();
@@ -1716,7 +1720,7 @@ bool Triangulate::mergeTriangles(const Vector<Point> &triangleData, rcPolyMesh& 
    if(pointCount > U16_MAX) // too many points for rcBuildPolyMesh
       return false;
 
-   for(S32 i = 0; i < pointCount; i++)
+   for(S32 i = 0; i < pointCount; ++i)
    {
       intPoints[2*i]   = (S32)round(triangleData[i].x) + mesh.offsetX;
       intPoints[2*i+1] = (S32)round(triangleData[i].y) + mesh.offsetY;
@@ -1740,7 +1744,7 @@ Point mean2d(const Vector<Point> &polyPoints)
    F64 y = 0;
    Point p1;
 
-   for(S32 i = 0; i < size; i++)
+   for(S32 i = 0; i < size; ++i)
    {
       p1 = polyPoints[i];
 //      p1.scaleFloorDiv(NormalizeMultiplier, NormalizeFraction);
@@ -1776,7 +1780,7 @@ Point findCentroid(const Vector<Point> &polyPoints)
    Point p2;
 
    // All segments except last
-   for(S32 i = 0; i < size - 1; i++)
+   for(S32 i = 0; i < size - 1; ++i)
    {
       p1 = polyPoints[i];
       p2 = polyPoints[i+1];
@@ -1824,7 +1828,7 @@ F32 angleOfLongestSide(const Vector<Point> &polyPoints)
    F32 maxlen = -1;
    F32 ang = 0;
 
-   for(S32 i = 0; i < polyPoints.size(); i++)
+   for(S32 i = 0; i < polyPoints.size(); ++i)
    {
       Point p1 = polyPoints[i];
       Point p2 = polyPoints[(i < polyPoints.size() - 1) ? i + 1 : 0];
@@ -1969,7 +1973,7 @@ void cornersToEdges(const Vector<Point> &corners, Vector<Point> &edges)
       return;
 
    S32 last = corners.size() - 1;
-   for(S32 i = 0; i < corners.size(); i++)
+   for(S32 i = 0; i < corners.size(); ++i)
    {
       edges.push_back(corners[last]);
       edges.push_back(corners[i]);
@@ -1991,7 +1995,7 @@ void constructBarrierEndPoints(const Vector<Point> *points, F32 width, Vector<Po
    bool loop = (points->first() == points->last());      // Does our barrier form a closed loop?
 
    Vector<Point> edgeVector;
-   for(S32 i = 0; i < points->size() - 1; i++)
+   for(S32 i = 0; i < points->size() - 1; ++i)
    {
       Point e = points->get(i+1) - points->get(i);
       e.normalize();
@@ -2001,7 +2005,7 @@ void constructBarrierEndPoints(const Vector<Point> *points, F32 width, Vector<Po
    Point lastEdge = edgeVector[edgeVector.size() - 1];
    Vector<F32> extend;
 
-   for(S32 i = 0; i < edgeVector.size(); i++)
+   for(S32 i = 0; i < edgeVector.size(); ++i)
    {
       Point curEdge = edgeVector[i];
       double cosTheta = curEdge.dot(lastEdge);
@@ -2025,7 +2029,7 @@ void constructBarrierEndPoints(const Vector<Point> *points, F32 width, Vector<Po
    F32 first = extend[0];
    extend.push_back(first);
 
-   for(S32 i = 0; i < edgeVector.size(); i++)
+   for(S32 i = 0; i < edgeVector.size(); ++i)
    {
       F32 extendBack = extend[i];
       F32 extendForward = extend[i+1];
@@ -2234,7 +2238,7 @@ void barrierLineToSegmentData(Vector<Point> inputLine, Vector<Vector<Point> > &o
 
 
    // Extract segment with pre/post points
-   for(S32 i = 0; i < pointCount - 1; i++)  // One less than full loop to guarantee nextPoint(s)
+   for(S32 i = 0; i < pointCount - 1; ++i)  // One less than full loop to guarantee nextPoint(s)
    {
       pts.clear();
 
@@ -2280,7 +2284,7 @@ static void pushPolyNode(lua_State *L, const PolyNode *node)
 
    // set the points
    lua_createtable(L, (int)node->Contour.size(), 0);   // -- node, points
-   for(U32 i = 1; i <= node->Contour.size(); i++)
+   for(U32 i = 1; i <= node->Contour.size(); ++i)
    {
       const Path &poly = node->Contour;
       lua_pushnumber(L, i);                       // -- node, points, i
@@ -2292,7 +2296,7 @@ static void pushPolyNode(lua_State *L, const PolyNode *node)
 
    // set the children
    lua_createtable(L, (int)node->Childs.size(), 0);    // -- node, children
-   for(U32 i = 1; i <= node->Childs.size(); i++)
+   for(U32 i = 1; i <= node->Childs.size(); ++i)
    {
       lua_pushnumber(L, i);                       // -- node, children, i
       pushPolyNode(L, node->Childs[i-1]);         // -- node, children, i, child

--- a/zap/Geometry.cpp
+++ b/zap/Geometry.cpp
@@ -226,7 +226,7 @@ void Geometry::rotateAboutPoint(const Point &center, F32 angle)
    F32 sinTheta = sinf(rad);
    F32 cosTheta = cosf(rad);
 
-   for(S32 j = 0; j < getVertCount(); j++)
+   for(S32 j = 0; j < getVertCount(); ++j)
    {
       Point v = getVert(j) - center;
       Point n(v.x * cosTheta + v.y * sinTheta, v.y * cosTheta - v.x * sinTheta);
@@ -240,7 +240,7 @@ void Geometry::flip(F32 center, bool isHoriz)
 {
    S32 count = getVertCount();
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       Point p = getVert(i);
 
@@ -260,10 +260,10 @@ void Geometry::reverseWinding()
    S32 count = getVertCount();
    Vector<Point> temp(count);
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
       temp.push_back(getVert(i));
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
       setVert(temp[i], count - i - 1);
 }
 
@@ -273,7 +273,7 @@ void Geometry::scale(const Point &center, F32 scale)
 {
    S32 count = getVertCount();
 
-   for(S32 j = 0; j < count; j++)
+   for(S32 j = 0; j < count; ++j)
       setVert((getVert(j) - center) * scale + center, j);
 }
 
@@ -289,7 +289,7 @@ void Geometry::offset(const Point &offset)
 {
    S32 count = getVertCount();
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
       setVert(getVert(i) + offset, i);
 }
 
@@ -816,7 +816,7 @@ void PolylineGeometry::unselectVert(S32 vertIndex)
 
 void PolylineGeometry::unselectVerts()
 {
-   for(S32 i = 0; i < mVertSelected.size(); i++)
+   for(S32 i = 0; i < mVertSelected.size(); ++i)
       mVertSelected[i] = false;
 
    mAnyVertsSelected = false;
@@ -834,7 +834,7 @@ void PolylineGeometry::checkIfAnyVertsSelected()
 {
    mAnyVertsSelected = false;
 
-   for(S32 i = 0; i < mVertSelected.size(); i++)
+   for(S32 i = 0; i < mVertSelected.size(); ++i)
       if(mVertSelected[i])
       {
          mAnyVertsSelected = true;
@@ -874,7 +874,7 @@ void PolylineGeometry::packGeom(GhostConnection *connection, BitStream *stream)
 
    // - 1 because writeEnum ranges from 0 to n-1; mPolyBounds.size() ranges from 1 to n
    stream->writeEnum(mPolyBounds.size() - 1, Geometry::MAX_POLY_POINTS);
-   for(S32 i = 0; i < mPolyBounds.size(); i++)
+   for(S32 i = 0; i < mPolyBounds.size(); ++i)
       mPolyBounds[i].write(stream);
 }
 
@@ -887,7 +887,7 @@ void PolylineGeometry::unpackGeom(GhostConnection *connection, BitStream *stream
    mPolyBounds.resize(size);
    mVertSelected.resize(size);
 
-   for(U32 i = 0; i < size; i++)
+   for(U32 i = 0; i < size; ++i)
       mPolyBounds[i].read(stream);
 
    // If we are getting this from a packet, we can reverse the order of the points without consequence.
@@ -904,7 +904,7 @@ void PolylineGeometry::setGeom(const Vector<Point> &points)
    mPolyBounds.clear();
    mPolyBounds.reserve(size);
 
-   for(S32 i = 0; i < size; i++)
+   for(S32 i = 0; i < size; ++i)
    {
       // Filter out points with NaN values
       if(points[i] == points[i])
@@ -927,7 +927,7 @@ string PolylineGeometry::geomToLevelCode() const
    S32 size = mPolyBounds.size();
 
    Point p;
-   for(S32 i = 0; i < size; i++)
+   for(S32 i = 0; i < size; ++i)
    {
       p = mPolyBounds[i];
       bounds += p.toLevelCode() + (i < size - 1 ? " " : "");

--- a/zap/HTFGame.cpp
+++ b/zap/HTFGame.cpp
@@ -65,7 +65,7 @@ Vector<string> HTFGameType::getGameParameterMenuKeys()
    Vector<string> items = Parent::getGameParameterMenuKeys();
 
    // Use "Win Score" as an indicator of where to insert our specific menu items
-   for(S32 i = 0; i < items.size(); i++)
+   for(S32 i = 0; i < items.size(); ++i)
       if(items[i] == "Win Score")
       {
          items.insert(i + 1, "Point Earn Rate");
@@ -218,7 +218,7 @@ void HTFGameType::shipTouchZone(Ship *ship, GoalZone *zone)
 
    // Does it already have a flag in it?
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
       if(static_cast<FlagItem *>(flags->get(i))->getZone() == zone)
          return;
 
@@ -265,7 +265,7 @@ void HTFGameType::idle(BfObject::IdleCallPath path, U32 deltaT)
    // Server only, from here on out
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
       if(flag->getZone() != NULL && flag->mTimer.update(deltaT))     // Flag is in a zone && it's scorin' time!
@@ -289,7 +289,7 @@ void HTFGameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clie
 
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
       if(flag->isAtHome() || flag->getZone())      // Flag is at home or in a zone
@@ -324,7 +324,7 @@ void HTFGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) cons
    const Vector<DatabaseObject *> *goalZones = getGame()->getGameObjDatabase()->findObjects_fast(GoalZoneTypeNumber);
    const Vector<DatabaseObject *> *flags     = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 
@@ -332,7 +332,7 @@ void HTFGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) cons
          continue;
 
       // Flag is mounted on our ship (generally, this will only get run once, as ships won't carry more than one flag)
-      for(S32 j = 0; j < goalZones->size(); j++)
+      for(S32 j = 0; j < goalZones->size(); ++j)
       {
          GoalZone *goalZone = static_cast<GoalZone *>(goalZones->get(j));
 
@@ -341,7 +341,7 @@ void HTFGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) cons
             continue;
 
          bool found = false;
-         for(S32 k = 0; k < flags->size(); k++)
+         for(S32 k = 0; k < flags->size(); ++k)
          {
             FlagItem *kflag = static_cast<FlagItem *>(flags->get(k));
 
@@ -358,7 +358,7 @@ void HTFGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) cons
       break;
    }
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 

--- a/zap/HelpItemManager.cpp
+++ b/zap/HelpItemManager.cpp
@@ -156,7 +156,7 @@ void HelpItemManager::idle(U32 timeDelta, const ClientGame *game)
       moveItemFromQueueToActiveList(game);
 
    // Expire displayed items
-   for(S32 i = 0; i < mHelpTimer.size(); i++)
+   for(S32 i = 0; i < mHelpTimer.size(); ++i)
    {
       if(!mHelpTimer[i].update(timeDelta))
          continue;
@@ -168,7 +168,8 @@ void HelpItemManager::idle(U32 timeDelta, const ClientGame *game)
          mHelpTimer.erase(i);
 
          buildItemsToHighlightList();
-         i--;
+         --i;
+
       }
 
       else                 // Display period over... enter rollup mode
@@ -196,7 +197,8 @@ S32 HelpItemManager::getLinesInHelpItem(S32 index) const
 {
    S32 lines = 0;
    while(helpItems[mHelpItems[index]].helpMessages[lines])
-      lines++;
+      ++lines;
+
 
    return lines;
 }
@@ -233,7 +235,8 @@ void HelpItemManager::moveItemFromQueueToActiveList(const ClientGame *game)
       // Handle special case -- want to suppress, but not delete, this item if there are bots in the game
       if(items->get(itemToShow).helpItem == AddBotsItem && game->getBotCount() > 0)
       {
-         itemToShow += 1;
+         ++itemToShow;
+
          continue;
       }
 
@@ -354,7 +357,7 @@ static S32 doRenderMessages(const ClientGame *game, const InputCodeManager *inpu
    S32 yOffset = 0;
 
    // Final item in messages array will be NULL; loop until we hit that
-   for(S32 i = 0; messages[i]; i++)
+   for(S32 i = 0; messages[i]; ++i)
    {
       TNLAssert(i < MAX_LINES, "Too many lines... better increase MAX_LINES!");
 
@@ -367,7 +370,8 @@ static S32 doRenderMessages(const ClientGame *game, const InputCodeManager *inpu
       maxw = max(maxw, w);
 
       yOffset += FontSize + FontGap;
-      lines++;
+      ++lines;
+
    }
 
    S32 leftPos = (S32)xPos - maxw / 2;
@@ -415,7 +419,7 @@ void HelpItemManager::renderMessages(const ClientGame *game, F32 yPos, F32 alpha
 
    FontManager::pushFontContext(HelpItemContext);
 
-   for(S32 i = 0; i < mHelpItems.size(); i++)      // Iterate over each message being displayed
+   for(S32 i = 0; i < mHelpItems.size(); ++i)      // Iterate over each message being displayed
    {
       r.setColor(Colors::HelpItemRenderColor, alpha);
 
@@ -443,7 +447,8 @@ void HelpItemManager::renderMessages(const ClientGame *game, F32 yPos, F32 alpha
 #ifdef TNL_DEBUG
 void HelpItemManager::debugShowNextSampleHelpItem()
 {
-   mTestingCtr++;
+   ++mTestingCtr;
+
    mTestingTimer.reset();
 }
 
@@ -452,7 +457,7 @@ void HelpItemManager::debugAdvanceHelpItem()
 {
    mInitialDelayTimer.clear();
 
-   for(S32 i = 0; i < mHelpTimer.size(); i++)
+   for(S32 i = 0; i < mHelpTimer.size(); ++i)
       mHelpTimer[i].update(mHelpTimer[i].getCurrent() - 1);
 
    mPacedTimer.update(mPacedTimer.getCurrent() - 1);
@@ -503,7 +508,7 @@ void HelpItemManager::removeInlineHelpItem(HelpItem item, bool markAsSeen, U8 we
       Vector<WeightedHelpItem> *queue = helpItems[item].priority == PacedHigh ? &mHighPriorityQueuedItems :
                                                                                 &mLowPriorityQueuedItems;
       S32 index = -1;
-      for(S32 i = 0; i < queue->size(); i++)
+      for(S32 i = 0; i < queue->size(); ++i)
          if(queue->get(i).helpItem == item)
          {
             index = i;
@@ -530,7 +535,7 @@ F32 HelpItemManager::getObjectiveArrowHighlightAlpha() const
 
    F32 alpha = 0;
 
-   for(S32 i = 0; i < mHelpItems.size(); i++)
+   for(S32 i = 0; i < mHelpItems.size(); ++i)
       if(helpItems[mHelpItems[i]].highlightObjectiveArrows)
          alpha = max(alpha, mHelpFading[i] ? mHelpTimer[i].getFraction() : 1);
 
@@ -631,7 +636,7 @@ void HelpItemManager::addInlineHelpItem(U8 objectType, S32 objectTeam, S32 playe
       return;
 
    // Figure out which help item to show for this object
-   for(S32 i = 0; i < HelpItemCount; i++)
+   for(S32 i = 0; i < HelpItemCount; ++i)
       if(helpItems[i].associatedObjectTypeNumber == objectType && checkWhose(helpItems[i].whose, objectTeam, playerTeam))
       {
          addInlineHelpItem(HelpItem(i));
@@ -758,7 +763,7 @@ void HelpItemManager::removeGameStartItemsFromQueue()
 // Only called from an assert
 bool HelpItemManager::queueHasGameStartItems() const
 {
-   for(S32 i = 0; i < mHighPriorityQueuedItems.size(); i++)
+   for(S32 i = 0; i < mHighPriorityQueuedItems.size(); ++i)
       if(helpItems[mHighPriorityQueuedItems[0].helpItem].priority == GameStart)
          return true;
 
@@ -776,7 +781,7 @@ void HelpItemManager::buildItemsToHighlightList()
 {
    mItemsToHighlight.clear();
 
-   for(S32 i = 0; i < mHelpItems.size(); i++)
+   for(S32 i = 0; i < mHelpItems.size(); ++i)
    {
       U8 itemType = helpItems[mHelpItems[i]].associatedObjectTypeNumber;
 

--- a/zap/HelperManager.cpp
+++ b/zap/HelperManager.cpp
@@ -77,7 +77,7 @@ void HelperManager::reset()
 
 void HelperManager::idle(U32 timeDelta)
 {
-   for(S32 i = 0; i < mHelperStack.size(); i++)
+   for(S32 i = 0; i < mHelperStack.size(); ++i)
       mHelperStack[i]->idle(timeDelta);
 
    if(mOffDeckHelper)
@@ -88,7 +88,7 @@ void HelperManager::idle(U32 timeDelta)
 void HelperManager::render() const
 {
    // Higher indexed helpers render on top
-   for(S32 i = 0; i < mHelperStack.size(); i++)
+   for(S32 i = 0; i < mHelperStack.size(); ++i)
       mHelperStack[i]->render();
 
    if(mOffDeckHelper)

--- a/zap/HttpRequest.cpp
+++ b/zap/HttpRequest.cpp
@@ -185,7 +185,7 @@ string HttpRequest::urlEncode(const string& str)
    string result;
    string::const_iterator it;
 
-   for(it = str.begin(); it < str.end(); it++)
+   for(it = str.begin(); it < str.end(); ++it)
    {
       result += urlEncodeChar(*it);
    }
@@ -219,14 +219,14 @@ string HttpRequest::buildRequest()
    if(mMethod == PostMethod)
    {
       stringstream encodedData("");
-      for(map<string, string>::iterator it = mData.begin(); it != mData.end(); it++)
+      for(map<string, string>::iterator it = mData.begin(); it != mData.end(); ++it)
       {
          encodedData << "--" + HttpRequestBoundary + "\r\n";
          encodedData << "Content-Disposition: form-data; name=\"" + (*it).first + "\"\r\n\r\n";
          encodedData << (*it).second + "\r\n";
       }
 
-      for(list<HttpRequestFileInfo>::iterator it = mFiles.begin(); it != mFiles.end(); it++)
+      for(list<HttpRequestFileInfo>::iterator it = mFiles.begin(); it != mFiles.end(); ++it)
       {
          stringstream fileData;
          fileData.write((const char*) (*it).data, (*it).length);

--- a/zap/IniFile.cpp
+++ b/zap/IniFile.cpp
@@ -196,7 +196,7 @@ void CIniFile::ReadFile()
    lineCount = iniLines.size();      // Set our INI vector length
 
    // Process our INI lines, will provide sensible defaults for any missing or malformed entries
-   for(S32 i = 0; i < lineCount; i++)
+   for(S32 i = 0; i < lineCount; ++i)
       processLine(iniLines[i]);
 }
 
@@ -395,7 +395,7 @@ bool CIniFile::SetAllValues(const string &section, const string &prefix, const V
 {
    char key[256];
    bool stat = true;
-   for(S32 i = 0; i < values.size(); i++)
+   for(S32 i = 0; i < values.size(); ++i)
    {
       dSprintf(key, 255, "%s%d", prefix.c_str(), i);
       stat &= SetValue(section, key, values[i], true);
@@ -470,7 +470,7 @@ string CIniFile::GetValue(const string &section, const string &keyName, const st
 // Fill valueList with values from all keys in the specified section.  Key names will be discarded.
 void CIniFile::GetAllValues(S32 const sectionId, Vector<string> &valueList) const
 {
-   for(S32 i = 0; i < sections[sectionId].keys.size(); i++)
+   for(S32 i = 0; i < sections[sectionId].keys.size(); ++i)
       // Only return non-empty values
       if(sections[sectionId].values[i] != "")
          valueList.push_back(expandEnvironmentVariables(sections[sectionId].values[i]));
@@ -493,7 +493,7 @@ void CIniFile::GetAllKeys(S32 const sectionId, Vector<string> &keyList) const
    if(GetNumEntries(sectionId) == 0)
       return;
 
-   for(S32 i = 0; i < sections[sectionId].keys.size(); i++)
+   for(S32 i = 0; i < sections[sectionId].keys.size(); ++i)
       keyList.push_back(sections[sectionId].keys[i]);
 }
 
@@ -723,7 +723,7 @@ bool CIniFile::deleteSectionComments(const string &keyname)
 bool CIniFile::deleteAllSectionComments()
 {
    bool result = true;
-   for(S32 i = 0; i < sections.size() && result; i++)
+   for(S32 i = 0; i < sections.size() && result; ++i)
       result &= deleteSectionComments(i);
 
    return result;

--- a/zap/InputCode.cpp
+++ b/zap/InputCode.cpp
@@ -287,7 +287,7 @@ InputCodeManager::~InputCodeManager()
 // Initialize state of keys... assume none are depressed, or even sad
 void InputCodeManager::resetStates()
 {
-   for(S32 i = 0; i < MAX_INPUT_CODES; i++)
+   for(S32 i = 0; i < MAX_INPUT_CODES; ++i)
       inputCodeIsDown[i] = false;
 }
 
@@ -295,7 +295,7 @@ void InputCodeManager::resetStates()
 // Prints list of any input codes that are down, for debugging purposes
 void InputCodeManager::dumpInputCodeStates()
 {
-  for(S32 i = 0; i < MAX_INPUT_CODES; i++)
+  for(S32 i = 0; i < MAX_INPUT_CODES; ++i)
      if(inputCodeIsDown[i])
         logprintf("Key %s down", inputCodeToString((InputCode) i));
 }
@@ -329,7 +329,7 @@ string InputCodeManager::getCurrentInputString(InputCode inputCode)
 
    // First, find the base key -- this will be the last non-modifier key we find, or one where the base key is the same as inputCode,
    // assuming the standard modifier-key combination
-   for(S32 i = 0; i < MAX_INPUT_CODES; i++)
+   for(S32 i = 0; i < MAX_INPUT_CODES; ++i)
    {
       InputCode code = (InputCode) i;
 
@@ -349,7 +349,7 @@ string InputCodeManager::getCurrentInputString(InputCode inputCode)
 
    string inputString = "";
 
-   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); i++)
+   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); ++i)
       if(getState(modifiers[i]))
          inputString += string(inputCodeToString(modifiers[i])) + InputStringJoiner;
 
@@ -363,11 +363,12 @@ bool InputCodeManager::checkModifier(InputCode mod1)
 {
    S32 foundCount = 0;
 
-   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); i++)
+   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); ++i)
       if(getState(modifiers[i]))                   // Modifier is down
       {
          if(modifiers[i] == mod1)
-            foundCount++;
+            ++foundCount;
+
          else                                      // Wrong modifier!
             return false;
       }
@@ -381,11 +382,12 @@ bool InputCodeManager::checkModifier(InputCode mod1, InputCode mod2)
 {
    S32 foundCount = 0;
 
-   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); i++)
+   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); ++i)
       if(getState(modifiers[i]))                   // Modifier is down
       {
          if(modifiers[i] == mod1 || modifiers[i] == mod2)
-            foundCount++;
+            ++foundCount;
+
          else                                      // Wrong modifier!
             return false;
       }
@@ -399,11 +401,12 @@ bool InputCodeManager::checkModifier(InputCode mod1, InputCode mod2, InputCode m
 {
    S32 foundCount = 0;
 
-   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); i++)
+   for(S32 i = 0; i < S32(ARRAYSIZE(modifiers)); ++i)
       if(getState(modifiers[i]))                   // Modifier is down
       {
          if(modifiers[i] == mod1 || modifiers[i] == mod2 || modifiers[i] == mod3)
-            foundCount++;
+            ++foundCount;
+
          else                                      // Wrong modifier!
             return false;
       }
@@ -426,17 +429,17 @@ string InputCodeManager::normalizeInputString(const string &inputString)
 
    // Modifiers will be first words... sort them, normalize capitalization, get them organized
    bool hasModifier[ARRAYSIZE(modifiers)];
-   for(U32 i = 0; i < ARRAYSIZE(modifiers); i++)
+   for(U32 i = 0; i < ARRAYSIZE(modifiers); ++i)
       hasModifier[i] = false;
 
-   for(S32 i = 0; i < words.size() - 1; i++)
+   for(S32 i = 0; i < words.size() - 1; ++i)
    {
       InputCode inputCode = stringToInputCode(words[i].c_str());
       if(inputCode == KEY_UNKNOWN)     // Encountered something unexpected
          return INVALID;
 
       bool found = false;
-      for(U32 i = 0; i < ARRAYSIZE(modifiers); i++)
+      for(U32 i = 0; i < ARRAYSIZE(modifiers); ++i)
          if(inputCode == modifiers[i])
          {
             hasModifier[i] = true;
@@ -458,7 +461,7 @@ string InputCodeManager::normalizeInputString(const string &inputString)
       return INVALID;
 
    string normalizedInputString = "";
-   for(U32 i = 0; i < ARRAYSIZE(modifiers); i++)
+   for(U32 i = 0; i < ARRAYSIZE(modifiers); ++i)
       if(hasModifier[i])
          normalizedInputString += string(keyNames[modifiers[i]]) + InputStringJoiner;
 
@@ -483,10 +486,10 @@ bool InputCodeManager::isValidInputString(const string &inputString)
    S32 startMod = 0;
 
    // Make sure all but the last word are modifiers
-   for(S32 i = 0; i < words.size() - 1; i++)
+   for(S32 i = 0; i < words.size() - 1; ++i)
    {
       bool found = false;
-      for(S32 j = startMod; j < S32(ARRAYSIZE(modifiers)); j++)
+      for(S32 j = startMod; j < S32(ARRAYSIZE(modifiers)); ++j)
          if(words[i] == mods->get(j))
          {
             found = true;
@@ -1532,7 +1535,7 @@ InputCode InputCodeManager::getKeyBoundToBindingCodeName(const string &name) con
 {
    // Linear search is not at all efficient, but this will be called very infrequently, in non-performance sensitive area
    // Note that for some reason the { }s are needed below... without them this code does not work right.
-   for(U32 i = 0; i < ARRAYSIZE(BindingNames); i++)
+   for(U32 i = 0; i < ARRAYSIZE(BindingNames); ++i)
    {
       if(caseInsensitiveStringCompare(BindingNames[i], name))
          return this->getBinding(BindingNameEnum(i));
@@ -1547,7 +1550,7 @@ string InputCodeManager::getEditorKeyBoundToBindingCodeName(const string &name) 
 {
    // Linear search is of O(n) speed and therefore is not really efficient, but this will be called very infrequently,
    // Note that for some reason the { }s are needed below... without them this code does not work right.
-   for(U32 i = 0; i < ARRAYSIZE(EditorBindingNames); i++)
+   for(U32 i = 0; i < ARRAYSIZE(EditorBindingNames); ++i)
    {
       if(caseInsensitiveStringCompare(EditorBindingNames[i], name))
          return this->getEditorBinding(EditorBindingNameEnum(i));
@@ -1562,7 +1565,7 @@ string InputCodeManager::getSpecialKeyBoundToBindingCodeName(const string &name)
 {
    // Linear search is of O(n) speed and therefore is not really efficient, but this will be called very infrequently,
    // Note that for some reason the { }s are needed below... without them this code does not work right.
-   for(U32 i = 0; i < ARRAYSIZE(SpecialBindingNames); i++)
+   for(U32 i = 0; i < ARRAYSIZE(SpecialBindingNames); ++i)
    {
       if(caseInsensitiveStringCompare(SpecialBindingNames[i], name))
          return this->getSpecialBinding(SpecialBindingNameEnum(i));
@@ -1576,7 +1579,7 @@ string InputCodeManager::getSpecialKeyBoundToBindingCodeName(const string &name)
 void InputCodeManager::initializeKeyNames()
 {
    // Fill name list with default value
-   for(S32 i = 0; i < KEY_COUNT; i++)
+   for(S32 i = 0; i < KEY_COUNT; ++i)
       keyNames[i] = "Unknown Key";
 
    // Now keys we know with our locally defined names
@@ -1744,7 +1747,7 @@ void InputCodeManager::initializeKeyNames()
    keyNames[S32(KEY_KEYPAD_ENTER)]    = "Keypad Enter";
    keyNames[S32(KEY_LESS)]            = "Less";
 
-   for(U32 i = 0; i < ARRAYSIZE(modifiers); i++)
+   for(U32 i = 0; i < ARRAYSIZE(modifiers); ++i)
       modifierNames.push_back(keyNames[S32(modifiers[i])]);
 }
 
@@ -1765,7 +1768,7 @@ const char *InputCodeManager::inputCodeToString(InputCode inputCode)
 // (primarily for loading key bindings from INI files)
 InputCode InputCodeManager::stringToInputCode(const char *inputName)
 {
-   for(S32 i = 0; i < KEY_COUNT; i++)
+   for(S32 i = 0; i < KEY_COUNT; ++i)
       if(stricmp(inputName, keyNames[i]) == 0)
          return InputCode(i);
 

--- a/zap/Joystick.cpp
+++ b/zap/Joystick.cpp
@@ -108,7 +108,7 @@ bool Joystick::initJoystick(GameSettings *settings)
 
    logprintf("%d joystick(s) detected:", joystickCount);
 
-   for(S32 i = 0; i < joystickCount; i++)
+   for(S32 i = 0; i < joystickCount; ++i)
    {
       // A GameController is a specific type of joystick
       if(SDL_IsGameController(i))

--- a/zap/LevelListDisplayer.cpp
+++ b/zap/LevelListDisplayer.cpp
@@ -55,7 +55,7 @@ void LevelListDisplayer::render() const
 {
    if(mLevelLoadDisplay || mLevelLoadDisplayFadeTimer.getCurrent() > 0)
    {
-      for(S32 i = 0; i < mLevelLoadDisplayNames.size(); i++)
+      for(S32 i = 0; i < mLevelLoadDisplayNames.size(); ++i)
       {
          FontManager::pushFontContext(MenuContext);
          Renderer::get().setColor(Colors::white, (1.4f - ((F32) (mLevelLoadDisplayNames.size() - i) / 10.f)) *
@@ -81,7 +81,8 @@ void LevelListDisplayer::addProgressListItem(string item)
 
    mLevelLoadDisplayNames.push_back(item);
 
-   mLevelLoadDisplayTotal++;
+   ++mLevelLoadDisplayTotal;
+
 
    if(mLevelLoadDisplayNames.size() > MaxItems)
       mLevelLoadDisplayNames.erase(0);

--- a/zap/LevelSource.cpp
+++ b/zap/LevelSource.cpp
@@ -156,7 +156,7 @@ void LevelSource::getLevelInfoFromCodeChunk(char *chunk, S32 size, LevelInfo &le
                string levelName = list[1];
 
                // Append additional words to levelName
-               for(S32 i = 2; i < list.size(); i++)
+               for(S32 i = 2; i < list.size(); ++i)
                   levelName += " " + list[i];
 
                levelInfo.mLevelName = levelName;
@@ -181,7 +181,8 @@ void LevelSource::getLevelInfoFromCodeChunk(char *chunk, S32 size, LevelInfo &le
          }
          startingCur = cur + 1;
       }
-      cur++;
+      ++cur;
+
    }
 
    levelInfo.ensureLevelInfoHasValidName();
@@ -192,7 +193,7 @@ void LevelSource::getLevelInfoFromCodeChunk(char *chunk, S32 size, LevelInfo &le
 pair<S32, bool> LevelSource::addLevel(LevelInfo levelInfo)
 {
    // Check if we already have this one -- matches by filename and folder
-   for(S32 i = 0; i < mLevelInfos.size(); i++)
+   for(S32 i = 0; i < mLevelInfos.size(); ++i)
    {
       if(mLevelInfos[i].filename == levelInfo.filename && mLevelInfos[i].folder == levelInfo.folder)
          return pair<S32, bool>(i, false);
@@ -295,7 +296,7 @@ bool MultiLevelSource::loadLevels(FolderManager *folderManager)
 {
    bool anyLoaded = false;
 
-   for(S32 i = 0; i < mLevelInfos.size(); i++)
+   for(S32 i = 0; i < mLevelInfos.size(); ++i)
    {
       string filename = folderManager->findLevelFile(mLevelInfos[i].folder, mLevelInfos[i].filename);
 
@@ -304,7 +305,8 @@ bool MultiLevelSource::loadLevels(FolderManager *folderManager)
       else
       {
          mLevelInfos.erase(i);
-         i--;
+         --i;
+
       }
    }
 
@@ -383,7 +385,7 @@ bool MultiLevelSource::isEmptyLevelDirOk() const
 // Constructor -- pass in a list of level names and a folder; create LevelInfos for each
 FolderLevelSource::FolderLevelSource(const Vector<string> &levelList, const string &folder)
 {
-   for(S32 i = 0; i < levelList.size(); i++)
+   for(S32 i = 0; i < levelList.size(); ++i)
       mLevelInfos.push_back(LevelInfo(levelList[i], folder));
 }
 
@@ -401,7 +403,7 @@ FolderLevelSource::~FolderLevelSource()
 // Constructor -- pass in a list of level names and a file; create LevelInfos for each
 FileListLevelSource::FileListLevelSource(const Vector<string> &levelList, const string &folder)
 {
-   for(S32 i = 0; i < levelList.size(); i++)
+   for(S32 i = 0; i < levelList.size(); ++i)
       mLevelInfos.push_back(LevelInfo(levelList[i], folder));
 }
 
@@ -444,7 +446,7 @@ Vector<string> FileListLevelSource::findAllFilesInPlaylist(const string &fileNam
    Vector<string> levels;
    Vector<string> lines = parseString(readFile(fileName));
 
-   for(S32 i = 0; i < lines.size(); i++)
+   for(S32 i = 0; i < lines.size(); ++i)
    {
       string filename = trim(chopComment(lines[i]));
       if(filename == "")    // Probably a comment or blank line

--- a/zap/LoadoutIndicator.cpp
+++ b/zap/LoadoutIndicator.cpp
@@ -148,7 +148,7 @@ static S32 doRender(const LoadoutTracker &loadout, ClientGame *game, S32 top)
    FontManager::pushFontContext(LoadoutIndicatorContext);
 
    // First, the weapons
-   for(auto i = 0; i < ShipWeaponCount; i++)
+   for(auto i = 0; i < ShipWeaponCount; ++i)
    {
       r.setColor(loadout.isWeaponActive(i) ? *INDICATOR_ACTIVE_COLOR : *INDICATOR_INACTIVE_COLOR);
 
@@ -160,7 +160,7 @@ static S32 doRender(const LoadoutTracker &loadout, ClientGame *game, S32 top)
    xPos += GapBetweenTheGroups;    // Small horizontal gap to separate the weapon indicators from the module indicators
 
    // Next, loadout modules
-   for(auto i = 0; i < ShipModuleCount; i++)
+   for(auto i = 0; i < ShipModuleCount; ++i)
    {
       ShipModule module = loadout.getModule(i);
 
@@ -182,12 +182,12 @@ S32 LoadoutIndicator::getWidth() const
 {
    S32 width = 0;
 
-   for(auto i = 0; i < ShipWeaponCount; i++)
+   for(auto i = 0; i < ShipWeaponCount; ++i)
       width += getComponentIndicatorWidth(WeaponInfo::getWeaponInfo(mCurrLoadout.getWeapon(i)).name.getString()) + IndicatorHorizPadding;
 
    width += GapBetweenTheGroups;
 
-   for(auto i = 0; i < ShipModuleCount; i++)
+   for(auto i = 0; i < ShipModuleCount; ++i)
       width += getComponentIndicatorWidth(ModuleInfo::getModuleInfo(mCurrLoadout.getModule(i))->getName()) + IndicatorHorizPadding;
 
    width -= IndicatorHorizPadding;

--- a/zap/LoadoutTracker.cpp
+++ b/zap/LoadoutTracker.cpp
@@ -45,10 +45,10 @@ LoadoutTracker::~LoadoutTracker()
 // Reset this loadout to its factory settings
 void LoadoutTracker::resetLoadout()
 {
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       mModules[i] = ModuleNone;
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       mWeapons[i] = WeaponNone;
 
    deactivateAllModules();
@@ -61,20 +61,20 @@ bool LoadoutTracker::update(const LoadoutTracker &loadout)
 {
    bool loadoutChanged = false;
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       if(mModules[i] != loadout.mModules[i])
       {
          mModules[i] = loadout.mModules[i];
          loadoutChanged = true;
       }
 
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
    {
       mModulePrimaryActive[i]   = loadout.mModulePrimaryActive[i];
       mModuleSecondaryActive[i] = loadout.mModuleSecondaryActive[i];
    }
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       if(mWeapons[i] != loadout.mWeapons[i])
       {
          mWeapons[i] = loadout.mWeapons[i];
@@ -95,19 +95,19 @@ void LoadoutTracker::setLoadout(const Vector<U8> &items)
       return;
 
    // Do some range checking
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       if(items[i] >= ModuleCount)
          return;
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       if(items[i + ShipModuleCount] >= WeaponCount)
          return;
 
    // If everything checks out, we can fill the loadout
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       mModules[i] = (ShipModule) items[i];
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       mWeapons[i] = (WeaponType) items[i + ShipModuleCount];
 }
 
@@ -131,12 +131,12 @@ void LoadoutTracker::setLoadout(const string &loadoutStr)
 
    bool found;
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
    {
       found = false;
       const char *word = words[i].c_str();
 
-      for(S32 j = 0; j < ModuleCount; j++)
+      for(S32 j = 0; j < ModuleCount; ++j)
          if(stricmp(word, ModuleInfo::getModuleInfo((ShipModule) j)->getName()) == 0)     // Case insensitive
          {
             mModules[i] = ShipModule(j);
@@ -152,12 +152,12 @@ void LoadoutTracker::setLoadout(const string &loadoutStr)
       }
    }
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
    {
       found = false;
       const char *word = words[i + ShipModuleCount].c_str();
 
-      for(S32 j = 0; j < WeaponCount; j++)
+      for(S32 j = 0; j < WeaponCount; ++j)
          if(stricmp(word, WeaponInfo::getWeaponInfo(WeaponType(j)).name.getString()) == 0)
          {
             mWeapons[i] = WeaponType(j);
@@ -219,7 +219,7 @@ void LoadoutTracker::setModuleIndexSecondary(U32 moduleIndex, bool isActive)
 
 void LoadoutTracker::deactivateAllModules()
 {
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
    {
       mModulePrimaryActive[i] = false;
       mModuleSecondaryActive[i] = false;
@@ -229,7 +229,7 @@ void LoadoutTracker::deactivateAllModules()
 
 bool LoadoutTracker::hasModule(ShipModule mod) const
 {
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       if(mModules[i] == mod)
          return true;
 
@@ -239,7 +239,7 @@ bool LoadoutTracker::hasModule(ShipModule mod) const
 
 bool LoadoutTracker::hasWeapon(WeaponType weapon) const
 {
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       if(mWeapons[i] == weapon)
          return true;
 
@@ -300,10 +300,10 @@ Vector<U8> LoadoutTracker::toU8Vector() const
 {
    Vector<U8> loadout(ShipModuleCount + ShipWeaponCount);
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       loadout.push_back(U8(mModules[i]));
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       loadout.push_back(U8(mWeapons[i]));
 
    return loadout;
@@ -312,11 +312,11 @@ Vector<U8> LoadoutTracker::toU8Vector() const
 
 bool LoadoutTracker::operator == (const LoadoutTracker &other) const
 {
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       if(getModule(i) != other.getModule(i))
          return false;
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       if(getWeapon(i) != other.getWeapon(i))
          return false;
 
@@ -339,11 +339,11 @@ string LoadoutTracker::toString(bool compact) const
    Vector<string> loadoutStrings(ShipModuleCount + ShipWeaponCount);    // Reserve space for efficiency
 
    // First modules
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       loadoutStrings.push_back(ModuleInfo::getModuleInfo((ShipModule) mModules[i])->getName());
 
    // Then weapons
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       loadoutStrings.push_back(WeaponInfo::getWeaponInfo(mWeapons[i]).name.getString());
 
    return listToString(loadoutStrings, compact ? "," : ", ");

--- a/zap/LuaBase.cpp
+++ b/zap/LuaBase.cpp
@@ -44,7 +44,7 @@ S32 checkArgList(lua_State *L, const LuaFunctionProfile *functionInfos, const ch
    const LuaFunctionProfile *functionInfo = NULL;
 
    // First, find the correct profile for this function
-   for(S32 i = 0; functionInfos[i].functionName != NULL; i++)
+   for(S32 i = 0; functionInfos[i].functionName != NULL; ++i)
       if(strcmp(functionInfos[i].functionName, functionName) == 0)
       {
          functionInfo = &functionInfos[i];
@@ -66,7 +66,7 @@ S32 checkArgList(lua_State *L, const char *moduleName, const char *functionName)
    if(iter != profileMap.end())
    {
       vector<LuaStaticFunctionProfile> &profiles = (*iter).second;
-      for(U32 i = 0; i < profiles.size(); i++)
+      for(U32 i = 0; i < profiles.size(); ++i)
       {
          if(!strcmp(profiles[i].functionName, functionName))
          {
@@ -86,19 +86,20 @@ S32 checkArgList(lua_State *L, const LuaFunctionArgList &functionArgList, const 
    S32 stackDepth = lua_gettop(L);
    S32 profileCount = functionArgList.profileCount;
 
-   for(S32 i = 0; i < profileCount; i++)
+   for(S32 i = 0; i < profileCount; ++i)
    {
       const LuaArgType *candidateArgList = functionArgList.argList[i];     // argList is a 2D array
       bool validProfile = true;
       S32 stackPos = 0;
 
-      for(S32 j = 0; candidateArgList[j] != END; j++)
+      for(S32 j = 0; candidateArgList[j] != END; ++j)
       {
          bool ok = false;
 
          if(stackPos < stackDepth)
          {
-            stackPos++;
+            ++stackPos;
+
             ok = checkLuaArgs(L, candidateArgList[j], stackPos);
          }
 
@@ -133,7 +134,8 @@ static bool checkPoints(lua_State *L, S32 minNumberOfPoints, S32 &stackPos)
    {
       S32 initialPos = stackPos;
       while(stackPos + 1 <= stackDepth && luaIsPoint(L, stackPos + 1))
-         stackPos++;
+         ++stackPos;
+
 
       return (stackPos - initialPos + 1) >= minNumberOfPoints;
    }
@@ -149,7 +151,8 @@ static bool checkPoints(lua_State *L, S32 minNumberOfPoints, S32 &stackPos)
             return false;
          }
          lua_pop(L, 1);
-         pointsFound++;
+         ++pointsFound;
+
       }
       return pointsFound >= minNumberOfPoints;
    }
@@ -187,7 +190,8 @@ bool checkLuaArgs(lua_State *L, LuaArgType argType, S32 &stackPos)
 
          if(ok)
             while(stackPos < stackDepth && lua_isnumber(L, stackPos))
-               stackPos++;
+               ++stackPos;
+
 
          return ok;
       }
@@ -201,7 +205,8 @@ bool checkLuaArgs(lua_State *L, LuaArgType argType, S32 &stackPos)
 
          if(ok)
             while(stackPos < stackDepth && lua_isstring(L, stackPos))
-               stackPos++;
+               ++stackPos;
+
 
          return ok;
       }
@@ -220,7 +225,8 @@ bool checkLuaArgs(lua_State *L, LuaArgType argType, S32 &stackPos)
          if(luaIsPoint(L, stackPos))           // Pair of Points
          {
             if(stackPos + 1 <= stackDepth && luaIsPoint(L, stackPos + 1))
-               stackPos++;
+               ++stackPos;
+
 
             return true;
          }
@@ -241,7 +247,8 @@ bool checkLuaArgs(lua_State *L, LuaArgType argType, S32 &stackPos)
          if(luaIsPoint(L, stackPos))             // Series of Points
          {
             while(stackPos + 1 <= stackDepth && luaIsPoint(L, stackPos + 1))
-               stackPos++;
+               ++stackPos;
+
 
             return true;
          }
@@ -298,7 +305,7 @@ bool checkLuaArgs(lua_State *L, LuaArgType argType, S32 &stackPos)
                logprintf(LogConsumer::LogError, "WARNING: It appears you have tried to add an item to teamIndex 0; this is\n"
                                                 "almost certainly an error.  If you want to add an item to the first team,\n"
                                                 "specify team 1.  Remember that Lua uses 1-based arrays.");
-            i--;    // Subtract 1 because Lua indices start with 1, and we need to convert to C++ 0-based index
+            --i;    // Subtract 1 because Lua indices start with 1, and we need to convert to C++ 0-based index
             return ((i >= 0 && i < Game::getAddTarget()->getTeamCount()) || (i + 1) == TEAM_NEUTRAL || (i + 1) == TEAM_HOSTILE);
          }
          return false;
@@ -431,7 +438,8 @@ Vector<Point> getPointsOrXYs(lua_State *L, S32 index)
       while(index + offset <= stackDepth && luaIsPoint(L, index + offset))
       {
          points.push_back(luaToPoint(L, index + offset));
-         offset++;
+         ++offset;
+
       }
    }
    else if(lua_istable(L, index))
@@ -455,7 +463,8 @@ Vector<Vector<Point> > getPolygons(lua_State *L, S32 index)
       Vector<Point > &poly = result[count];
       getPointVectorFromTable(L, -1, poly);     // table ... k, v, v
       lua_pop(L, 2);                                     // table ... k
-      count += 1;
+      ++count;
+
    }
                                                          // table ...
    return result;
@@ -510,7 +519,8 @@ bool dumpTable(lua_State *L, S32 tableIndex, const char *msg)
 
    // Compensate for other stuff we'll be putting on the stack
    if(tableIndex < 0)
-      tableIndex -= 1;
+      --tableIndex;
+
                                                             // -- ... table  <=== arrive with table and other junk (perhaps) on the stack
    lua_pushnil(L);      // First key                        // -- ... table nil
    while(lua_next(L, tableIndex) != 0)                      // -- ... table nextkey table[nextkey]
@@ -533,7 +543,7 @@ bool dumpStack(lua_State* L, const char *msg)
    bool hasMsg = (strcmp(msg, "") != 0);
    printf("\nTotal in stack: %d %s%s%s\n", top, hasMsg ? "[" : "", msg, hasMsg ? "]" : "");
 
-   for(S32 i = 1; i <= top; i++)
+   for(S32 i = 1; i <= top; ++i)
    {
       string val = stringify(L, i);
       printf("%d : %s\n", i, val.c_str());
@@ -787,7 +797,7 @@ S32 returnPoints(lua_State *L, const Vector<Point> *points)
    lua_createtable(L, points->size(), 0);                  //                                -- table
    S32 tableIndex = 1;     // Table will live on top of the stack, at index 1
 
-   for(S32 i = 0; i < points->size(); i++)
+   for(S32 i = 0; i < points->size(); ++i)
    {
       luaPushPoint(L, points->get(i).x, points->get(i).y);  // Push point onto the stack      -- table, point
       lua_rawseti(L, tableIndex, i + 1);                   // + 1  => Lua indices 1-based    -- table[i + 1] = point
@@ -802,12 +812,12 @@ S32 returnPolygons(lua_State *L, const Vector<Vector<Point> > &polys)
    TNLAssert(lua_gettop(L) == 0 || dumpStack(L), "Stack not clean!");
 
    lua_createtable(L, polys.size(), 0);            // polylist
-   for(S32 i = 0; i < polys.size(); i++)
+   for(S32 i = 0; i < polys.size(); ++i)
    {
       Vector<Point> points = polys[i];
       lua_createtable(L, points.size(), 0);        // polylist, poly
 
-      for(S32 j = 0; j < points.size(); j++)
+      for(S32 j = 0; j < points.size(); ++j)
       {
          luaPushPoint(L, points[j].x, points[j].y); // polylist, poly, point
          lua_rawseti(L, -2, j + 1);                // polylist, poly
@@ -970,13 +980,13 @@ string prettyPrintParamList(const LuaFunctionArgList &functionArgList)
 {
    string msg;
 
-   for(S32 i = 0; i < functionArgList.profileCount; i++)
+   for(S32 i = 0; i < functionArgList.profileCount; ++i)
    {
       msg += "\n\t";
 
       bool none = true;
 
-      for(S32 j = 0; functionArgList.argList[i][j] != END; j++)
+      for(S32 j = 0; functionArgList.argList[i][j] != END; ++j)
       {
          if(j > 0)
             msg += ", ";

--- a/zap/LuaGlobals.cpp
+++ b/zap/LuaGlobals.cpp
@@ -30,7 +30,7 @@ static string buildPrintString(lua_State *L)
   string out;
 
   lua_getglobal(L, "tostring");
-  for(i = 1; i <= n; i++)
+  for(i = 1; i <= n; ++i)
   {
     const char *s;
     lua_pushvalue(L, -1);  /* function to be called */

--- a/zap/LuaScriptRunner.cpp
+++ b/zap/LuaScriptRunner.cpp
@@ -64,7 +64,7 @@ LuaScriptRunner::LuaScriptRunner()
    static U32 mNextScriptId = 0;
 
    // Initialize all subscriptions to unsubscribed -- bits will automatically subscribe to onTick later
-   for(S32 i = 0; i < EventManager::EventTypes; i++)
+   for(S32 i = 0; i < EventManager::EventTypes; ++i)
       mSubscriptions[i] = false;
 
    mScriptId = "script" + itos(mNextScriptId++);
@@ -79,7 +79,7 @@ LuaScriptRunner::~LuaScriptRunner()
 {
    // Make sure we're unsubscribed to all those events we subscribed to.  Don't want to
    // send an event to a dead bot, after all...
-   for(S32 i = 0; i < EventManager::EventTypes; i++)
+   for(S32 i = 0; i < EventManager::EventTypes; ++i)
       if(mSubscriptions[i])
          EventManager::get()->unsubscribeImmediate(this, (EventManager::EventType)i);
 
@@ -249,7 +249,7 @@ bool LuaScriptRunner::loadScript(bool cacheScript)
          // Check if script is in our cache
          S32 cacheSize = (S32)mCachedScripts.size();
 
-         for(S32 i = 0; i < cacheSize; i++)
+         for(S32 i = 0; i < cacheSize; ++i)
             if(mCachedScripts[i] == mScriptName)
             {
                found = true;
@@ -724,7 +724,7 @@ void LuaScriptRunner::setLuaArgs(const Vector<string> &args)
    lua_pushstring(L, mScriptName.c_str());            //                                        -- ..., env_table, "arg", table, scriptName
    lua_rawseti(L, -2, 0);                             //                                        -- ..., env_table, "arg", table
 
-   for(S32 i = 0; i < args.size(); i++)
+   for(S32 i = 0; i < args.size(); ++i)
    {
       lua_pushstring(L, args[i].c_str());             //                                        -- ..., env_table, "arg", table, string
       lua_rawseti(L, -2, i + 1);                      //                                        -- ..., env_table, "arg", table
@@ -775,7 +775,7 @@ S32 LuaScriptRunner::findObjectById(lua_State *L, const Vector<DatabaseObject *>
 {
    S32 id = S32(getInt(L, 1));
 
-   for(S32 i = 0; i < objects->size(); i++)
+   for(S32 i = 0; i < objects->size(); ++i)
    {
       BfObject *bfObject = static_cast<BfObject *>(objects->get(i));
       if(bfObject->getUserAssignedId() == id)
@@ -1000,7 +1000,7 @@ void LuaScriptRunner::setGlobalObjectArrays(lua_State *L)
    // ModuleInfo
    lua_newtable(L);                                // table
 
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
    {
       lua_pushinteger(L, i);                       // table, index
       lua_newtable(L);                             // table, index, table
@@ -1022,7 +1022,7 @@ void LuaScriptRunner::setGlobalObjectArrays(lua_State *L)
    // WeaponInfo
    lua_newtable(L);                                // table
 
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
    {
       WeaponInfo weaponInfo = WeaponInfo::getWeaponInfo(WeaponType(i));
 
@@ -1116,12 +1116,12 @@ void LuaScriptRunner::registerLooseFunctions(lua_State *L)
    ProfileMap moduleProfiles = LuaModuleRegistrarBase::getModuleProfiles();
 
    ProfileMap::iterator it;
-   for(it = moduleProfiles.begin(); it != moduleProfiles.end(); it++)
+   for(it = moduleProfiles.begin(); it != moduleProfiles.end(); ++it)
    {
       if((*it).first == "global")
       {
          vector<LuaStaticFunctionProfile> &profiles = (*it).second;
-         for(U32 i = 0; i < profiles.size(); i++)
+         for(U32 i = 0; i < profiles.size(); ++i)
          {
             LuaStaticFunctionProfile &profile = profiles[i];
             lua_pushcfunction(L, profile.function);                 // -- fn
@@ -1133,7 +1133,7 @@ void LuaScriptRunner::registerLooseFunctions(lua_State *L)
          lua_createtable(L, 0, 0);                                  // -- table
 
          vector<LuaStaticFunctionProfile> &profiles = (*it).second;
-         for(U32 i = 0; i < profiles.size(); i++)
+         for(U32 i = 0; i < profiles.size(); ++i)
          {
             LuaStaticFunctionProfile &profile = profiles[i];
             lua_pushcfunction(L, profile.function);                 // -- table, fn
@@ -1297,10 +1297,10 @@ S32 LuaScriptRunner::lua_findAllObjects(lua_State *L)
 
    S32 pushed = 0;      // Count of items we put into our table
 
-   for(S32 i = 0; i < results->size(); i++)
+   for(S32 i = 0; i < results->size(); ++i)
    {
       static_cast<BfObject *>(results->get(i))->push(L);
-      pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 
@@ -1382,10 +1382,10 @@ S32 LuaScriptRunner::lua_findAllObjectsInArea(lua_State *L)
 
    S32 pushed = 0;      // Count of items we put into our table
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       static_cast<BfObject *>(fillVector[i])->push(L);
-      pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 

--- a/zap/LuaWrapper.h
+++ b/zap/LuaWrapper.h
@@ -1017,7 +1017,7 @@ private:
    // Helper function -- return true if name is found in orderedClassList
    static bool findInOrderedClassList(const char *name)
    {
-      for(int i = 0; i < (int)getOrderedClassList().size(); i++)
+      for(int i = 0; i < (int)getOrderedClassList().size(); ++i)
          if(strcmp(name, getOrderedClassList()[i]) == 0)
             return true;
 
@@ -1045,7 +1045,7 @@ private:
       {
          bool foundAtLeastOneThisIteration = false;      // For detecting and preventing endless loops due to hierarchy problems
 
-         for(int i = (int)getUnorderedClassList().size() - 1; i >= 0; i--)    // Descending order for greater efficiency
+         for(int i = (int)getUnorderedClassList().size() - 1; i >= 0; --i)    // Descending order for greater efficiency
             // If parent is in orderedClassList, we can move the item to the orderedClassList
             if(findInOrderedClassList(getUnorderedClassList()[i].parent))
             {
@@ -1057,7 +1057,7 @@ private:
          TNLAssert(foundAtLeastOneThisIteration, "Registering items is stuck -- check luaW class/subclass declarations!");
 
          if(!foundAtLeastOneThisIteration)
-            for(int i = (int)getUnorderedClassList().size() - 1; i > -1; i--)
+            for(int i = (int)getUnorderedClassList().size() - 1; i > -1; --i)
                moveToOrderedList(i);
 
          itemsRemainingInList = getUnorderedClassList().size();
@@ -1113,11 +1113,11 @@ public:
       std::vector<ClassName> &orderedClassList = getOrderedClassList();
 
       // Register all our classes
-      for(unsigned int i = 0; i < orderedClassList.size(); i++)
+      for(unsigned int i = 0; i < orderedClassList.size(); ++i)
          getRegistrationFunctions()[orderedClassList[i]](L);
 
       // Extend those that need extending
-      for(unsigned int i = 0; i < orderedClassList.size(); i++)
+      for(unsigned int i = 0; i < orderedClassList.size(); ++i)
       {
          // Skip base classes
          if(getExtensionFunctions()[orderedClassList[i]] == NULL)

--- a/zap/MapTile.cpp
+++ b/zap/MapTile.cpp
@@ -90,7 +90,8 @@ static Path64 pointsToPath64(const Vector<Point> &pts)
 static U32 nextPow2(U32 v)
 {
    if(v == 0) return 1;
-   v--;
+   --v;
+
    v |= v >> 1;
    v |= v >> 2;
    v |= v >> 4;
@@ -206,11 +207,11 @@ static void buildProtectedBoundaries(const Vector<Vector<Point>> &wallPolygons,
                                       S32 gridWidth, S32 gridHeight,
                                       std::unordered_set<U16> &outProtected)
 {
-   for(S32 w = 0; w < wallPolygons.size(); w++)
+   for(S32 w = 0; w < wallPolygons.size(); ++w)
    {
       const Vector<Point> &poly = wallPolygons[w];
       S32 n = poly.size();
-      for(S32 v = 0; v < n; v++)
+      for(S32 v = 0; v < n; ++v)
       {
          const Point &p1 = poly[v];
          const Point &p2 = poly[(v + 1) % n];
@@ -247,7 +248,7 @@ static void buildProtectedBoundaries(const Vector<Vector<Point>> &wallPolygons,
             if(gyEnd >= gridHeight) gyEnd = gridHeight - 1;
 
             // Protect the tile this edge's grid coordinate maps to
-            for(S32 gy = gyStart; gy <= gyEnd; gy++)
+            for(S32 gy = gyStart; gy <= gyEnd; ++gy)
             {
                U16 tid = static_cast<U16>(gy * gridWidth + gx);
                outProtected.insert(protectedKey(tid, side));
@@ -268,7 +269,7 @@ static void buildProtectedBoundaries(const Vector<Vector<Point>> &wallPolygons,
             }
             if(adjGx >= 0 && adjGx < gridWidth)
             {
-               for(S32 gy = gyStart; gy <= gyEnd; gy++)
+               for(S32 gy = gyStart; gy <= gyEnd; ++gy)
                {
                   U16 tid = static_cast<U16>(gy * gridWidth + adjGx);
                   outProtected.insert(protectedKey(tid, adjSide));
@@ -300,7 +301,7 @@ static void buildProtectedBoundaries(const Vector<Vector<Point>> &wallPolygons,
             if(gxStart < 0) gxStart = 0;
             if(gxEnd >= gridWidth) gxEnd = gridWidth - 1;
 
-            for(S32 gx = gxStart; gx <= gxEnd; gx++)
+            for(S32 gx = gxStart; gx <= gxEnd; ++gx)
             {
                U16 tid = static_cast<U16>(gy * gridWidth + gx);
                outProtected.insert(protectedKey(tid, side));
@@ -320,7 +321,7 @@ static void buildProtectedBoundaries(const Vector<Vector<Point>> &wallPolygons,
             }
             if(adjGy >= 0 && adjGy < gridHeight)
             {
-               for(S32 gx = gxStart; gx <= gxEnd; gx++)
+               for(S32 gx = gxStart; gx <= gxEnd; ++gx)
                {
                   U16 tid = static_cast<U16>(adjGy * gridWidth + gx);
                   outProtected.insert(protectedKey(tid, adjSide));
@@ -370,13 +371,13 @@ static bool computeEdgeSpans(const WallPoly &wp, U32 edgeIdx,
 
    const int64_t fixedC = vertical ? p1.x : p1.y;   // x (vertical) or y (horizontal)
 
-   for(S32 pi = 0; pi < globalUnion.size(); pi++)
+   for(S32 pi = 0; pi < globalUnion.size(); ++pi)
    {
       const Path64 &path = globalUnion[pi];
       if(path.size() < 2)
          continue;
 
-      for(S32 ei = 0; ei < path.size(); ei++)
+      for(S32 ei = 0; ei < path.size(); ++ei)
       {
          const Point64 &a = path[ei];
          const Point64 &b = path[(ei + 1) % path.size()];
@@ -426,7 +427,7 @@ static bool computeEdgeSpans(const WallPoly &wp, U32 edgeIdx,
    std::sort(crossings.begin(), crossings.end());
    std::vector<double> uniq;
    uniq.reserve(crossings.size());
-   for(S32 i = 0; i < (S32)crossings.size(); i++)
+   for(S32 i = 0; i < (S32)crossings.size(); ++i)
       if(uniq.empty() || std::fabs(crossings[i] - uniq.back()) > 1e-4)
          uniq.push_back(crossings[i]);
 
@@ -446,7 +447,7 @@ static bool computeEdgeSpans(const WallPoly &wp, U32 edgeIdx,
                             // Clipper2 precision shifts (1 unit = 1000 C2 units)
 
    double prevS = 0.0;
-   for(S32 i = 0; i <= (S32)uniq.size(); i++)
+   for(S32 i = 0; i <= (S32)uniq.size(); ++i)
    {
       const double sNext = (i < (S32)uniq.size()) ? uniq[i] : 1.0;
       const double midS = (prevS + sNext) * 0.5;
@@ -468,7 +469,7 @@ static bool computeEdgeSpans(const WallPoly &wp, U32 edgeIdx,
    }
 
    splitTs.reserve(uniq.size());
-   for(S32 i = 0; i < (S32)uniq.size(); i++)
+   for(S32 i = 0; i < (S32)uniq.size(); ++i)
       splitTs.push_back((F32)uniq[i]);
 
    return true;
@@ -490,7 +491,7 @@ static void applyEdgeSplits(WallPoly &wp, const std::vector<EdgeSpanSplit> &spli
    newEdges.reserve(wp.edges.size() + splits.size() * 6);
 
    auto findSplit = [&splits](U32 edgeIdx) -> const EdgeSpanSplit * {
-      for(S32 s = 0; s < (S32)splits.size(); s++)
+      for(S32 s = 0; s < (S32)splits.size(); ++s)
          if(splits[s].edgeIdx == edgeIdx)
             return &splits[s];
       return NULL;
@@ -500,7 +501,7 @@ static void applyEdgeSplits(WallPoly &wp, const std::vector<EdgeSpanSplit> &spli
    newVerts.push_back(wp.verts[0]);
    newVerts.push_back(wp.verts[1]);
 
-   for(U32 i = 0; i < n; i++)
+   for(U32 i = 0; i < n; ++i)
    {
       const U32 next = (i + 1) % n;
       const F32 eX = wp.verts[next * 2];
@@ -517,7 +518,7 @@ static void applyEdgeSplits(WallPoly &wp, const std::vector<EdgeSpanSplit> &spli
          const F32 sX = wp.verts[i * 2];
          const F32 sY = wp.verts[i * 2 + 1];
 
-         for(S32 k = 0; k < split->ts.size(); k++)
+         for(S32 k = 0; k < split->ts.size(); ++k)
          {
             const F32 t = split->ts[k];
             newVerts.push_back(sX + (eX - sX) * t);
@@ -569,7 +570,7 @@ static void classifyEdges(WallPoly &wallPoly, const Rect &tileBounds, U16 tileId
    const U32 numVerts = wallPoly.numVerts();
    std::vector<EdgeSpanSplit> splits;   // collected split ops, applied after the loop
 
-   for(U32 i = 0; i < numVerts; i++)
+   for(U32 i = 0; i < numVerts; ++i)
    {
       const F32 x1 = wallPoly.verts[i * 2];
       const F32 y1 = wallPoly.verts[i * 2 + 1];
@@ -601,7 +602,7 @@ static void classifyEdges(WallPoly &wallPoly, const Rect &tileBounds, U16 tileId
       {
          bool allNone    = true;
          bool allVisible = true;
-         for(S32 s = 0; s < segStyles.size(); s++)
+         for(S32 s = 0; s < segStyles.size(); ++s)
          {
             if(segStyles[s] != EdgeStyle::None)
                allNone = false;
@@ -671,7 +672,7 @@ static void stripCollinearPoints(Path64 &path)
    result.reserve(path.size());
 
    S32 n = static_cast<S32>(path.size());
-   for(S32 i = 0; i < n; i++)
+   for(S32 i = 0; i < n; ++i)
    {
       const Point64 &prev = path[(i - 1 + n) % n];
       const Point64 &curr = path[i];
@@ -720,7 +721,7 @@ static void mergeOverlappingEdges(WallPoly &wp)
    };
 
    Vector<EdgeInfo> infos;
-   for(U32 e = 0; e < nv; e++)
+   for(U32 e = 0; e < nv; ++e)
    {
       if(wp.edges[e] == EdgeStyle::None)
          continue;
@@ -755,12 +756,12 @@ static void mergeOverlappingEdges(WallPoly &wp)
 
    // Find overlapping pairs and merge
    S32 n = infos.size();
-   for(S32 i = 0; i < n; i++)
+   for(S32 i = 0; i < n; ++i)
    {
       if(wp.edges[infos[i].idx] == EdgeStyle::None)
          continue;
 
-      for(S32 j = i + 1; j < n; j++)
+      for(S32 j = i + 1; j < n; ++j)
       {
          if(wp.edges[infos[j].idx] == EdgeStyle::None)
             continue;
@@ -849,7 +850,7 @@ static void suppressInteriorBoundaryEdges(WallPoly &wp)
    };
 
    Vector<EdgeRange> ranges;
-   for(U32 e = 0; e < nv; e++)
+   for(U32 e = 0; e < nv; ++e)
    {
       F32 x1 = wp.verts[e * 2];
       F32 y1 = wp.verts[e * 2 + 1];
@@ -872,9 +873,9 @@ static void suppressInteriorBoundaryEdges(WallPoly &wp)
 
    // Mark interior edges: if edge B's range is strictly inside edge A's range
    // on the same line, edge B is interior.
-   for(S32 i = 0; i < ranges.size(); i++)
+   for(S32 i = 0; i < ranges.size(); ++i)
    {
-      for(S32 j = i + 1; j < ranges.size(); j++)
+      for(S32 j = i + 1; j < ranges.size(); ++j)
       {
          EdgeRange &a = ranges[i];
          EdgeRange &b = ranges[j];
@@ -903,7 +904,7 @@ static void appendClippedPaths(MapTile &mt, const Rect &tileBounds, const Paths6
                                const std::unordered_set<U16> &protectedBoundaries,
                                const Paths64 &globalUnion)
 {
-   for(S32 i = 0; i < paths.size(); i++)
+   for(S32 i = 0; i < paths.size(); ++i)
    {
       if(paths[i].size() < 3) 
          continue;
@@ -961,7 +962,7 @@ void MapTileBuilder::build(Vector<MapTile> &outTiles)
    Vector<ClipperWall> clipperWalls;
    clipperWalls.reserve(mWallPolygons.size());
 
-   for(S32 w = 0; w < mWallPolygons.size(); w++)
+   for(S32 w = 0; w < mWallPolygons.size(); ++w)
    {
       ClipperWall cw;
       cw.path = pointsToPath64(mWallPolygons[w]);
@@ -986,7 +987,7 @@ void MapTileBuilder::build(Vector<MapTile> &outTiles)
    // Direct tileId → index lookup table (tileId = gy * mGridWidth + gx)
    std::vector<S32> tileLookup(mGridWidth * mGridHeight, -1);
 
-   for(S32 i = 0; i < clipperWalls.size(); i++)
+   for(S32 i = 0; i < clipperWalls.size(); ++i)
    {
       const Path64 &wallPath = clipperWalls[i].path;
 
@@ -1002,9 +1003,9 @@ void MapTileBuilder::build(Vector<MapTile> &outTiles)
       const S32 tileMaxGY = static_cast<S32>(std::floor(
          (wallBounds.max.y - mLevelBounds.min.y) / static_cast<F32>(mTileSize)));
 
-      for(S32 gy = tileMinGY; gy <= tileMaxGY; gy++)
+      for(S32 gy = tileMinGY; gy <= tileMaxGY; ++gy)
       {
-         for(S32 gx = tileMinGX; gx <= tileMaxGX; gx++)
+         for(S32 gx = tileMinGX; gx <= tileMaxGX; ++gx)
          {
             if(gx < 0 || gx >= mGridWidth || gy < 0 || gy >= mGridHeight)
                continue;
@@ -1072,7 +1073,7 @@ void MapTileBuilder::build(Vector<MapTile> &outTiles)
 
    // Collect original (pre-clip) wall paths, separated by type
    Paths64 origPermPaths, origDestPaths;
-   for(S32 w = 0; w < mWallPolygons.size(); w++)
+   for(S32 w = 0; w < mWallPolygons.size(); ++w)
    {
       Path64 path = pointsToPath64(mWallPolygons[w]);
       if(mWallDestructible[w])
@@ -1090,7 +1091,7 @@ void MapTileBuilder::build(Vector<MapTile> &outTiles)
    // This avoids the merged-Union Z-callback complexity entirely.
    // ------------------------------------------------------------
 
-   for(S32 i = 0; i < outTiles.size(); i++)
+   for(S32 i = 0; i < outTiles.size(); ++i)
    {
       MapTile &tile = outTiles[i];
       TilePaths &tilePath = tilePaths[i];

--- a/zap/NexusGame.cpp
+++ b/zap/NexusGame.cpp
@@ -172,7 +172,7 @@ static S32 getMountedFlagCount(Ship *ship)
    S32 flagCount = 0;
    S32 itemCount = ship->getMountedItemCount();
 
-   for(S32 i = 0; i < itemCount; i++)
+   for(S32 i = 0; i < itemCount; ++i)
    {
       MountableItem *mountedItem = ship->getMountedItem(i);
 
@@ -192,7 +192,7 @@ bool NexusGameType::isCarryingItems(Ship *ship)
 {
    S32 itemCount = ship->getMountedItemCount();
 
-   for(S32 i = 0; i < itemCount; i++)
+   for(S32 i = 0; i < itemCount; ++i)
    {
       MountableItem *mountedItem = ship->getMountedItem(i);
       if(!mountedItem)        // Could be null when a player drop their flags and gets destroyed at the same time
@@ -270,7 +270,7 @@ Vector<string> NexusGameType::getGameParameterMenuKeys()
    Vector<string> items = Parent::getGameParameterMenuKeys();
 
    // Remove Win Score, replace it with some Nexus specific items
-   for(S32 i = 0; i < items.size(); i++)
+   for(S32 i = 0; i < items.size(); ++i)
       if(items[i] == "Win Score")
       {
          items.erase(i);      // Delete "Win Score"
@@ -454,7 +454,8 @@ void NexusGameType::idle_client(U32 deltaT)
       if(mYardSaleWaypoints[i].timeLeft.update(deltaT))
          mYardSaleWaypoints.erase_fast(i);
       else
-         i++;
+         ++i;
+
    }
 #endif
 }
@@ -479,7 +480,7 @@ void NexusGameType::openNexus(S32 timeNexusOpened)
    mNexusChangeAtTime = getNextChangeTime(timeNexusOpened, mNexusOpenTime);
 
    // Check if anyone is already in the Nexus, examining each client's ship in turn...
-   for(S32 i = 0; i < getGame()->getClientCount(); i++)
+   for(S32 i = 0; i < getGame()->getClientCount(); ++i)
    {
       Ship *client_ship = getGame()->getClientInfo(i)->getShip();
 
@@ -661,12 +662,12 @@ S32 NexusGameType::renderTimeLeftSpecial(S32 right, S32 bottom, bool render) con
 
 void NexusGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) const
 {
-   for(S32 i = 0; i < mYardSaleWaypoints.size(); i++)
+   for(S32 i = 0; i < mYardSaleWaypoints.size(); ++i)
       renderObjectiveArrow(mYardSaleWaypoints[i].pos, &Colors::white, canvasWidth, canvasHeight);
 
    const Color *color = mNexusIsOpen ? &Colors::NexusOpenColor : &Colors::NexusClosedColor;
 
-   for(S32 i = 0; i < mNexus.size(); i++)
+   for(S32 i = 0; i < mNexus.size(); ++i)
       renderObjectiveArrow(mNexus[i], color, canvasWidth, canvasHeight);
 
    Parent::renderInterfaceOverlay(canvasWidth, canvasHeight);
@@ -722,7 +723,8 @@ void NexusGameType::shipTouchFlag(Ship *ship, FlagItem *touchedFlag)
    if(touchedFlag)
       shipFlagCount += touchedFlag->getFlagCount();
    else
-      shipFlagCount++;
+      ++shipFlagCount;
+
 
    shipFlag->changeFlagCount(shipFlagCount);
 
@@ -832,7 +834,7 @@ void NexusFlagItem::dropFlags(U32 flags)
 
    if(flags > MAX_DROP_FLAGS)
    {
-      for(U32 i = MAX_DROP_FLAGS; i > 0; i--)
+      for(U32 i = MAX_DROP_FLAGS; i > 0; --i)
       {
          // By dividing and subtracting, it works by using integer divide, subtracting from "flags" left,
          // and the last loop is (i == 1), dropping exact amount using only limited FlagItems
@@ -844,7 +846,7 @@ void NexusFlagItem::dropFlags(U32 flags)
       }
    }
    else     // Normal situation
-      for(U32 i = 0; i < flags; i++)
+      for(U32 i = 0; i < flags; ++i)
          getGame()->releaseFlag(mMount->getActualPos(), mMount->getActualVel());
 
    changeFlagCount(0);
@@ -980,7 +982,7 @@ bool NexusZone::processArguments(S32 argc2, const char **argv2, Game *game)
    // so a possible future version can add parameters without compatibility problem.
    S32 argc = 0;
    const char *argv[Geometry::MAX_POLY_POINTS * 2];
-   for(S32 i = 0; i < argc2; i++)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char c = argv2[i][0];
       //switch(c)
@@ -991,7 +993,8 @@ bool NexusZone::processArguments(S32 argc2, const char **argv2, Game *game)
       {
          if(argc < Geometry::MAX_POLY_POINTS * 2)
          {  argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }

--- a/zap/PickupItem.cpp
+++ b/zap/PickupItem.cpp
@@ -51,7 +51,7 @@ void PickupItem::idle(BfObject::IdleCallPath path)
          show();
 
          // Check if there is a ship sitting on this item... it so, ship gets the pickup!
-         for(S32 i = 0; i < getGame()->getClientCount(); i++)
+         for(S32 i = 0; i < getGame()->getClientCount(); ++i)
          {
             Ship *ship = getGame()->getClientInfo(i)->getShip();
 

--- a/zap/Rect.cpp
+++ b/zap/Rect.cpp
@@ -118,7 +118,7 @@ void Rect::set(const Vector<Point> &p)
    min = p[0];
    max = p[0];
 
-   for(int i = 1; i < p.size(); i++)
+   for(int i = 1; i < p.size(); ++i)
       unionPoint(p[i]);
 }
 

--- a/zap/RenderUtils.cpp
+++ b/zap/RenderUtils.cpp
@@ -752,7 +752,7 @@ void wrapString(const string &str, S32 wrapWidth, S32 fontSize, FontContext cont
    Vector<string> wrapped = wrapString(str, wrapWidth, fontSize);
    FontManager::popFontContext();
 
-   for(S32 i = 0; i < wrapped.size(); i++)
+   for(S32 i = 0; i < wrapped.size(); ++i)
       lines.push_back(wrapped[i]);
 }
 
@@ -771,7 +771,7 @@ Vector<string> wrapString(const string &str, S32 wrapWidth, S32 fontSize, const 
    string::size_type start = 0;
    string::size_type potentialBreakPoint = start;
 
-   for(string::size_type i = 0; i < str.length(); i++)
+   for(string::size_type i = 0; i < str.length(); ++i)
    {
       if(str[i] == '\n')
       {
@@ -792,7 +792,8 @@ Vector<string> wrapString(const string &str, S32 wrapWidth, S32 fontSize, const 
          else
          {
             wrappedLines.push_back((wrappedLines.size() > 0 ? indentPrefix : "") + str.substr(start, potentialBreakPoint - start));
-            potentialBreakPoint++;
+            ++potentialBreakPoint;
+
             start = potentialBreakPoint;
          }
       }
@@ -826,14 +827,15 @@ U32 drawWrapText(const string &msg, S32 xpos, S32 ypos, S32 width, S32 ypos_end,
    ypos -= lines.size() * lineHeight;     // Align according to number of wrapped lines
 
    // Draw lines that need to wrap
-   for(S32 i = 0; i < lines.size(); i++)
+   for(S32 i = 0; i < lines.size(); ++i)
    {
       if(ypos >= ypos_end)      // If there is room to draw some lines at top when aligned bottom
       {
          if(draw)
             drawString(xpos, ypos, fontSize, lines[i].c_str());
 
-         linesDrawn++;
+         ++linesDrawn;
+
       }
       ypos += lineHeight;
    }

--- a/zap/RobotManager.cpp
+++ b/zap/RobotManager.cpp
@@ -64,7 +64,7 @@ void RobotManager::balanceTeams()
    S32 totalFixedPlayers = 0;
    S32 largestFixedPlayerCount = 0;
 
-   for(S32 i = 0; i < botCounts.size(); i++)
+   for(S32 i = 0; i < botCounts.size(); ++i)
    {
       S32 kickablePlayers = botCounts[i][ClientInfo::ClassRobotAddedByAutoleveler];
       S32 fixedPlayers = (mGame->getTeam(i)->getPlayerBotCount() - kickablePlayers);
@@ -78,7 +78,7 @@ void RobotManager::balanceTeams()
    S32 playersNeededPerTeam = max(largestFixedPlayerCount, maxPlayersPerBalancedTeam);
 
    // Kick bots on any teams with more players than we need
-   for(S32 i = 0; i < teamCount; i++)
+   for(S32 i = 0; i < teamCount; ++i)
    {
       Team *team = static_cast<Team *>(mGame->getTeam(i));
 
@@ -99,7 +99,7 @@ void RobotManager::balanceTeams()
       {
          Vector<const char *> noArgs;
 
-         for(S32 j = teamSize; j < playersNeededPerTeam; j++)
+         for(S32 j = teamSize; j < playersNeededPerTeam; ++j)
             addBot(noArgs, ClientInfo::ClassRobotAddedByAutoleveler, i);
       }
    }
@@ -166,7 +166,7 @@ S32 RobotManager::getBotCount() const
 // Find bot from its id (static)
 Robot *RobotManager::findBot(const char *id)
 {
-   for(S32 i = 0; i < mRobots.size(); i++)
+   for(S32 i = 0; i < mRobots.size(); ++i)
       if(strcmp(mRobots[i]->getScriptId(), id) == 0)
          return mRobots[i];
 
@@ -184,7 +184,7 @@ void RobotManager::addBot(Robot *robot)
 // Remove this robot from the list of bots; does not delete it (only called from Robot destructor)
 void RobotManager::removeBot(Robot *robot)
 {
-   for(S32 i = 0; i < mRobots.size(); i++)
+   for(S32 i = 0; i < mRobots.size(); ++i)
    if(mRobots[i] == robot)
    {
       mRobots.erase_fast(i);
@@ -196,7 +196,7 @@ void RobotManager::removeBot(Robot *robot)
 // Delete bot by index
 void RobotManager::deleteBot(const StringTableEntry &name)
 {
-   for(S32 i = 0; i < mRobots.size(); i++)
+   for(S32 i = 0; i < mRobots.size(); ++i)
    if(mRobots[i]->getClientInfo()->getName() == name)
       deleteBot(i);
 }
@@ -218,7 +218,7 @@ void RobotManager::moreBots()
    // Find largest team player count
    S32 largestTeamCount = 0;
 
-   for(S32 i = 0; i < teamCount; i++)
+   for(S32 i = 0; i < teamCount; ++i)
    {
       S32 currentCount = mGame->getTeam(i)->getPlayerBotCount();
 
@@ -230,7 +230,7 @@ void RobotManager::moreBots()
    // add bots until all teams are even.
    S32 neededBotCount = 0;
 
-   for(S32 i = 0; i < teamCount; i++)
+   for(S32 i = 0; i < teamCount; ++i)
    {
       Team *team = static_cast<Team *>(mGame->getTeam(i));
       if(team->getPlayerBotCount() < largestTeamCount)
@@ -239,12 +239,12 @@ void RobotManager::moreBots()
 
    // If teams all have the same number of players, neededBotCount will be 0 ==> add a bot to each team
    if(neededBotCount == 0)
-      for(S32 i = 0; i < teamCount; i++)
+      for(S32 i = 0; i < teamCount; ++i)
          addBot(Vector<const char *>(), ClientInfo::ClassRobotAddedByAutoleveler);
 
    // Otherwise, add neededBotCount bots to bring all the teams up to the same number of players as on the biggest team
    else
-      for(S32 i = 0; i < neededBotCount; i++)
+      for(S32 i = 0; i < neededBotCount; ++i)
          addBot(Vector<const char *>(), ClientInfo::ClassRobotAddedByAutoleveler);
    mAutoLevelTeams = true;
    mManagerActive = true;
@@ -271,7 +271,7 @@ void RobotManager::fewerBots()
    TNLAssert(targetPlayerCount >= 0, "Negative players makes no sense!");
 
    // Scan the teams -- any teams with a bot and more players than targetPlayerCount will lose bots
-   for(S32 i = 0; i < teamCount; i++)
+   for(S32 i = 0; i < teamCount; ++i)
    {
       // Determine how many bots we can remove from this team if it has more players than the smallest team
       S32 botsToKick = mGame->getTeam(i)->getPlayerBotCount() - targetPlayerCount;
@@ -309,7 +309,7 @@ void RobotManager::printTeams(Game *game, const string &message)
 
    string teamDescr = "";
 
-   for(S32 i = 0; i < teams; i++)
+   for(S32 i = 0; i < teams; ++i)
    {
       AbstractTeam *team = game->getTeam(i);
       teamDescr += string(team->getPlayerCount(), 'H');
@@ -332,7 +332,8 @@ void RobotManager::deleteBotsFromTeam(S32 botsToKick, S32 teamIndex)
    while(botsToKick > 0)
    {
       if(deleteBotFromTeam(teamIndex, ClientInfo::ClassRobotAddedByAutoleveler))
-         botsToKick--;
+         --botsToKick;
+
       else
          break;
    }
@@ -341,7 +342,8 @@ void RobotManager::deleteBotsFromTeam(S32 botsToKick, S32 teamIndex)
    while(botsToKick > 0)
    {
       if(deleteBotFromTeam(teamIndex, ClientInfo::ClassRobotAddedByAddbots))
-         botsToKick--;
+         --botsToKick;
+
       else
          break;
    }
@@ -350,7 +352,8 @@ void RobotManager::deleteBotsFromTeam(S32 botsToKick, S32 teamIndex)
    while(botsToKick > 0)
    {
       if(deleteBotFromTeam(teamIndex, ClientInfo::ClassAnyBot))
-         botsToKick--;
+         --botsToKick;
+
       else
          break;
    }
@@ -362,7 +365,7 @@ void RobotManager::deleteBotsFromTeam(S32 botsToKick, S32 teamIndex)
 // Returns true if it found a bot to delete
 bool RobotManager::deleteBotFromTeam(S32 teamIndex, ClientInfo::ClientClass botClass)
 {
-   for(S32 i = 0; i < mRobots.size(); i++)
+   for(S32 i = 0; i < mRobots.size(); ++i)
       if(mRobots[i]->getTeam() == teamIndex && (mRobots[i]->getClientInfo()->getClientClass() == botClass ||
                                                 botClass == ClientInfo::ClassAnyBot))
       {
@@ -382,7 +385,7 @@ bool RobotManager::deleteBotFromTeam(S32 teamIndex, ClientInfo::ClientClass botC
 // Get here when player issues /kickbots command, or when they choose REMOVE ALL ROBOTS from the game menu
 void RobotManager::deleteAllBots()
 {
-   for(S32 i = mRobots.size() - 1; i >= 0; i--)
+   for(S32 i = mRobots.size() - 1; i >= 0; --i)
       deleteBot(i);
 
    mManagerActive = false;
@@ -392,7 +395,7 @@ void RobotManager::deleteAllBots()
 
 void RobotManager::clearMoves()
 {
-   for(S32 i = 0; i < mRobots.size(); i++)
+   for(S32 i = 0; i < mRobots.size(); ++i)
       mRobots[i]->clearMove();
 }
 

--- a/zap/ScoreboardRenderer.cpp
+++ b/zap/ScoreboardRenderer.cpp
@@ -242,7 +242,8 @@ void ScoreboardRenderer::renderTeamScoreboard(S32 index, S32 teams, bool isTeamG
    S32 colIndexWidths[ColIndexCount];
    S32 maxColIndexWidths[ColIndexCount] = {0};
 
-   for(S32 i = 0; i < playerInfos.size(); ++i)
+   S32 playerInfos_sz = playerInfos.size();
+   for (S32 i = 0; i < playerInfos_sz; ++i)
    {
       renderScoreboardLine(playerInfos, isTeamGame, i, x, curRowY, lineHeight, xr, colIndexWidths);
       curRowY += lineHeight;

--- a/zap/ScoreboardRenderer.cpp
+++ b/zap/ScoreboardRenderer.cpp
@@ -53,7 +53,7 @@ void getDummyPlayerScores(ClientGame *game, Vector<ClientInfo *> &scores)
    ClientInfo *clientInfo;
    const S32 teams = getDummyTeamCount();
 
-   for(S32 i = 0; i < getDummyMaxPlayers(); i++)
+   for(S32 i = 0; i < getDummyMaxPlayers(); ++i)
    {
       string name = "PlayerName-" + itos(i);
 
@@ -162,7 +162,7 @@ void ScoreboardRenderer::render()
    const S32 teams = isTeamGame ? game->getTeamCount() : 1;
    S32 maxTeamPlayers = 0;
 
-   for(S32 i = 0; i < teams; i++)
+   for(S32 i = 0; i < teams; ++i)
    {
       Team *team = static_cast<Team *>(game->getTeam(i));
 
@@ -195,7 +195,7 @@ void ScoreboardRenderer::render()
 
    FontManager::pushFontContext(ScoreboardContext);
 
-   for(S32 i = 0; i < teams; i++)
+   for(S32 i = 0; i < teams; ++i)
       renderTeamScoreboard(i, teams, isTeamGame, scoreboardTop, sectionHeight, teamHeaderHeight, lineHeight);
 
    renderScoreboardLegend(game->getPlayerCount(), scoreboardTop, totalHeight);
@@ -242,12 +242,12 @@ void ScoreboardRenderer::renderTeamScoreboard(S32 index, S32 teams, bool isTeamG
    S32 colIndexWidths[ColIndexCount];
    S32 maxColIndexWidths[ColIndexCount] = {0};
 
-   for(S32 i = 0; i < playerInfos.size(); i++)
+   for(S32 i = 0; i < playerInfos.size(); ++i)
    {
       renderScoreboardLine(playerInfos, isTeamGame, i, x, curRowY, lineHeight, xr, colIndexWidths);
       curRowY += lineHeight;
 
-      for(S32 j = 0; j < ColIndexCount; j++)
+      for(S32 j = 0; j < ColIndexCount; ++j)
          maxColIndexWidths[j] = max(colIndexWidths[j], maxColIndexWidths[j]);
    }
 
@@ -360,7 +360,7 @@ void ScoreboardRenderer::renderBadges(ClientInfo *clientInfo, S32 x, S32 y, F32 
 
    bool hasBBBBadge = false;
 
-   for(S32 i = 0; i < BADGE_COUNT; i++)
+   for(S32 i = 0; i < BADGE_COUNT; ++i)
    {
       MeritBadges badge = MeritBadges(i);
 

--- a/zap/ScreenShooter.cpp
+++ b/zap/ScreenShooter.cpp
@@ -175,7 +175,7 @@ void ScreenShooter::saveScreenshot(UIManager *uiManager, GameSettings *settings,
       restoreViewportToWindow(settings);
 
    // Convert Data
-   for (S32 i = 0; i < height; i++)
+   for (S32 i = 0; i < height; ++i)
       rows[i] = &screenBuffer[(height - i - 1) * (BytesPerPixel * width)];  // Backwards!
 
    // Write the PNG!

--- a/zap/ServerGame.cpp
+++ b/zap/ServerGame.cpp
@@ -156,7 +156,7 @@ void ServerGame::cleanUp()
 
    mLevelGens.deleteAndClear();
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
       delete dynamic_cast<Object *>(fillVector[i]);
 
    mVoteTimer = 0;
@@ -216,7 +216,7 @@ bool ServerGame::voteStart(ClientInfo *clientInfo, VoteType type, S32 number)
    mVoteNumber = number;
    mVoteClientName = clientInfo->getName();
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       if(getClientInfo(i)->getConnection())  // Robots don't have GameConnection
          getClientInfo(i)->getConnection()->mVote = 0;
 
@@ -267,7 +267,7 @@ LevelInfo ServerGame::getLevelInfo(S32 index)
 //{
 //   mLevelInfos.clear();
 //
-//   for(S32 i = 0; i < levelList.size(); i++)
+//   for(S32 i = 0; i < levelList.size(); ++i)
 //      mLevelInfos.push_back(LevelInfo(levelList[i]));
 //}
 //
@@ -279,7 +279,7 @@ LevelInfo ServerGame::getLevelInfo(S32 index)
 
 void ServerGame::sendLevelListToLevelChangers(const string &message)
 {
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       ClientInfo *clientInfo = getClientInfo(i);
       GameConnection *conn = clientInfo->getConnection();
@@ -322,7 +322,7 @@ bool ServerGame::onlyClientIs(GameConnection *client)
    if(!gameType)
       return false;
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       if(!mClientInfos[i]->isRobot() && mClientInfos[i]->getConnection() != client)
          return false;
 
@@ -384,7 +384,8 @@ string ServerGame::loadNextLevelInfo()
    if(mLevelSource->populateLevelInfoFromSource(filename, mLevelLoadIndex))
    {
       levelName = mLevelSource->getLevelName(mLevelLoadIndex);    // This will be the name specified in the level file we just populated
-      mLevelLoadIndex++;
+      ++mLevelLoadIndex;
+
    }
    else     // Failed to process level; remove it from the list
       mLevelSource->remove(mLevelLoadIndex);
@@ -582,7 +583,7 @@ void ServerGame::cycleLevel(S32 nextLevel)
    mLevelSwitchTimer.clear();
    mScopeAlwaysList.clear();
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       ClientInfo *clientInfo = getClientInfo(i);
       GameConnection *conn = clientInfo->getConnection();
@@ -662,7 +663,7 @@ void ServerGame::cycleLevel(S32 nextLevel)
                                                                           getWorldExtents(), triangulate);
    if(mGameType->mBotZoneCreationFailed)
    {
-      for(int i = 0; i < getClientCount(); i++)
+      for(int i = 0; i < getClientCount(); ++i)
          getClientInfo(i)->getConnection()->s2cDisplayConsoleMessage("Zone creation failed for level; bots disabled.");
    }
 
@@ -670,7 +671,7 @@ void ServerGame::cycleLevel(S32 nextLevel)
    resetAllClientTeams();
 
    // Reset loadouts now that we have GameType set up
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       getClientInfo(i)->resetLoadout(levelHasLoadoutZone());
 
 
@@ -681,7 +682,7 @@ void ServerGame::cycleLevel(S32 nextLevel)
    if(mGameType.isValid())
    {
       // Backwards!  So the lowest scorer goes on the larger team (if there is uneven teams)
-      for(S32 i = getClientCount() - 1; i > -1; i--)
+      for(S32 i = getClientCount() - 1; i > -1; --i)
       {
          ClientInfo *clientInfo = getClientInfo(i);   // Could be a robot when level have "Robot" line, or a levelgen adds one
 
@@ -697,7 +698,7 @@ void ServerGame::cycleLevel(S32 nextLevel)
    }
 
    // Fire onPlayerJoined event for any players already on the server
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       EventManager::get()->fireEvent(NULL, EventManager::PlayerJoinedEvent, getClientInfo(i)->getPlayerInfo());
 
 
@@ -716,7 +717,7 @@ void ServerGame::onConnectedToMaster()
    // Check if we have any clients that need to have their authentication status checked; might happen if we've lost touch with master
    // and clients have connected in the meantime.  In some rare circumstances, could lead to double-verification, but I don't think this
    // would be a real problem
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       if(!getClientInfo(i)->isRobot())
          getClientInfo(i)->getConnection()->requestAuthenticationVerificationFromMaster();
 
@@ -744,7 +745,7 @@ void ServerGame::sendLevelStatsToMaster()
 
    // Check if we've already sent these stats... if so, no need to waste bandwidth and resend
    // TODO: Is there a standard container that would make this process simpler?  like a sorted hash or whatnot?
-   for(S32 i = 0; i < mSentHashes.size(); i++)
+   for(S32 i = 0; i < mSentHashes.size(); ++i)
       if(mSentHashes[i] == mLevelFileHash)
          return;
 
@@ -773,7 +774,7 @@ void ServerGame::sendLevelStatsToMaster()
 // Resets all player team assignments
 void ServerGame::resetAllClientTeams()
 {
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       getClientInfo(i)->setTeamIndex(NO_TEAM);
 }
 
@@ -835,7 +836,8 @@ S32 ServerGame::getAbsoluteLevelIndex(S32 nextLevel)
       // there are either 0 or 1 players, so the next game will need to be good for 1 or 2 players.
       S32 playerCount = getPlayerCount();
       if(mGameSuspended)
-         playerCount++;
+         ++playerCount;
+
 
       bool first = true;
       bool found = false;
@@ -860,14 +862,16 @@ S32 ServerGame::getAbsoluteLevelIndex(S32 nextLevel)
       // We didn't find a suitable level... just proceed to the next one in the list
       if(!found)
       {
-         currentLevelIndex++;
+         ++currentLevelIndex;
+
          if(S32(currentLevelIndex) >= levelCount)
             currentLevelIndex = FIRST_LEVEL;
       }
    }
    else if(nextLevel == PREVIOUS_LEVEL)
    {
-      currentLevelIndex--;
+      --currentLevelIndex;
+
       if(currentLevelIndex < 0)
          currentLevelIndex = levelCount - 1;
    }
@@ -878,12 +882,13 @@ S32 ServerGame::getAbsoluteLevelIndex(S32 nextLevel)
       S32 playerCount = getPlayerCount();
 
       if(mGameSuspended)
-         playerCount++;
+         ++playerCount;
+
 
       do
       {
          newLevel = TNL::Random::readI(0, levelCount - 1);
-         retriesLeft--;  // Prevent endless loop
+         --retriesLeft;  // Prevent endless loop
 
          if(retriesLeft == 0)
             break;
@@ -919,11 +924,12 @@ bool ServerGame::clientCanSuspend(ClientInfo *info)
       return false;
 
    U32 activePlayers = 0;
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       ClientInfo *clientInfo = getClientInfo(i);
       if(!clientInfo->isRobot() && !clientInfo->isSpawnDelayed())
-         activePlayers++;
+         ++activePlayers;
+
    }
    return activePlayers <= 1; // If only one player active, allow suspend.
 }
@@ -934,7 +940,7 @@ void ServerGame::suspendGame()
    if(mGameSuspended) // Already suspended
       return;
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       if(getClientInfo(i)->getConnection())
          getClientInfo(i)->getConnection()->s2rSetSuspendGame(true);
 
@@ -960,7 +966,7 @@ void ServerGame::unsuspendGame(bool remoteRequest)
 
    mGameSuspended = false;
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
       if(getClientInfo(i)->getConnection())
          getClientInfo(i)->getConnection()->s2rSetSuspendGame(false);
 
@@ -984,7 +990,7 @@ GameConnection *ServerGame::getSuspendor()
 static bool shouldBeSuspended(ServerGame *game)
 {
    // Check all clients and make sure they're not active
-   for(S32 i = 0; i < game->getClientCount(); i++)
+   for(S32 i = 0; i < game->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = game->getClientInfo(i);
 
@@ -1072,7 +1078,7 @@ bool ServerGame::loadLevel()
    Vector<string> scriptList;
    parseString(mSettings->getIniSettings()->globalLevelScript, scriptList, '|');
 
-   for(S32 i = 0; i < scriptList.size(); i++)
+   for(S32 i = 0; i < scriptList.size(); ++i)
       runLevelGenScript(scriptList[i]);
 
    // Fire an update to make sure certain events run on level start (like onShipSpawned)
@@ -1129,20 +1135,21 @@ Vector<Vector<S32> > ServerGame::getCategorizedPlayerCountsByTeam() const
    Vector<Vector<S32> > counts;
 
    counts.resize(getTeamCount());
-   for(S32 i = 0; i < counts.size(); i++)
+   for(S32 i = 0; i < counts.size(); ++i)
    {
       counts[i].resize(ClientInfo::ClassCount);
-      for(S32 j = 0; j < counts[i].size(); j++)
+      for(S32 j = 0; j < counts[i].size(); ++j)
          counts[i][j] = 0;
    }
 
-   for(S32 i = 0; i < mClientInfos.size(); i++)
+   for(S32 i = 0; i < mClientInfos.size(); ++i)
    {
       S32 team = mClientInfos[i]->getTeamIndex();
       S32 cc   = mClientInfos[i]->getClientClass();
 
       if(team >= 0)
-         counts[team][cc]++;
+         ++counts[team][cc];
+
    }
 
    return counts;
@@ -1349,7 +1356,7 @@ bool ServerGame::isReadyToShutdown(U32 timeDelta, string &reason)
          // move from main server list into "Host from server" list
          // Loop backwards to avoid skipping clients
 
-         for(S32 i = getClientCount() - 1; i >= 0; i--)
+         for(S32 i = getClientCount() - 1; i >= 0; --i)
          {
             ClientInfo *clientInfo = getClientInfo(i);
 
@@ -1435,7 +1442,7 @@ void ServerGame::idle(U32 timeDelta)
 
    mCurrentTime += timeDelta;
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       ClientInfo *clientInfo = getClientInfo(i);
 
@@ -1449,11 +1456,11 @@ void ServerGame::idle(U32 timeDelta)
    }
 
    // Tick levelgen timers
-   for(S32 i = 0; i < mLevelGens.size(); i++)
+   for(S32 i = 0; i < mLevelGens.size(); ++i)
       mLevelGens[i]->tickTimer<LuaLevelGenerator>(timeDelta);
 
    // Check for any levelgens that must die
-   for(S32 i = 0; i < mLevelGenDeleteList.size(); i++)
+   for(S32 i = 0; i < mLevelGenDeleteList.size(); ++i)
    {
       S32 index = mLevelGens.getIndex(mLevelGenDeleteList[i]);
       if(index != -1)
@@ -1481,7 +1488,7 @@ void ServerGame::idle(U32 timeDelta)
    const Vector<DatabaseObject *> *gameObjects = mGameObjDatabase->findObjects_fast();
 
    // Visit each game object, handling moves and running its idle method
-   for(S32 i = gameObjects->size() - 1; i >= 0; i--)
+   for(S32 i = gameObjects->size() - 1; i >= 0; --i)
    {
       BfObject *obj = static_cast<BfObject *>((*gameObjects)[i]);
 
@@ -1508,7 +1515,7 @@ void ServerGame::idle(U32 timeDelta)
       if(getSettings()->getIniSettings()->kickIdlePlayers)
       {
          // Kick any players who were idle the entire previous game.  But DO NOT kick the hosting player!
-         for(S32 i = 0; i < getClientCount(); i++)
+         for(S32 i = 0; i < getClientCount(); ++i)
          {
             ClientInfo *clientInfo = getClientInfo(i);
 
@@ -1626,7 +1633,7 @@ void ServerGame::processVoting(U32 timeDelta)
 
             bool WaitingToVote = false;
 
-            for(S32 i2 = 0; i2 < getClientCount(); i2++)
+            for(S32 i2 = 0; i2 < getClientCount(); ++i2)
             {
                ClientInfo *clientInfo = getClientInfo(i2);
                GameConnection *conn = clientInfo->getConnection();
@@ -1650,17 +1657,20 @@ void ServerGame::processVoting(U32 timeDelta)
          S32 voteNothing = 0;
          mVoteTimer = 0;
 
-         for(S32 i = 0; i < getClientCount(); i++)
+         for(S32 i = 0; i < getClientCount(); ++i)
          {
             ClientInfo *clientInfo = getClientInfo(i);
             GameConnection *conn = clientInfo->getConnection();
 
             if(conn && conn->mVote == 1)
-               voteYes++;
+               ++voteYes;
+
             else if(conn && conn->mVote == 2)
-               voteNo++;
+               ++voteNo;
+
             else if(conn && !clientInfo->isRobot())
-               voteNothing++;
+               ++voteNothing;
+
          }
 
          bool votePass = voteYes     * mSettings->getIniSettings()->voteYesStrength +
@@ -1700,7 +1710,7 @@ void ServerGame::processVoting(U32 timeDelta)
                case VoteChangeTeam:
                   if(mGameType)
                   {
-                     for(S32 i = 0; i < getClientCount(); i++)
+                     for(S32 i = 0; i < getClientCount(); ++i)
                      {
                         ClientInfo *clientInfo = getClientInfo(i);
 
@@ -1713,7 +1723,7 @@ void ServerGame::processVoting(U32 timeDelta)
                   if(mGameType && mGameType->getGameTypeId() != CoreGame) // No changing score in Core
                   {
                      // Reset player scores
-                     for(S32 i = 0; i < getClientCount(); i++)
+                     for(S32 i = 0; i < getClientCount(); ++i)
                      {
                         if(getClientInfo(i)->getScore() != 0)
                            mGameType->s2cSetPlayerScore(i, 0);
@@ -1721,7 +1731,7 @@ void ServerGame::processVoting(U32 timeDelta)
                      }
 
                      // Reset team scores
-                     for(S32 i = 0; i < getTeamCount(); i++)
+                     for(S32 i = 0; i < getTeamCount(); ++i)
                      {
                         // broadcast it to the clients
                         if(((Team*)getTeam(i))->getScore() != 0)
@@ -1748,7 +1758,7 @@ void ServerGame::processVoting(U32 timeDelta)
          i.push_back(voteNothing);
          e.push_back(votePass ? "Pass" : "Fail");
 
-         for(S32 i2 = 0; i2 < getClientCount(); i2++)
+         for(S32 i2 = 0; i2 < getClientCount(); ++i2)
          {
             ClientInfo *clientInfo = getClientInfo(i2);
             GameConnection *conn = clientInfo->getConnection();
@@ -1824,7 +1834,7 @@ bool ServerGame::startHosting()
 
    S32 levelCount = mLevelSource->getLevelCount();
 
-   for(S32 i = 0; i < levelCount; i++)
+   for(S32 i = 0; i < levelCount; ++i)
       logprintf(LogConsumer::ServerFilter, "\t%s [%s]", getLevelNameFromIndex(i).getString(),
                 mLevelSource->getLevelFileName(i).c_str());
 
@@ -1853,7 +1863,7 @@ Ship *ServerGame::getLocalPlayerShip() const
 void ServerGame::levelAddedNotifyClients(const LevelInfo &levelInfo)
 {
    // Let levelChangers know about the new level if it was just added
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       ClientInfo *clientInfo = getClientInfo(i);
       GameConnection *conn = clientInfo->getConnection();
@@ -1894,7 +1904,7 @@ void ServerGame::removeLevel(S32 index)
    else
       mLevelSource->remove(index);
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       ClientInfo *clientInfo = getClientInfo(i);
       if(clientInfo->isLevelChanger())
@@ -1961,7 +1971,7 @@ U16 ServerGame::findZoneContaining(const Point &p) const
    mBotZoneDatabase->findObjects(BotNavMeshZoneTypeNumber, fillVector,
                                 Rect(p - Point(0.1f, 0.1f), p + Point(0.1f, 0.1f)));  // Slightly extend Rect, it can be on the edge of zone
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       // First a quick, crude elimination check then more comprehensive one
       // Since our zones are convex, we can use the faster method!  Yay!

--- a/zap/Settings.cpp
+++ b/zap/Settings.cpp
@@ -136,7 +136,7 @@ string Settings::getSection(const string &name) const
 Vector<AbstractSetting *> Settings::getSettingsInSection(const string &section) const
 {
    Vector<AbstractSetting *> settings;
-   for(S32 i = 0; i < mSettings.size(); i++)
+   for(S32 i = 0; i < mSettings.size(); ++i)
    {
       if(mSettings[i]->getSection() == section)
          settings.push_back(mSettings[i]);

--- a/zap/SlipZone.cpp
+++ b/zap/SlipZone.cpp
@@ -76,7 +76,7 @@ bool SlipZone::processArguments(S32 argc2, const char **argv2, Game *game)
    // so a possible future version can add parameters without compatibility problem.
    S32 argc = 0;
    const char *argv[Geometry::MAX_POLY_POINTS * 2 + 1];
-   for(S32 i = 0; i < argc2; i++)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char c = argv2[i][0];
       //switch(c)
@@ -87,7 +87,8 @@ bool SlipZone::processArguments(S32 argc2, const char **argv2, Game *game)
       {
 			if(argc < Geometry::MAX_POLY_POINTS * 2 + 1)
          {  argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }

--- a/zap/SoundSystem.cpp
+++ b/zap/SoundSystem.cpp
@@ -322,7 +322,7 @@ void SoundSystem::init(const string &sfxDir, const string &musicDir, float music
    gSFXProfiles = sfxProfilesModern;
 
    // Iterate through all sounds and load them
-   for(U32 i = 0; i < NumSFXBuffers; i++)
+   for(U32 i = 0; i < NumSFXBuffers; ++i)
    {
       // End when we find a sound sans filename
       if(!gSFXProfiles[i].fileName)
@@ -351,7 +351,7 @@ void SoundSystem::init(const string &sfxDir, const string &musicDir, float music
    else     // Got us some music!
    {
       // Remove the menu music from the file list
-      for(S32 i = 0; i < mGameMusicList.size(); i++)
+      for(S32 i = 0; i < mGameMusicList.size(); ++i)
       {
          if(mGameMusicList[i] == mMenuMusicFile)
          {
@@ -362,7 +362,7 @@ void SoundSystem::init(const string &sfxDir, const string &musicDir, float music
       }
 
       // Remove the credits music from the file list
-      for(S32 i = 0; i < mGameMusicList.size(); i++)
+      for(S32 i = 0; i < mGameMusicList.size(); ++i)
       {
          if(mGameMusicList[i] == mCreditsMusicFile)
          {
@@ -424,7 +424,7 @@ void SoundSystem::shutdown()
    }
 
    // Clean up sources
-   for (S32 i = 0; i < NumSamples; i++)
+   for (S32 i = 0; i < NumSamples; ++i)
       alDeleteSources(1, &(gFreeSources[i]));
 
    gFreeSources.clear();
@@ -433,7 +433,7 @@ void SoundSystem::shutdown()
    alDeleteBuffers(NumSFXBuffers, gSfxBuffers);
 
    // Clean up voice buffers
-   for (S32 i = 0; i < 32; i++)
+   for (S32 i = 0; i < 32; ++i)
       alDeleteBuffers(1, &(gVoiceFreeBuffers[i]));
    gVoiceFreeBuffers.clear();
 
@@ -503,7 +503,7 @@ void SoundSystem::playSoundEffect(const SFXHandle &effect)
    else
    {
       // See if it's already on the play list:
-      for(S32 i = 0; i < gPlayList.size(); i++)
+      for(S32 i = 0; i < gPlayList.size(); ++i)
          if(effect == gPlayList[i].getPointer())
             return;
 
@@ -524,7 +524,7 @@ void SoundSystem::stopSoundEffect(SFXHandle &effect)
       alSourceStop(gFreeSources[effect->mSourceIndex]);
       effect->mSourceIndex = -1;
    }
-   for(S32 i = 0; i < gPlayList.size(); i++)
+   for(S32 i = 0; i < gPlayList.size(); ++i)
    {
       if(gPlayList[i].getPointer() == effect)
       {
@@ -553,14 +553,15 @@ void SoundSystem::unqueueBuffers(S32 sourceIndex)
          if(alGetError() != AL_NO_ERROR)
             return;
 
-         processed--;
+         --processed;
+
 
          // ok, this is a lame solution - but the way OpenAL should work is...
          // you should only be able to unqueue buffers that you queued - duh!
          // otherwise it's a bitch to manage sources that can either be streamed
          // or already loaded.
          U32 i;
-         for(i = 0 ; i < NumSFXBuffers; i++)
+         for(i = 0 ; i < NumSFXBuffers; ++i)
             if(buffer == gSfxBuffers[i])
                break;
          if(i == NumSFXBuffers)
@@ -765,7 +766,7 @@ void SoundSystem::processMusic(U32 timeDelta, F32 musicVol, MusicLocation musicL
          {
             // Start streaming: queue initial buffers
             alSourcei(mMusicData.source, AL_BUFFER, 0); // clear old buffers
-            for (S32 i = 0; i < NumMusicStreamBuffers; i++)
+            for (S32 i = 0; i < NumMusicStreamBuffers; ++i)
                queueNextMusicBuffer();
 
             ALint state;
@@ -779,7 +780,8 @@ void SoundSystem::processMusic(U32 timeDelta, F32 musicVol, MusicLocation musicL
          static U32 failedCount = 0;
          if(failed)
          {
-            failedCount++;
+            ++failedCount;
+
 
             if(failedCount >= 10)  // Arbitrary
             {
@@ -920,7 +922,7 @@ void SoundSystem::processSoundEffects(F32 sfxVol, F32 voiceVol)
    // ones need to be retired:
 
    bool sourceActive[NumSamples];
-   for(S32 i = 0; i < NumSamples; i++)
+   for(S32 i = 0; i < NumSamples; ++i)
    {
       ALint state;
       unqueueBuffers(i);
@@ -945,17 +947,18 @@ void SoundSystem::processSoundEffects(F32 sfxVol, F32 voiceVol)
             s->mPriority = (500 - (s->mPosition - mListenerPosition).len()) / 500.0f;
          else
             s->mPriority = 1.0;
-         i++;
+         ++i;
+
       }
    }
    // Now, bubble sort all the sounds up the list:
    // we choose bubble sort, because the list should
    // have a lot of frame-to-frame coherency, making the
    // sort most often O(n)
-   for(S32 i = 1; i < gPlayList.size(); i++)
+   for(S32 i = 1; i < gPlayList.size(); ++i)
    {
       F32 priority = gPlayList[i]->mPriority;
-      for(S32 j = i - 1; j >= 0; j--)
+      for(S32 j = i - 1; j >= 0; --j)
       {
          if(priority > gPlayList[j]->mPriority)
          {
@@ -978,7 +981,8 @@ void SoundSystem::processSoundEffects(F32 sfxVol, F32 voiceVol)
       if(!s->mProfile->isLooping)
          gPlayList.erase_fast(i);
       else
-         i++;
+         ++i;
+
    }
    // Assign sources to all sounds that need them
    S32 firstFree = 0;
@@ -986,13 +990,14 @@ void SoundSystem::processSoundEffects(F32 sfxVol, F32 voiceVol)
    if(max > gPlayList.size())
       max = gPlayList.size();
 
-   for(S32 i = 0; i < max; i++)
+   for(S32 i = 0; i < max; ++i)
    {
       SFXHandle &s = gPlayList[i];
       if(s->mSourceIndex == -1)
       {
          while(firstFree < NumSamples-1 && sourceActive[firstFree])
-            firstFree++;
+            ++firstFree;
+
          s->mSourceIndex = firstFree;
          sourceActive[firstFree] = true;
          playOnSource(s, sfxVol, voiceVol);
@@ -1078,7 +1083,8 @@ void SoundSystem::queueVoiceChatBuffer(const SFXHandle &effect, ByteBufferPtr p)
       {
          if(max < *ptr)
             max = *ptr;
-         ptr++;
+         ++ptr;
+
       }
 
       alBufferData(buffer, AL_FORMAT_MONO16, effect->mInitialBuffer->getBuffer(),

--- a/zap/Spawn.cpp
+++ b/zap/Spawn.cpp
@@ -577,7 +577,7 @@ bool AsteroidSpawn::processArguments(S32 argc, const char** argv, Game* game)
    Point pos;
    pos.read(argv);
    pos *= game->getLegacyGridSize();
-   for (S32 i = 0; i < argc; i++)
+   for (S32 i = 0; i < argc; ++i)
    {
       char firstChar = argv[i][0];    // First character of arg
 

--- a/zap/SymbolShape.cpp
+++ b/zap/SymbolShape.cpp
@@ -48,18 +48,18 @@ S32 SymbolStringSetCollection::render(S32 yPos) const
    S32 lines = -1;
 
    // Figure out how many lines in our tallest SymbolStringSet
-   for(S32 i = 0; i < mSymbolSet.size(); i++)
+   for(S32 i = 0; i < mSymbolSet.size(); ++i)
       lines = max(lines, mSymbolSet[i].getItemCount());
 
    // Render the SymbolStringSets line-by-line, keeping all lines aligned with one another.
    // Make a tally of the total height along the way (using the height of the tallest item rendered).
    S32 totalHeight = 0;
 
-   for(S32 i = 0; i < lines; i++)
+   for(S32 i = 0; i < lines; ++i)
    {
       S32 height = 0;
 
-      for(S32 j = 0; j < mSymbolSet.size(); j++)
+      for(S32 j = 0; j < mSymbolSet.size(); ++j)
       {
          S32 h = mSymbolSet[j].renderLine(i, mXPos[j], yPos + totalHeight, mAlignment[j]);
          height = max(h, height);   // Find tallest
@@ -97,7 +97,7 @@ void SymbolStringSet::add(const SymbolString &symbolString)
 S32 SymbolStringSet::getHeight() const
 {
    S32 height = 0;
-   for(S32 i = 0; i < mSymbolStrings.size(); i++)
+   for(S32 i = 0; i < mSymbolStrings.size(); ++i)
       height += mSymbolStrings[i].getHeight() + (mSymbolStrings[i].getHasGap() ? mGap : 0);
 
    return height;
@@ -107,7 +107,7 @@ S32 SymbolStringSet::getHeight() const
 S32 SymbolStringSet::getWidth() const
 {
    S32 width = 0;
-   for(S32 i = 0; i < mSymbolStrings.size(); i++)
+   for(S32 i = 0; i < mSymbolStrings.size(); ++i)
       width = max(mSymbolStrings[i].getWidth(), width);
 
    return width;
@@ -131,7 +131,7 @@ S32 SymbolStringSet::render(F32 x, F32 yStart, Alignment alignment, S32 blockWid
    S32 width = getWidth();
    S32 y = 0;
 
-   for(S32 i = 0; i < mSymbolStrings.size(); i++)
+   for(S32 i = 0; i < mSymbolStrings.size(); ++i)
    {
       mSymbolStrings[i].render(x, yStart + y, alignment, width);
       y += mSymbolStrings[i].getHeight() + mGap;
@@ -160,7 +160,7 @@ static S32 computeWidth(const Vector<SymbolShapePtr > &symbols)
 {
    S32 width = 0;
 
-   for(S32 i = 0; i < symbols.size(); i++)
+   for(S32 i = 0; i < symbols.size(); ++i)
       width += symbols[i]->getWidth();
 
    return width;
@@ -172,7 +172,7 @@ static S32 computeLayeredWidth(const Vector<SymbolShapePtr> &symbols)
 {
    S32 width = 0;
 
-   for(S32 i = 0; i < symbols.size(); i++)
+   for(S32 i = 0; i < symbols.size(); ++i)
    {
       S32 w = symbols[i]->getWidth();
 
@@ -187,7 +187,7 @@ static S32 computeHeight(const Vector<SymbolShapePtr> &symbols)
 {
    S32 height = 0;
 
-   for(S32 i = 0; i < symbols.size(); i++)
+   for(S32 i = 0; i < symbols.size(); ++i)
    {
       S32 h = symbols[i]->getHeight();
       height = max(h, height);
@@ -276,7 +276,7 @@ S32 SymbolString::getWidth() const
 S32 SymbolString::getHeight() const
 {
    S32 height = 0;
-   for(S32 i = 0; i < mSymbols.size(); i++)
+   for(S32 i = 0; i < mSymbols.size(); ++i)
       height = max(height, mSymbols[i]->getHeight());
 
    return height;
@@ -331,7 +331,7 @@ S32 SymbolString::render(F32 x, F32 y, Alignment blockAlignment, S32 blockWidth)
          x -= (blockWidth - mWidth) / 2;
    }
 
-   for(S32 i = 0; i < mSymbols.size(); i++)
+   for(S32 i = 0; i < mSymbols.size(); ++i)
    {
       S32 w = mSymbols[i]->getWidth();
       mSymbols[i]->render(Point(x + w / 2, y));
@@ -344,7 +344,7 @@ S32 SymbolString::render(F32 x, F32 y, Alignment blockAlignment, S32 blockWidth)
 
 bool SymbolString::getHasGap() const
 {
-   for(S32 i = 0; i < mSymbols.size(); i++)
+   for(S32 i = 0; i < mSymbols.size(); ++i)
       if(mSymbols[i]->getHasGap())
          return true;
 
@@ -502,7 +502,7 @@ SymbolShapePtr SymbolString::getModifiedKeySymbol(const string &symbolName, cons
 
    while(found)
    {
-      for(S32 i = 0; i < mods->size(); i++)
+      for(S32 i = 0; i < mods->size(); ++i)
       {
          string mod = mods->get(i) + "+";
          found = false;
@@ -533,7 +533,7 @@ SymbolShapePtr SymbolString::getModifiedKeySymbol(InputCode inputCode, const Vec
       return getSymbol(inputCode, color);
 
    Vector<SymbolShapePtr> symbols;
-   for(S32 i = 0; i < modifiers.size(); i++)
+   for(S32 i = 0; i < modifiers.size(); ++i)
    {
       symbols.push_back(SymbolShapePtr(new SymbolKey(modifiers[i], color)));
       symbols.push_back(SymbolShapePtr(new SymbolText("+", 13, KeyContext, Point(0, -3), color))); // Use offset to vertically center "+"
@@ -742,7 +742,7 @@ static void getSymbolShape(const InputCodeManager *inputCodeManager, const strin
       S32 width = atoi(words[1].c_str());
 
       S32 w = 0;
-      for(S32 i = 0; i < symbols.size(); i++)
+      for(S32 i = 0; i < symbols.size(); ++i)
          w += symbols[i]->getWidth();
 
       symbols.push_back(SymbolShapePtr(new SymbolBlank(width - w)));
@@ -791,7 +791,8 @@ void SymbolString::symbolParse(const InputCodeManager *inputCodeManager, const s
 
       // Check for the exception of the ']' key, which would create a symbol ending in ']]]'
       if(str[endPos+2] == ']')
-         endPos++;
+         ++endPos;
+
 
       symbols.push_back(SymbolShapePtr(new SymbolText(str.substr(offset, startPos - offset), fontSize, fontContext, textColor)));
 
@@ -824,7 +825,7 @@ LayeredSymbolString::~LayeredSymbolString()
 // Each layer is rendered atop the previous, creating a layered effect
 S32 LayeredSymbolString::render(F32 x, F32 y, Alignment alignment, S32 blockWidth) const
 {
-   for(S32 i = 0; i < mSymbols.size(); i++)
+   for(S32 i = 0; i < mSymbols.size(); ++i)
       mSymbols[i]->render(Point(x, y));
 
    return mHeight;

--- a/zap/SystemFunctions.cpp
+++ b/zap/SystemFunctions.cpp
@@ -78,7 +78,7 @@ void initHosting(GameSettingsPtr settings, LevelSourcePtr levelSource, bool test
 #ifndef ZAP_DEDICATED
    const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
 
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
       clientGames->get(i)->getUIManager()->enableLevelLoadDisplay();
 #endif
 }
@@ -102,7 +102,7 @@ void abortHosting_noLevels(ServerGame *serverGame)
 #ifndef ZAP_DEDICATED
    const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
 
-   for(S32 i = 0; i < clientGames->size(); i++)    // <<=== Should probably only display this message on the clientGame that initiated hosting
+   for(S32 i = 0; i < clientGames->size(); ++i)    // <<=== Should probably only display this message on the clientGame that initiated hosting
    {
       UIManager *uiManager = clientGames->get(i)->getUIManager();
 

--- a/zap/TeamShuffleHelper.cpp
+++ b/zap/TeamShuffleHelper.cpp
@@ -54,14 +54,14 @@ void TeamShuffleHelper::shuffle()
    teamCount = getGame()->getTeamCount();
 
    mTeams.resize(teamCount);
-   for(S32 i = 0; i < teamCount; i++)
+   for(S32 i = 0; i < teamCount; ++i)
       mTeams[i].clear();
 
    const Vector<RefPtr<ClientInfo> > *clientInfos = getGame()->getClientInfos();
 
    playersPerTeam = S32(ceil(F32(clientInfos->size()) / F32(mTeams.size())));
 
-   for(S32 i = 0; i < clientInfos->size(); i++)
+   for(S32 i = 0; i < clientInfos->size(); ++i)
    {
       while(true)
       {
@@ -119,8 +119,8 @@ void TeamShuffleHelper::calculateRenderSizes()
    maxColumnWidth = (DisplayManager::getScreenInfo()->getGameCanvasWidth() - 100) / cols;
    rowHeight = (2 * vpad) + S32((playersPerTeam + 1) * TEXT_SIZE * TEXT_SIZE_FACTOR);
 
-   for(S32 i = 0; i < mTeams.size(); i++)
-      for(S32 j = 0; j < mTeams[i].size(); j++)
+   for(S32 i = 0; i < mTeams.size(); ++i)
+      for(S32 j = 0; j < mTeams[i].size(); ++j)
       {
          S32 width = getStringWidth(TEXT_SIZE, mTeams[i][j]->getName().getString());
 
@@ -153,8 +153,8 @@ void TeamShuffleHelper::render()
 
    FontManager::pushFontContext(TeamShuffleContext);
 
-   for(S32 i = 0; i < rows; i++)
-      for(S32 j = 0; j < cols; j++)
+   for(S32 i = 0; i < rows; ++i)
+      for(S32 j = 0; j < cols; ++j)
       {
          if(i * cols + j >= teamCount)
             break;
@@ -177,7 +177,7 @@ void TeamShuffleHelper::render()
          drawHorizLine(x + hpad, x + columnWidth - hpad, y + vpad + TEXT_SIZE + 3);
 
          r.setColor(Colors::white);
-         for(S32 k = 0; k < mTeams[teamIndex].size(); k++)
+         for(S32 k = 0; k < mTeams[teamIndex].size(); ++k)
             drawString(x + hpad, y + S32(vpad + (k + 1) * TEXT_SIZE_FACTOR * TEXT_SIZE + 3),
                   TEXT_SIZE, mTeams[teamIndex][k]->getName().getString());
       }
@@ -212,8 +212,8 @@ bool TeamShuffleHelper::processInputCode(InputCode inputCode)
       exitHelper();
 
       // Now determine if a player is going to change teams
-      for(S32 i = 0; i < mTeams.size(); i++)
-         for(S32 j = 0; j < mTeams[i].size(); j++)
+      for(S32 i = 0; i < mTeams.size(); ++i)
+         for(S32 j = 0; j < mTeams[i].size(); ++j)
          {
             ClientInfo *thisClientInfo = mTeams[i][j];
 

--- a/zap/Teleporter.cpp
+++ b/zap/Teleporter.cpp
@@ -90,7 +90,7 @@ void Teleporter::delDest(S32 index)
    if(getGame() && getGame()->isServer())
    {
       s2cClearDestinations();
-      for(S32 i = 0; i < mDests.size(); i++)
+      for(S32 i = 0; i < mDests.size(); ++i)
          s2cAddDestination(mDests[i]);
    }
 }
@@ -222,7 +222,7 @@ bool Teleporter::processArguments(S32 argc2, const char **argv2, Game *game)
    S32 argc = 0;
    const char *argv[8];
 
-   for(S32 i = 0; i < argc2; i++)      // The idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)      // The idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char firstChar = argv2[i][0];    // First character of arg
 
@@ -236,7 +236,8 @@ bool Teleporter::processArguments(S32 argc2, const char **argv2, Game *game)
          if(argc < 8)
          {
             argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }
@@ -262,7 +263,7 @@ bool Teleporter::processArguments(S32 argc2, const char **argv2, Game *game)
       foundObjects.clear();
       game->getGameObjDatabase()->findObjects(TeleporterTypeNumber, foundObjects, Rect(pos, 1));
 
-      for(S32 i = 0; i < foundObjects.size(); i++)
+      for(S32 i = 0; i < foundObjects.size(); ++i)
       {
          Teleporter *tel = static_cast<Teleporter *>(foundObjects[i]);
          if(tel->getOrigin().distSquared(pos) < 1)     // i.e These are really close!  Must be the same!
@@ -334,7 +335,7 @@ bool Teleporter::checkDeploymentPosition(const Point &position, const GridDataba
    Point foundObjectCenter;
    F32 foundObjectRadius;
 
-   for(S32 i = 0; i < foundObjects.size(); i++)
+   for(S32 i = 0; i < foundObjects.size(); ++i)
    {
       BfObject *bfObject = static_cast<BfObject *>(foundObjects[i]);
 
@@ -392,7 +393,7 @@ U32 Teleporter::packUpdate(GhostConnection *connection, U32 updateMask, BitStrea
 
       stream->writeInt(dests, 16);
 
-      for(S32 i = 0; i < dests; i++)
+      for(S32 i = 0; i < dests; ++i)
          getDest(i).write(stream);
    }
 
@@ -451,7 +452,7 @@ void Teleporter::unpackUpdate(GhostConnection *connection, BitStream *stream)
       count = stream->readInt(16);
       resize(count);         // Prepare the list for multiple additions
 
-      for(U32 i = 0; i < count; i++)
+      for(U32 i = 0; i < count; ++i)
          read(i, stream);
 
       computeExtent();
@@ -557,7 +558,7 @@ void Teleporter::doTeleport()
    Point teleportCenter = getOrigin();
 
    bool isTriggered = false; // First, check if triggered, can come from idle timer.
-   for(S32 i = 0; i < foundObjects.size(); i++)
+   for(S32 i = 0; i < foundObjects.size(); ++i)
    {
       if((teleportCenter - static_cast<Ship *>(foundObjects[i])->getRenderPos()).lenSquared() < sq(TRIGGER_RADIUS))
       {
@@ -573,7 +574,7 @@ void Teleporter::doTeleport()
    mTeleportCooldown.reset(mTeleporterCooldown);      // Teleport needs to wait a bit before being usable again
 
    // We've triggered the teleporter.  Relocate any ships within range.  Any ship touching the teleport will be warped.
-   for(S32 i = 0; i < foundObjects.size(); i++)
+   for(S32 i = 0; i < foundObjects.size(); ++i)
    {
       Ship *ship = static_cast<Ship *>(foundObjects[i]);
       if((teleportCenter - ship->getRenderPos()).lenSquared() < sq(TELEPORT_RADIUS))
@@ -596,7 +597,7 @@ void Teleporter::doTeleport()
    Vector<DatabaseObject *> foundTeleporters; // Must be kept local, non static, because of possible recursive.
    queryRect.set(getDest(dest), TRIGGER_RADIUS * 2);
    findObjects(TeleporterTypeNumber, foundTeleporters, queryRect);
-   for(S32 i = 0; i < foundTeleporters.size(); i++)
+   for(S32 i = 0; i < foundTeleporters.size(); ++i)
       if(static_cast<Teleporter *>(foundTeleporters[i])->mTeleportCooldown.getCurrent() == 0)
          static_cast<Teleporter *>(foundTeleporters[i])->doTeleport();
 }
@@ -606,7 +607,7 @@ void Teleporter::checkAllTeleporters(BfObject *obj)
    Vector<DatabaseObject *> foundTeleporters;
    Rect queryRect(obj->getPos(), TELEPORTER_RADIUS);
    obj->findObjects(TeleporterTypeNumber, foundTeleporters, queryRect);
-   for(S32 i = 0; i < foundTeleporters.size(); i++)
+   for(S32 i = 0; i < foundTeleporters.size(); ++i)
       if(static_cast<Teleporter *>(foundTeleporters[i])->mTeleportCooldown.getCurrent() == 0)
          static_cast<Teleporter *>(foundTeleporters[i])->doTeleport();
 }
@@ -680,7 +681,7 @@ void Teleporter::generateOutlinePoints()
    F32 x = getOrigin().x;
    F32 y = getOrigin().y;
 
-   for(S32 i = 0; i < sides; i++)
+   for(S32 i = 0; i < sides; ++i)
       mOutlinePoints[i] = Point(TELEPORTER_RADIUS * cos(i * Float2Pi / sides + FloatHalfPi) + x,
                                 TELEPORTER_RADIUS * sin(i * Float2Pi / sides + FloatHalfPi) + y);
 }
@@ -820,7 +821,7 @@ void Teleporter::render()
       F32 sizeFraction = mHasExploded ? F32(mExplosionTimer.getCurrent() - implosionOffset) / implosionTime : 1;
 
       if(sizeFraction > 0)
-         for(S32 i = getDestCount() - 1; i >= 0; i--)
+         for(S32 i = getDestCount() - 1; i >= 0; --i)
             renderTeleporterOutline(getDest(i), (F32)TELEPORTER_RADIUS * sizeFraction, Colors::richGreen);
    }
 #endif
@@ -1031,7 +1032,7 @@ S32 Teleporter::lua_delDest(lua_State *L)
 
    S32 index = S32(getInt(L, 1, "Teleporter:delDest()", 1, getDestCount()));
 
-   index--;    // Adjust for Lua's 1-based index
+   --index;    // Adjust for Lua's 1-based index
 
    delDest(index);
 
@@ -1204,7 +1205,7 @@ void Teleporter::doSetGeom(const Vector<Point> &points)
       clearDests();
 
       // Notify destination manager about the new destinations
-      for(S32 i = 1; i < points.size(); i++)
+      for(S32 i = 1; i < points.size(); ++i)
          addDest(points[i]);
 
       TNLAssert(getDest(0) == points[1], "Should have been set by addDest()!");
@@ -1239,7 +1240,7 @@ S32 Teleporter::lua_getGeom(lua_State *L)
 
    points.push_back(getPos());
 
-   for(S32 i = 0; i < getDestCount(); i++)
+   for(S32 i = 0; i < getDestCount(); ++i)
       points.push_back(getDest(i));
 
    return returnPoints(L, &points);

--- a/zap/TextItem.cpp
+++ b/zap/TextItem.cpp
@@ -199,7 +199,7 @@ bool TextItem::processArguments(S32 argc, const char **argv, Game *game)
 
    // Assemble any remaining args into a string
    mText = "";
-   for(S32 i = 6; i < argc; i++)
+   for(S32 i = 6; i < argc; ++i)
    {
       mText += argv[i];
       if(i < argc - 1)

--- a/zap/TimeLeftRenderer.cpp
+++ b/zap/TimeLeftRenderer.cpp
@@ -80,7 +80,7 @@ S32 TimeLeftRenderer::renderTeamScores(const GameType *gameType, S32 bottom, boo
 
    S32 teamCount = game->getTeamCount();
 
-   for(S32 i = teamCount - 1; i >= 0; i--)
+   for(S32 i = teamCount - 1; i >= 0; --i)
    {
       if(render)
          gameType->renderScoreboardOrnament(i, xpos, ypos);
@@ -101,7 +101,7 @@ S32 TimeLeftRenderer::renderHeadlineScores(const Game *game, S32 ypos) const
 
    Renderer::get().setColor(Colors::white);
 
-   for(S32 i = teamCount - 1; i >= 0; i--)
+   for(S32 i = teamCount - 1; i >= 0; --i)
    {
       TNLAssert(dynamic_cast<Team *>(game->getTeam(i)), "Bad team pointer or bad type");
       S32 score = static_cast<Team *>(game->getTeam(i))->getScore();

--- a/zap/UI.cpp
+++ b/zap/UI.cpp
@@ -172,7 +172,7 @@ void UserInterface::renderMessageBox(const string &titleStr, const string &instr
 
    Vector<SymbolShapePtr> message(wrappedLines.size());
 
-   for(S32 i = 0; i < wrappedLines.size(); i++)
+   for(S32 i = 0; i < wrappedLines.size(); ++i)
       message.push_back(SymbolShapePtr(new SymbolString(wrappedLines[i], inputCodeManager, Context, TextSize, true)));
 
    renderMessageBox(title, instr, message.address(), message.size(), vertOffset, style);
@@ -210,13 +210,13 @@ void UserInterface::renderMessageBox(const SymbolShapePtr &title, const SymbolSh
    S32 boxHeight = vertMargin + titleHeight + instrHeight + vertMargin;
 
    // Don't include a linespacing gap after the final line
-   for(S32 i = 0; i < msgLines; i++ )
+   for(S32 i = 0; i < msgLines; ++i )
       boxHeight += S32(message[i]->getHeight() * LinespacingFactor);
 
    S32 boxTop = (canvasHeight - boxHeight) / 2 + vertOffset;
 
    S32 maxLen = 0;
-   for(S32 i = 0; i < msgLines; i++)
+   for(S32 i = 0; i < msgLines; ++i)
    {
       static const S32 HorizBoxPadding = 20;
       S32 len = message[i]->getWidth() + HorizBoxPadding * 2;
@@ -240,7 +240,7 @@ void UserInterface::renderMessageBox(const SymbolShapePtr &title, const SymbolSh
    // the first message so that it will be drawn in the correct location
    S32 y = boxTop + vertMargin + titleHeight + message[0]->getHeight();
 
-   for(S32 i = 0; i < msgLines; i++)
+   for(S32 i = 0; i < msgLines; ++i)
    {
       message[i]->render(DisplayManager::getScreenInfo()->getGameCanvasWidth() / 2, y, AlignmentCenter);
       y += S32(message[i]->getHeight() * LinespacingFactor);
@@ -409,7 +409,7 @@ void UserInterface::renderDiagnosticKeysOverlay()
      r.setColor(Colors::white);
 
      // Key states
-     for (U32 i = 0; i < MAX_INPUT_CODES; i++)
+     for (U32 i = 0; i < MAX_INPUT_CODES; ++i)
         if(InputCodeManager::getState((InputCode) i))
            hpos += drawStringAndGetWidth( hpos, vpos, 18, InputCodeManager::inputCodeToString((InputCode) i) );
 
@@ -417,7 +417,7 @@ void UserInterface::renderDiagnosticKeysOverlay()
       hpos = horizMargin;
       r.setColor(Colors::magenta);
 
-      for(U32 i = 0; i < CHAR_BIT * sizeof(Joystick::ButtonMask); i++)
+      for(U32 i = 0; i < CHAR_BIT * sizeof(Joystick::ButtonMask); ++i)
          if(Joystick::ButtonMask & (1 << i))
          {
             drawStringf( hpos, vpos, 18, "RawBut [%d]", i );

--- a/zap/UIAbstractInstructions.cpp
+++ b/zap/UIAbstractInstructions.cpp
@@ -58,7 +58,7 @@ void AbstractInstructionsUserInterface::pack(SymbolStringSet &instrs,      // <=
 {
    Vector<SymbolShapePtr> symbols;
 
-   for(S32 i = 0; i < bindingCount; i++)
+   for(S32 i = 0; i < bindingCount; ++i)
    {
       if(helpBindings[i] == "-")
       {
@@ -82,7 +82,7 @@ void AbstractInstructionsUserInterface::pack(SymbolStringSet &instrs,  SymbolStr
 {
    Vector<SymbolShapePtr> symbols;
 
-   for(S32 i = 0; i < bindingCount; i++)
+   for(S32 i = 0; i < bindingCount; ++i)
    {
       if(helpBindings[i].command == "-")
       {
@@ -172,7 +172,7 @@ void AbstractInstructionsUserInterface::renderConsoleCommands(const SymbolString
    ypos += 10;     // Small gap before cmds start
    ypos += cmdSize;
 
-   for(S32 i = 0; cmdList[i].command != ""; i++)
+   for(S32 i = 0; cmdList[i].command != ""; ++i)
    {
       if(cmdList[i].command[0] == '-')      // Horiz spacer
       {

--- a/zap/UIChat.cpp
+++ b/zap/UIChat.cpp
@@ -106,7 +106,8 @@ void AbstractChat::newMessage(const string &from, const string &message, bool is
    }
 
    mMessages[mMessageCount % MESSAGES_TO_RETAIN] = ChatMessage(from, message, color, isPrivate, isSystem);
-   mMessageCount++;
+   ++mMessageCount;
+
 
    if(fromSelf && isPrivate)     // I don't think this can ever happen!  ==> Should be !fromSelf ?
       deliverPrivateMessage(from.c_str(), message.c_str());
@@ -117,7 +118,7 @@ void AbstractChat::setPlayersInGlobalChat(const Vector<StringTableEntry> &player
 {
    mPlayersInGlobalChat.clear();
 
-   for(S32 i = 0; i < playerNicks.size(); i++)
+   for(S32 i = 0; i < playerNicks.size(); ++i)
       mPlayersInGlobalChat.push_back(playerNicks[i]);
 }
 
@@ -137,7 +138,7 @@ void AbstractChat::playerLeftGlobalChat(const StringTableEntry &playerNick)
 {
    ChatUserInterface *ui = mGame->getUIManager()->getUI<ChatUserInterface>();
 
-   for(S32 i = 0; i < ui->mPlayersInGlobalChat.size(); i++)
+   for(S32 i = 0; i < ui->mPlayersInGlobalChat.size(); ++i)
       if(ui->mPlayersInGlobalChat[i] == playerNick)
       {
          ui->mPlayersInGlobalChat.erase_fast(i);
@@ -155,7 +156,7 @@ bool AbstractChat::isPlayerInGlobalChat(const StringTableEntry &playerNick)
 {
    ChatUserInterface *ui = mGame->getUIManager()->getUI<ChatUserInterface>();
 
-   for(S32 i = 0; i < ui->mPlayersInGlobalChat.size(); i++)
+   for(S32 i = 0; i < ui->mPlayersInGlobalChat.size(); ++i)
       if(ui->mPlayersInGlobalChat[i] == playerNick)
          return true;
 
@@ -199,7 +200,8 @@ Color AbstractChat::getNextColor()
       Color(0.48,0.41,0.93)
    };
 
-   mColorPtr++;
+   ++mColorPtr;
+
    if(mColorPtr >= ARRAYSIZE(colorList))     // Wrap-around
       mColorPtr = 0;
 
@@ -232,7 +234,7 @@ void AbstractChat::renderMessages(U32 ypos, U32 lineCountToDisplay)  // ypos is 
    // Double pass.  First loop is just to calculate number of lines used, then second pass will render.
    bool renderLoop = false;
    do {
-      for(U32 i = lineCountToDisplay - 1; i != U32_MAX; i--)
+      for(U32 i = lineCountToDisplay - 1; i != U32_MAX; --i)
       {
          // No more rendering - we've rendered to the line count limit
          if(ypos <= ypos_top)
@@ -373,7 +375,7 @@ void AbstractChat::renderChatters(S32 xpos, S32 ypos)
       drawString(xpos, ypos, CHAT_NAMELIST_SIZE, "No other players currently in lobby/chat room");
    }
    else
-      for(S32 i = 0; i < mPlayersInGlobalChat.size(); i++)
+      for(S32 i = 0; i < mPlayersInGlobalChat.size(); ++i)
       {
          const char *name = mPlayersInGlobalChat[i].getString();
 

--- a/zap/UICredits.cpp
+++ b/zap/UICredits.cpp
@@ -174,7 +174,8 @@ CreditsScroller::CreditsScroller()
       else
          c.lines.push_back(gameCredits[index]);
 
-      index++;
+      ++index;
+
    }
 
    // Start credits position at the appropriate place
@@ -201,7 +202,7 @@ void CreditsScroller::updateFX(U32 delta)
    if(mCredits[indexMinus1].pos > 150 - (CreditSpace * mCredits[indexMinus1].lines.size()))  // 150 = banner height
    {
       // Scroll the credits text from bottom to top
-      for(S32 i = 0; i < mCredits.size(); i++)
+      for(S32 i = 0; i < mCredits.size(); ++i)
          mCredits[i].pos -= (delta / 8.f);
 
       // Test if credit music is playing - this just picks an arbitrary time to test if the music loaded properly
@@ -233,8 +234,8 @@ void CreditsScroller::render()
    r.setColor(Colors::white);
 
    // Draw the credits text, section by section, line by line
-   for(S32 i = 0; i < mCredits.size(); i++)
-      for(S32 j = 0; j < mCredits[i].lines.size(); j++)
+   for(S32 i = 0; i < mCredits.size(); ++i)
+      for(S32 j = 0; j < mCredits[i].lines.size(); ++j)
          drawCenteredString(S32(mCredits[i].pos) + CreditSpace * (j), 25, mCredits[i].lines[j]);
 
    r.setColor(Colors::black);
@@ -256,7 +257,7 @@ void CreditsScroller::resetPosition()
 {
    mCredits[0].pos = (F32)DisplayManager::getScreenInfo()->getGameCanvasHeight();
 
-   for(S32 i = 1; i < mCredits.size(); i++)
+   for(S32 i = 1; i < mCredits.size(); ++i)
       mCredits[i].pos = mCredits[i-1].pos + (CreditSpace * mCredits[i-1].lines.size()) + SectionSpace;
 }
 

--- a/zap/UIDiagnostics.cpp
+++ b/zap/UIDiagnostics.cpp
@@ -90,7 +90,8 @@ bool DiagnosticUserInterface::onKeyDown(InputCode inputCode)
 {
    if(checkInputCode(BINDING_DIAG, inputCode))
    {
-      mCurPage++;
+      ++mCurPage;
+
       if(mCurPage >= NUM_PAGES)
          quit();
    }
@@ -117,7 +118,7 @@ S32 findLongestString(F32 size, const Vector<const char *> *strings)
    F32 maxLen = 0;
    S32 longest = 0;
 
-   for(S32 i = 0; i < strings->size(); i++)
+   for(S32 i = 0; i < strings->size(); ++i)
    {
       F32 len = getStringWidth(size, strings->get(i));
       if(len > maxLen)
@@ -196,7 +197,7 @@ static S32 showFoldersBlock(FolderManager *folderManager, F32 textsize, S32 ypos
    if(names.size() == 0)      // Lazy init
       initFoldersBlock(folderManager, (S32)textsize);
 
-   for(S32 i = 0; i < names.size(); i++)
+   for(S32 i = 0; i < names.size(); ++i)
    {
       S32 xpos = (DisplayManager::getScreenInfo()->getGameCanvasWidth() - totLen) / 2;
       r.setColor(Colors::cyan);
@@ -424,7 +425,7 @@ void DiagnosticUserInterface::render()
 
          y += 25;
 
-         for(S32 i = 0; i < SDL_CONTROLLER_AXIS_MAX; i++)
+         for(S32 i = 0; i < SDL_CONTROLLER_AXIS_MAX; ++i)
          {
             F32 a = (F32)Joystick::rawAxesValues[i] / (F32)S16_MAX;    // Range: -1 to 1
             if(fabs(a) > .1f)
@@ -450,7 +451,7 @@ void DiagnosticUserInterface::render()
       hpos += drawStringAndGetWidth(hpos, ypos, textsize, "Keys down: ");
 
       r.setColor(Colors::red);
-      for(U32 i = 0; i < MAX_INPUT_CODES; i++)
+      for(U32 i = 0; i < MAX_INPUT_CODES; ++i)
       {
          InputCode inputCode = InputCode(i);
          if(InputCodeManager::getState(inputCode))
@@ -476,7 +477,7 @@ void DiagnosticUserInterface::render()
       r.setColor(Colors::magenta);
 
       InputCode inputCode;
-      for(U32 i = 0; i < MAX_INPUT_CODES; i++)
+      for(U32 i = 0; i < MAX_INPUT_CODES; ++i)
       {
          inputCode = InputCode(i);
          if(InputCodeManager::getState(inputCode))
@@ -525,7 +526,7 @@ void DiagnosticUserInterface::render()
          hpos += 55;
 
          // Render controller buttons
-         for(U32 i = FIRST_CONTROLLER_BUTTON; i <= LAST_CONTROLLER_BUTTON; i++)
+         for(U32 i = FIRST_CONTROLLER_BUTTON; i <= LAST_CONTROLLER_BUTTON; ++i)
          {
             InputCode code = InputCode(i);
             const Color *color = InputCodeManager::getState(code) ? &Colors::red : NULL;
@@ -541,7 +542,7 @@ void DiagnosticUserInterface::render()
          symbols.push_back(UI::SymbolShapePtr(new UI::SymbolString("SymbolStrings:   ", NULL, HelpContext, 16, false)));
 
          S32 buttonCount = LAST_CONTROLLER_BUTTON - FIRST_CONTROLLER_BUTTON + 1;
-         for(S32 i = 0; i < buttonCount; i++)
+         for(S32 i = 0; i < buttonCount; ++i)
          {
             symbols.push_back(UI::SymbolString::getControlSymbol(InputCode(i + FIRST_CONTROLLER_BUTTON)));
             if(i < buttonCount - 1)
@@ -647,18 +648,19 @@ void DiagnosticUserInterface::render()
       if(!GameManager::getServerGame())
          allLevels += " >>> Level list won't be resolved until you start hosting <<<";
       else
-         for(S32 i = 0; i < GameManager::getServerGame()->getLevelCount(); i++)
+         for(S32 i = 0; i < GameManager::getServerGame()->getLevelCount(); ++i)
             allLevels += string(GameManager::getServerGame()->getLevelNameFromIndex(i).getString()) + "; ";
 
       U32 i, j, k;
       i = j = k = 0;
 
-      for(j = 0; j < 4 && i < allLevels.length(); j++)
+      for(j = 0; j < 4 && i < allLevels.length(); ++j)
       {
          while(getStringWidth(textsize - 6, allLevels.substr(k, i - k).c_str()) <
                DisplayManager::getScreenInfo()->getGameCanvasWidth() - 2 * horizMargin && i < allLevels.length())
          {
-            i++;
+            ++i;
+
          }
 
          drawString(horizMargin, ypos, textsize - 6, allLevels.substr(k, i - k).c_str());
@@ -675,7 +677,7 @@ void DiagnosticUserInterface::render()
       //drawDivetedTriangle(20,9);
       //drawGear(8,20,15,10,8, 5);
 
-      for(S32 i = 0; i < 2; i++)
+      for(S32 i = 0; i < 2; ++i)
       {
          F32 x = (F32)horizMargin + 10;
          F32 y = 500.0f + 20.0f * i;

--- a/zap/UIEditor.cpp
+++ b/zap/UIEditor.cpp
@@ -292,8 +292,10 @@ EditorUserInterface::~EditorUserInterface()
 // Removes most recent undo state from stack --> won't actually delete items on stack until we need the slot, or we quit
 void EditorUserInterface::deleteUndoState()
 {
-   mLastUndoIndex--;
-   mLastRedoIndex--;
+   --mLastUndoIndex;
+
+   --mLastRedoIndex;
+
 }
 
 
@@ -321,13 +323,15 @@ void EditorUserInterface::saveUndoState(bool forceSelectionOfTargetObject)
 
    mUndoItems[mLastUndoIndex % UNDO_STATES] = shared_ptr<GridDatabase>(newDB);
 
-   mLastUndoIndex++;
+   ++mLastUndoIndex;
+
    mLastRedoIndex = mLastUndoIndex;
 
    if(mLastUndoIndex % UNDO_STATES == mFirstUndoIndex % UNDO_STATES)           // Undo buffer now full...
    {
-      mFirstUndoIndex++;
-      mAllUndoneUndoLevel -= 1;     // If this falls below 0, then we can't undo our way out of needing to save
+      ++mFirstUndoIndex;
+
+      --mAllUndoneUndoLevel;     // If this falls below 0, then we can't undo our way out of needing to save
    }
 
    setNeedToSave(mAllUndoneUndoLevel != mLastUndoIndex);
@@ -342,13 +346,15 @@ void EditorUserInterface::saveUndoState(bool forceSelectionOfTargetObject)
 // Remove and discard the most recently saved undo state
 void EditorUserInterface::removeUndoState()
 {
-   mLastUndoIndex--;
+   --mLastUndoIndex;
+
    mLastRedoIndex = mLastUndoIndex;
 
    if(mLastUndoIndex % UNDO_STATES == mFirstUndoIndex % UNDO_STATES)           // Undo buffer now full...
    {
-      mFirstUndoIndex++;
-      mAllUndoneUndoLevel -= 1;     // If this falls below 0, then we can't undo our way out of needing to save
+      ++mFirstUndoIndex;
+
+      --mAllUndoneUndoLevel;     // If this falls below 0, then we can't undo our way out of needing to save
    }
 
    setNeedToSave(mAllUndoneUndoLevel != mLastUndoIndex);
@@ -372,12 +378,15 @@ void EditorUserInterface::undo(bool addToRedoStack)
    if(mLastUndoIndex == mLastRedoIndex && !mRedoingAnUndo)
    {
       saveUndoState();
-      mLastUndoIndex--;
-      mLastRedoIndex--;
+      --mLastUndoIndex;
+
+      --mLastRedoIndex;
+
       mRedoingAnUndo = true;
    }
 
-   mLastUndoIndex--;
+   --mLastUndoIndex;
+
 
    setDatabase(mUndoItems[mLastUndoIndex % UNDO_STATES]);
    GridDatabase *database = getDatabase();
@@ -398,7 +407,8 @@ void EditorUserInterface::redo()
    {
       clearSnapEnvironment();
 
-      mLastUndoIndex++;
+      ++mLastUndoIndex;
+
 
       // Perform a little trick here... if we're redoing, and it's our final step of the redo tree, and there's only one item selected,
       // we'll make sure that same item is selected when we're finished.  That will help keep the focus on the item that's being modified
@@ -410,7 +420,7 @@ void EditorUserInterface::redo()
       {
          const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-         for(S32 i = 0; i < objList->size(); i++)
+         for(S32 i = 0; i < objList->size(); ++i)
          {
             BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -454,7 +464,7 @@ BfObject *EditorUserInterface::findObjBySerialNumber(const GridDatabase *databas
 {
    const Vector<DatabaseObject *> *objList = database->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -486,7 +496,7 @@ void EditorUserInterface::resnapAllEngineeredItems(GridDatabase *database, bool 
    fillVector.clear();
    database->findObjects((TestFunc)isEngineeredType, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       EngineeredItem *engrObj = dynamic_cast<EngineeredItem *>(fillVector[i]);
 
@@ -650,7 +660,7 @@ void EditorUserInterface::copyScriptItemsToEditor()
    // We can't call addToEditor immediately because it calls addToGame which will trigger
    // an assert since the levelGen items are already added to the game.  We must therefore
    // remove them from the game first
-   for(S32 i = 0; i < tempList.size(); i++)
+   for(S32 i = 0; i < tempList.size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(tempList[i]);
 
@@ -754,7 +764,7 @@ void EditorUserInterface::runScript(GridDatabase *database, const FolderManager 
    fillVector.clear();
    database->findObjects((TestFunc)isWallType, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *obj = dynamic_cast<BfObject *>(fillVector[i]);
 
@@ -767,14 +777,14 @@ void EditorUserInterface::runScript(GridDatabase *database, const FolderManager 
    fillVector.clear();
    database->findObjects(TeleporterTypeNumber, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       Teleporter *teleporter = static_cast<Teleporter *>(fillVector[i]);
       if(teleporter->getDestCount() == 0)
          database->removeFromDatabase(teleporter, true);
       else
       {
-         for(S32 i = 1; i < teleporter->getDestCount(); i++)
+         for(S32 i = 1; i < teleporter->getDestCount(); ++i)
          {
             Teleporter *newTel = new Teleporter;
             newTel->setPos(teleporter->getPos());
@@ -785,7 +795,7 @@ void EditorUserInterface::runScript(GridDatabase *database, const FolderManager 
          }
 
          // Delete any destinations past the first one
-         for(S32 i = 1; i < teleporter->getDestCount(); i++)
+         for(S32 i = 1; i < teleporter->getDestCount(); ++i)
             teleporter->delDest(i);
       }
    }
@@ -819,7 +829,7 @@ string EditorUserInterface::getPluginSignature()
    string key = mPluginRunner->getScriptName();
 
    if(mPluginMenu)
-      for(S32 i = 0; i < mPluginMenu->getMenuItemCount(); i++)
+      for(S32 i = 0; i < mPluginMenu->getMenuItemCount(); ++i)
       {
          MenuItem *menuItem = mPluginMenu->getMenuItem(i);
          key += itos(menuItem->getItemType()) + "-";
@@ -880,7 +890,7 @@ void EditorUserInterface::runPlugin(const FolderManager *folderManager, const st
    // Build a menu from the menuItems returned by the plugin
    mPluginMenu.reset(new PluginMenuUI(getGame(), title));      // Using a smart pointer here, for auto deletion
 
-   for(S32 i = 0; i < menuItems.size(); i++)
+   for(S32 i = 0; i < menuItems.size(); ++i)
       mPluginMenu->addWrappedMenuItem(menuItems[i]);
 
 
@@ -892,7 +902,7 @@ void EditorUserInterface::runPlugin(const FolderManager *folderManager, const st
    string key = getPluginSignature();
 
    if(mPluginMenuValues.count(key) == 1)    // i.e. the key exists; use count to avoid creating new entry if it does not exist
-      for(S32 i = 0; i < mPluginMenuValues[key].size(); i++)
+      for(S32 i = 0; i < mPluginMenuValues[key].size(); ++i)
          mPluginMenu->getMenuItem(i)->setValue(mPluginMenuValues[key].get(i));
 
    getGame()->getUIManager()->activate(mPluginMenu.get());
@@ -958,7 +968,7 @@ static bool TeamListToString(string &output, Vector<bool> teamVector)
    char buf[16];
 
    // Make sure each team has a spawn point
-   for(S32 i = 0; i < (S32)teamVector.size(); i++)
+   for(S32 i = 0; i < (S32)teamVector.size(); ++i)
       if(!teamVector[i])
       {
          dSprintf(buf, sizeof(buf), "%d", i+1);
@@ -989,7 +999,7 @@ static bool hasTeamFlags(GridDatabase *database)
 {
    const Vector<DatabaseObject *> *flags = database->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
       if(static_cast<FlagItem *>(flags->get(i))->getTeam() > TEAM_NEUTRAL)
          return true;
 
@@ -1002,7 +1012,7 @@ static bool hasTeamSpawns(GridDatabase *database)
    fillVector.clear();
    database->findObjects(FlagSpawnTypeNumber, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
       if(dynamic_cast<FlagSpawn *>(fillVector[i])->getTeam() >= 0)
          return true;
 
@@ -1025,7 +1035,7 @@ void EditorUserInterface::validateLevel()
    S32 teamCount = getTeamCount();
    foundSpawn.resize(teamCount);
 
-   for(S32 i = 0; i < teamCount; i++)      // Initialize vector
+   for(S32 i = 0; i < teamCount; ++i)      // Initialize vector
       foundSpawn[i] = false;
 
    GridDatabase *gridDatabase = getDatabase();
@@ -1033,7 +1043,7 @@ void EditorUserInterface::validateLevel()
    fillVector.clear();
    gridDatabase->findObjects(ShipSpawnTypeNumber, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       Spawn *spawn = static_cast<Spawn *>(fillVector[i]);
       const S32 team = spawn->getTeam();
@@ -1085,12 +1095,12 @@ void EditorUserInterface::validateLevel()
 
    if(gameType->getGameTypeId() == CoreGame)
    {
-      for(S32 i = 0; i < teamCount; i++)      // Initialize vector
+      for(S32 i = 0; i < teamCount; ++i)      // Initialize vector
          foundSpawn[i] = false;
 
       fillVector.clear();
       gridDatabase->findObjects(CoreTypeNumber, fillVector);
-      for(S32 i = 0; i < fillVector.size(); i++)
+      for(S32 i = 0; i < fillVector.size(); ++i)
       {
          CoreItem *core = static_cast<CoreItem *>(fillVector[i]);
          const S32 team = core->getTeam();
@@ -1114,7 +1124,7 @@ void EditorUserInterface::validateTeams(const Vector<DatabaseObject *> *dbObject
 {
    S32 teams = getTeamCount();
 
-   for(S32 i = 0; i < dbObjects->size(); i++)
+   for(S32 i = 0; i < dbObjects->size(); ++i)
    {
       BfObject *obj = dynamic_cast<BfObject *>(dbObjects->get(i));
       S32 team = obj->getTeam();
@@ -1147,7 +1157,7 @@ void EditorUserInterface::teamsHaveChanged()
    if(getTeamCount() != mOldTeams.size())     // Number of teams has changed
       teamsChanged = true;
    else
-      for(S32 i = 0; i < getTeamCount(); i++)
+      for(S32 i = 0; i < getTeamCount(); ++i)
       {
          EditorTeam *team = getTeam(i);
 
@@ -1166,7 +1176,7 @@ void EditorUserInterface::teamsHaveChanged()
    // TODO: I hope we can get rid of this in future... perhaps replace with mDockItems being stored in a database, and pass the database?
    Vector<DatabaseObject *> hackyjunk;
    hackyjunk.resize(mDockItems.size());
-   for(S32 i = 0; i < mDockItems.size(); i++)
+   for(S32 i = 0; i < mDockItems.size(); ++i)
       hackyjunk[i] = mDockItems[i].get();
 
    validateTeams(&hackyjunk);
@@ -1201,7 +1211,7 @@ void EditorUserInterface::onSelectionChanged()
    fillVector.clear();
    database->findObjects((TestFunc)isWallType, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       TNLAssert(dynamic_cast<BfObject *>(fillVector[i]), "Bad cast!");
       BfObject *obj = static_cast<BfObject *>(fillVector[i]);
@@ -1219,7 +1229,7 @@ void EditorUserInterface::onBeforeRunScriptFromConsole()
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
    // Use selection as a marker -- will have to change in future
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
       obj->setSelected(true);
@@ -1233,7 +1243,7 @@ void EditorUserInterface::onAfterRunScriptFromConsole()
 
    // Since all our original objects were marked as selected before the script was run, and since the objects generated by
    // the script are not selected, if we invert the selection, our script items will now be selected.
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
       obj->setSelected(!obj->isSelected());
@@ -1467,7 +1477,7 @@ Point EditorUserInterface::snapPoint(GridDatabase *database, Point const &p, boo
       bool snapToWallCorners = getSnapToWallCorners();
 
       // Now look for other things we might want to snap to
-      for(S32 i = 0; i < objList->size(); i++)
+      for(S32 i = 0; i < objList->size(); ++i)
       {
          BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -1475,7 +1485,7 @@ Point EditorUserInterface::snapPoint(GridDatabase *database, Point const &p, boo
          if(obj->isSelected() || obj->anyVertsSelected())
             continue;
 
-         for(S32 j = 0; j < obj->getVertCount(); j++)
+         for(S32 j = 0; j < obj->getVertCount(); ++j)
          {
             F32 dist = obj->getVert(j).distSquared(p);
             if(dist < minDist)
@@ -1527,7 +1537,7 @@ static void markSelectedObjectsAsUnsnapped_init(S32 itemCount, bool calledDuring
    if(calledDuringDragInitialization)
    {
       promiscuousSnapper.resize(itemCount);
-      for(S32 i = 0; i < itemCount; i++)
+      for(S32 i = 0; i < itemCount; ++i)
          promiscuousSnapper[i] = true;    // They're all a bit loose to begin with!
    }
 }
@@ -1566,7 +1576,7 @@ static void markSelectedObjectAsUnsnapped_done(bool calledDuringDragInitializati
 {
    // Now review all the engineer items that are being dragged and see if the wall they are mounted to is being
    // dragged as well.  If it is, keep them snapped; if not, mark them as unsnapped.
-   for(S32 i = 0; i < selectedSnappedEngrObjects.size(); i++)
+   for(S32 i = 0; i < selectedSnappedEngrObjects.size(); ++i)
    {
       bool snapped = selectedWalls.contains(selectedSnappedEngrObjects[i]->getMountSegment()->getOwner());
       selectedSnappedEngrObjects[i]->setSnapped(snapped);
@@ -1582,7 +1592,7 @@ void EditorUserInterface::markSelectedObjectsAsUnsnapped(const Vector<shared_ptr
    markSelectedObjectsAsUnsnapped_init(objList.size(), true);
 
    // Mark all items being dragged as no longer being snapped -- only our primary "focus" item will be snapped
-   for(S32 i = 0; i < objList.size(); i++)
+   for(S32 i = 0; i < objList.size(); ++i)
       markSelectedObjectAsUnsnapped_body(objList[i].get(), i, true);
 
    markSelectedObjectAsUnsnapped_done(true);
@@ -1594,7 +1604,7 @@ void EditorUserInterface::markSelectedObjectsAsUnsnapped(const Vector<DatabaseOb
    markSelectedObjectsAsUnsnapped_init(objList->size(), true);
 
    // Mark all items being dragged as no longer being snapped -- only our primary "focus" item will be snapped
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
       markSelectedObjectAsUnsnapped_body(static_cast<BfObject *>(objList->get(i)), i, true);
 
    markSelectedObjectAsUnsnapped_done(true);
@@ -1630,8 +1640,8 @@ S32 EditorUserInterface::checkCornersForSnap(const Point &clickPoint, const Vect
 {
    const Point *vert;
 
-   for(S32 i = 0; i < edges->size(); i++)
-      for(S32 j = 0; j < 1; j++)
+   for(S32 i = 0; i < edges->size(); ++i)
+      for(S32 j = 0; j < 1; ++j)
       {
          WallEdge *edge = static_cast<WallEdge *>(edges->get(i));
          vert = (j == 0) ? edge->getStart() : edge->getEnd();
@@ -1680,7 +1690,7 @@ void EditorUserInterface::renderTurretAndSpyBugRanges(GridDatabase *editorDb)
       S32 prevTeam = -10;
 
       // Draw spybug visibility ranges first, underneath everything else
-      for(S32 i = 0; i < fillVector.size(); i++)
+      for(S32 i = 0; i < fillVector.size(); ++i)
       {
          BfObject *editorObj = dynamic_cast<BfObject*>(fillVector[i]);
 
@@ -1703,7 +1713,7 @@ void EditorUserInterface::renderTurretAndSpyBugRanges(GridDatabase *editorDb)
    fillVector.clear();
 
    editorDb->findObjects(TurretTypeNumber, fillVector);
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *editorObj = dynamic_cast<BfObject *>(fillVector[i]);
       if(editorObj->isSelected() || editorObj->isLitUp())
@@ -1830,7 +1840,7 @@ static void renderAttribText(S32 xpos, S32 ypos, S32 textsize,
    Renderer& r = Renderer::get();
 
    TNLAssert(keys.size() == vals.size(), "Expected equal number of keys and values!");
-   for(S32 i = 0; i < keys.size(); i++)
+   for(S32 i = 0; i < keys.size(); ++i)
    {
       r.setColor(keyColor);
       xpos += drawStringAndGetWidth(xpos, ypos, textsize, keys[i].c_str());
@@ -1883,7 +1893,7 @@ void EditorUserInterface::renderItemInfoPanel()
       // Cycle through all our objects to find the selected ones
       const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-      for(S32 i = 0; i < objList->size(); i++)
+      for(S32 i = 0; i < objList->size(); ++i)
       {
          BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -1908,7 +1918,8 @@ void EditorUserInterface::renderItemInfoPanel()
                }
             }
 
-            hitCount++;
+            ++hitCount;
+
          }  // end if obj is selected
 
          else if(obj->isLitUp() && !mouseOnDock())
@@ -2042,7 +2053,7 @@ void EditorUserInterface::render()
          fillVector.clear();
          editorDb->findObjects((TestFunc)isLineItemType, fillVector);
 
-         for(S32 i = 0; i < fillVector.size(); i++)
+         for(S32 i = 0; i < fillVector.size(); ++i)
          {
             LineItem *obj = dynamic_cast<LineItem *>(fillVector[i]);   // Walls are a subclass of LineItem, so this will work for both
 
@@ -2120,7 +2131,7 @@ void EditorUserInterface::renderObjects(GridDatabase *database, RenderModes rend
    bool wantSelected = (renderMode == RENDER_SELECTED_NONWALLS || renderMode == RENDER_SELECTED_WALLS);
    bool wantWalls =    (renderMode == RENDER_UNSELECTED_WALLS  || renderMode == RENDER_SELECTED_WALLS);
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2184,7 +2195,7 @@ void EditorUserInterface::renderObjectsUnderConstruction()
    r.renderPointVector(mNewItem->getOutline(), RenderType::LineStrip);
    r.setLineWidth(gDefaultLineWidth);
 
-   for(S32 j = mNewItem->getVertCount() - 1; j >= 0; j--)      // Go in reverse order so that placed vertices are drawn atop unplaced ones
+   for(S32 j = mNewItem->getVertCount() - 1; j >= 0; --j)      // Go in reverse order so that placed vertices are drawn atop unplaced ones
    {
       Point v = mNewItem->getVert(j);
 
@@ -2218,7 +2229,7 @@ static void renderDockItem(BfObject *object, F32 currentScale, S32 snapVertexInd
 
 void EditorUserInterface::renderDockItems()
 {
-   for(S32 i = 0; i < mDockItems.size(); i++)
+   for(S32 i = 0; i < mDockItems.size(); ++i)
       renderDockItem(mDockItems[i].get(), mCurrentScale, mSnapVertexIndex);
 }
 
@@ -2250,7 +2261,7 @@ void EditorUserInterface::renderDockPlugins()
 {
    S32 hoveredPlugin = mouseOnDock() ? findHitPlugin() : -1;
    S32 maxPlugins = getDockHeight() / PLUGIN_LINE_SPACING;
-   for(S32 i = mDockPluginScrollOffset; i < mPluginInfos.size() && (i - mDockPluginScrollOffset) < maxPlugins; i++)
+   for(S32 i = mDockPluginScrollOffset; i < mPluginInfos.size() && (i - mDockPluginScrollOffset) < maxPlugins; ++i)
    {
       if(hoveredPlugin == i)
       {
@@ -2318,7 +2329,7 @@ void EditorUserInterface::renderWarnings() const
 
       r.setColor(Colors::ErrorMessageTextColor);
 
-      for(S32 i = 0; i < mLevelErrorMsgs.size(); i++)
+      for(S32 i = 0; i < mLevelErrorMsgs.size(); ++i)
       {
          drawCenteredString(ypos, 20, mLevelErrorMsgs[i].c_str());
          ypos += 25;
@@ -2326,7 +2337,7 @@ void EditorUserInterface::renderWarnings() const
 
       r.setColor(Colors::yellow);
 
-      for(S32 i = 0; i < mLevelWarnings.size(); i++)
+      for(S32 i = 0; i < mLevelWarnings.size(); ++i)
       {
          drawCenteredString(ypos, 20, mLevelWarnings[i].c_str());
          ypos += 25;
@@ -2363,7 +2374,7 @@ void EditorUserInterface::clearSelection(GridDatabase *database)
 {
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
       obj->unselect();
@@ -2376,7 +2387,7 @@ void EditorUserInterface::selectAll(GridDatabase *database)
 {
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
       obj->setSelected(true);
@@ -2388,7 +2399,7 @@ bool EditorUserInterface::anyItemsSelected(const GridDatabase *database) const
 {
    const Vector<DatabaseObject *> *objList = database->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
       if(obj->isSelected())
@@ -2411,7 +2422,7 @@ void EditorUserInterface::copySelection()
 
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2447,7 +2458,7 @@ void EditorUserInterface::pasteSelection()
    Point offsetFromFirstPoint;
    Vector<DatabaseObject *> copiedObjects;
 
-   for(S32 i = 0; i < objCount; i++)
+   for(S32 i = 0; i < objCount; ++i)
    {
       offsetFromFirstPoint = firstPoint - mClipboard[i]->getVert(0);
 
@@ -2465,7 +2476,7 @@ void EditorUserInterface::pasteSelection()
 
    // TODO: Need to do something here to snap pasted turrets that are not already snapped to something else
 
-   for(S32 i = 0; i < copiedObjects.size(); i++)
+   for(S32 i = 0; i < copiedObjects.size(); ++i)
       copiedObjects[i]->onGeomChanged();
 
    onSelectionChanged();
@@ -2500,7 +2511,7 @@ void EditorUserInterface::scaleSelection(F32 scale)
 
    const Vector<DatabaseObject *> *objList = database->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2550,7 +2561,7 @@ void EditorUserInterface::rotateSelection(F32 angle, bool useOrigin)
       // We'll then get the centroid of the set
       set<Point, PointCompare> centroidSet;
 
-      for(S32 i = 0; i < objList->size(); i++)
+      for(S32 i = 0; i < objList->size(); ++i)
       {
          BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2580,7 +2591,7 @@ void EditorUserInterface::rotateSelection(F32 angle, bool useOrigin)
    }
 
    // Now do the actual rotation
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2600,7 +2611,7 @@ void EditorUserInterface::setSelectionId(S32 id)
 {
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2641,7 +2652,7 @@ void EditorUserInterface::setCurrentTeam(S32 currentTeam)
    }
 
    // Update all dock items to reflect new current team
-   for(S32 i = 0; i < mDockItems.size(); i++)
+   for(S32 i = 0; i < mDockItems.size(); ++i)
    {
       if(!mDockItems[i]->hasTeam())
          continue;
@@ -2658,7 +2669,7 @@ void EditorUserInterface::setCurrentTeam(S32 currentTeam)
 
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2734,7 +2745,7 @@ void EditorUserInterface::flipSelection(F32 center, bool isHoriz)
 
    wallSegmentManager->beginBatchGeomUpdate();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2764,7 +2775,7 @@ void EditorUserInterface::toggleDestructibleWallSegment()
 
    bool modifiedWalls = false;
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2827,8 +2838,8 @@ void EditorUserInterface::findHitItemAndEdge()
 
    // Do this in two passes -- the first we only consider selected items, the second pass will consider all targets.
    // This will give priority to hitting vertices of selected items.
-   for(S32 firstPass = 1; firstPass >= 0; firstPass--)     // firstPass will be true the first time through, false the second time
-      for(S32 i = fillVector.size() - 1; i >= 0; i--)      // Go in reverse order to prioritize items drawn on top
+   for(S32 firstPass = 1; firstPass >= 0; --firstPass)     // firstPass will be true the first time through, false the second time
+      for(S32 i = fillVector.size() - 1; i >= 0; --i)      // Go in reverse order to prioritize items drawn on top
       {
          BfObject *obj = dynamic_cast<BfObject *>(fillVector[i]);
 
@@ -2847,13 +2858,13 @@ void EditorUserInterface::findHitItemAndEdge()
 
    wallDb->findObjects((TestFunc)isAnyObjectType, fillVector2, cursorRect);
 
-   for(S32 i = 0; i < fillVector2.size(); i++)
+   for(S32 i = 0; i < fillVector2.size(); ++i)
       if(checkForWallHit(mouse, fillVector2[i]))
          return;
 
    // If we're still here, it means we didn't find anything yet.  Make one more pass, and see if we're in any polys.
    // This time we'll loop forward, though I don't think it really matters.
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
      if(checkForPolygonHit(mouse, dynamic_cast<BfObject *>(fillVector[i])))
         return;
 }
@@ -2865,7 +2876,7 @@ bool EditorUserInterface::checkForVertexHit(BfObject *object)
 {
    F32 radius = object->getEditorRadius(mCurrentScale);
 
-   for(S32 i = object->getVertCount() - 1; i >= 0; i--)
+   for(S32 i = object->getVertCount() - 1; i >= 0; --i)
    {
       // p represents pixels from mouse to obj->getVert(j), at any zoom
       Point p = mMousePos - mCurrentOffset - (object->getVert(i) + object->getEditorSelectionOffset(mCurrentScale)) * mCurrentScale;
@@ -2900,7 +2911,7 @@ bool EditorUserInterface::checkForEdgeHit(const Point &point, BfObject *object)
 
    S32 j_prev  = loop ? (verts.size() - 1) : 0;
 
-   for(S32 j = loop ? 0 : 1; j < verts.size(); j++)
+   for(S32 j = loop ? 0 : 1; j < verts.size(); ++j)
    {
       if(findNormalPoint(point, verts[j_prev], verts[j], closest))
       {
@@ -2929,7 +2940,7 @@ bool EditorUserInterface::checkForWallHit(const Point &point, DatabaseObject *ob
    {
       // Now that we've found a segment that our mouse is over, we need to find the wall object that it belongs to.  Chances are good
       // that it will be one of the objects sitting in fillVector.
-      for(S32 i = 0; i < fillVector.size(); i++)
+      for(S32 i = 0; i < fillVector.size(); ++i)
       {
          if(isWallType(fillVector[i]->getObjectTypeNumber()))
          {
@@ -2950,7 +2961,7 @@ bool EditorUserInterface::checkForWallHit(const Point &point, DatabaseObject *ob
 
       const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-      for(S32 i = 0; i < objList->size(); i++)
+      for(S32 i = 0; i < objList->size(); ++i)
       {
          BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -2986,7 +2997,7 @@ void EditorUserInterface::findHitItemOnDock()
 {
    mDockItemHit = NULL;
 
-   for(S32 i = mDockItems.size() - 1; i >= 0; i--)     // Go in reverse order because the code we copied did ;-)
+   for(S32 i = mDockItems.size() - 1; i >= 0; --i)     // Go in reverse order because the code we copied did ;-)
    {
       Point pos = mDockItems[i]->getPos();
 
@@ -2998,11 +3009,11 @@ void EditorUserInterface::findHitItemOnDock()
    }
 
    // Now check for polygon interior hits
-   for(S32 i = 0; i < mDockItems.size(); i++)
+   for(S32 i = 0; i < mDockItems.size(); ++i)
       if(mDockItems[i]->getGeomType() == geomPolygon)
       {
          Vector<Point> verts;
-         for(S32 j = 0; j < mDockItems[i]->getVertCount(); j++)
+         for(S32 j = 0; j < mDockItems[i]->getVertCount(); ++j)
             verts.push_back(mDockItems[i]->getVert(j));
 
          if(polygonContainsPoint(verts.address(),verts.size(), mMousePos))
@@ -3019,7 +3030,7 @@ void EditorUserInterface::findHitItemOnDock()
 S32 EditorUserInterface::findHitPlugin()
 {
    S32 i;
-   for(i = 0; i < mPluginInfos.size(); i++)
+   for(i = 0; i < mPluginInfos.size(); ++i)
    {
       if(mMousePos.y > 1.5 * vertMargin + PLUGIN_LINE_SPACING * i &&
          mMousePos.y < 1.5 * vertMargin + PLUGIN_LINE_SPACING * (i + 1)
@@ -3157,7 +3168,7 @@ void EditorUserInterface::onMouseDragged_StartDragging(const bool needToSaveUndo
 
    // Save the original location of each item pre-move, only used for snapping engineered items to walls
    // Saves location of every item, selected or not
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
       mMoveOrigins[i].set(objList->get(i)->getVert(0));
 
    markSelectedObjectsAsUnsnapped(objList);
@@ -3169,7 +3180,7 @@ void EditorUserInterface::onMouseDragged_CopyAndDrag(const Vector<DatabaseObject
 {
    Vector<DatabaseObject *> copiedObjects;
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -3193,7 +3204,7 @@ void EditorUserInterface::onMouseDragged_CopyAndDrag(const Vector<DatabaseObject
    mDragCopying = true;
 
    // Now mark source objects as unselected
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -3205,7 +3216,7 @@ void EditorUserInterface::onMouseDragged_CopyAndDrag(const Vector<DatabaseObject
    getDatabase()->addToDatabase(copiedObjects);
 
    // Running onGeomChanged causes any copied walls to have a full body while we're dragging them
-   for(S32 i = 0; i < copiedObjects.size(); i++)
+   for(S32 i = 0; i < copiedObjects.size(); ++i)
       copiedObjects[i]->onGeomChanged();
 }
 
@@ -3217,7 +3228,7 @@ void EditorUserInterface::translateSelectedItems(const Vector<Point> &origins, c
    //mMoveOrigins[i].set(objList->get(i)->getPos());
    TNLAssert(mMoveOrigins.size() == objList->size(), "Expected these to be the same size!");
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -3225,7 +3236,7 @@ void EditorUserInterface::translateSelectedItems(const Vector<Point> &origins, c
 
       if(obj->isSelected())            // ==> Dragging whole object
       {
-         for(S32 j = obj->getVertCount() - 1; j >= 0;  j--)
+         for(S32 j = obj->getVertCount() - 1; j >= 0;  --j)
          {
             newVert = (obj->getVert(j) - obj->getVert(0)) + (mMoveOrigins[i] + offset);
             obj->setVert(newVert, j);
@@ -3235,7 +3246,7 @@ void EditorUserInterface::translateSelectedItems(const Vector<Point> &origins, c
 
       else if(obj->anyVertsSelected()) // ==> Dragging individual vertex
       {
-         for(S32 j = obj->getVertCount() - 1; j >= 0;  j--)
+         for(S32 j = obj->getVertCount() - 1; j >= 0;  --j)
             if(obj->vertSelected(j))
             {
                // Pos of vert at last tick + Offset from last tick
@@ -3254,7 +3265,7 @@ void EditorUserInterface::snapSelectedEngineeredItems(const Point &cumulativeOff
 
    WallSegmentManager *wallSegmentManager = getDatabase()->getWallSegmentManager();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       if(isEngineeredType(objList->get(i)->getObjectTypeNumber()))
       {
@@ -3307,7 +3318,7 @@ void EditorUserInterface::startDraggingDockItem()
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
    mEdgeHit = NONE;
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -3354,7 +3365,7 @@ void EditorUserInterface::findSnapVertex()
       }
 
       // Didn't hit an edge... find the closest vertex anywhere in the item
-      for(S32 j = 0; j < mHitItem->getVertCount(); j++)
+      for(S32 j = 0; j < mHitItem->getVertCount(); ++j)
       {
          F32 dist = mHitItem->getVert(j).distSquared(mouseLevelCoord);
 
@@ -3372,11 +3383,11 @@ void EditorUserInterface::findSnapVertex()
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
    // Otherwise, we don't have a selected hitItem -- look for a selected vertex
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
-      for(S32 j = 0; j < obj->getVertCount(); j++)
+      for(S32 j = 0; j < obj->getVertCount(); ++j)
       {
          F32 dist = obj->getVert(j).distSquared(mouseLevelCoord);
 
@@ -3404,7 +3415,7 @@ void EditorUserInterface::deleteSelection(bool objectsOnly)
 
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = objList->size() - 1; i >= 0; i--)  // Reverse to avoid having to have i-- in middle of loop
+   for(S32 i = objList->size() - 1; i >= 0; --i)  // Reverse to avoid having to have i-- in middle of loop
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -3428,7 +3439,7 @@ void EditorUserInterface::deleteSelection(bool objectsOnly)
          bool geomChanged = false;
 
          // Backwards!  Since we could be deleting multiple at once
-         for(S32 j = obj->getVertCount() - 1; j > -1 ; j--)
+         for(S32 j = obj->getVertCount() - 1; j > -1 ; --j)
          {
             if(obj->vertSelected(j))
             {
@@ -3481,7 +3492,7 @@ void EditorUserInterface::changeBarrierWidth(S32 amt)
    fillVector2.clear();    // fillVector gets modified in some child function, so use our secondary reusable container
    getDatabase()->findObjects((TestFunc)isWallItemType, fillVector2);
 
-   for(S32 i = 0; i < fillVector2.size(); i++)
+   for(S32 i = 0; i < fillVector2.size(); ++i)
    {
       WallItem *obj = static_cast<WallItem *>(fillVector2[i]);
       if(obj->isSelected())
@@ -3502,12 +3513,12 @@ void EditorUserInterface::splitBarrier()
 
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
       if(obj->getGeomType() == geomPolyLine)
-          for(S32 j = 1; j < obj->getVertCount() - 1; j++)     // Can't split on end vertices!
+          for(S32 j = 1; j < obj->getVertCount() - 1; ++j)     // Can't split on end vertices!
             if(obj->vertSelected(j))
             {
                saveUndoState();
@@ -3549,13 +3560,14 @@ void EditorUserInterface::doSplit(BfObject *object, S32 vertex)
    // Note that it would be more efficient to start at the end and work backwards, but the direction of our numbering would be
    // reversed in the new object compared to what it was.  This isn't important at the moment, but it just seems wrong from a
    // geographic POV.  Which I have.
-   for(S32 i = vertex; i < object->getVertCount(); i++)
+   for(S32 i = vertex; i < object->getVertCount(); ++i)
    {
       newObj->addVert(object->getVert(i), true);      // true: If wall already has more than max number of points, let children have more as well
       if(i != vertex)               // i.e. if this isn't the first iteration
       {
          object->deleteVert(i);     // Don't delete first vertex -- we need it to remain as final vertex of old feature
-         i--;
+         --i;
+
       }
    }
 
@@ -3577,7 +3589,7 @@ void EditorUserInterface::joinBarrier()
 
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size()-1; i++)
+   for(S32 i = 0; i < objList->size()-1; ++i)
    {
       BfObject *obj_i = static_cast<BfObject *>(objList->get(i));
 
@@ -3621,7 +3633,7 @@ BfObject *EditorUserInterface::doMergePolygons(BfObject *firstItem, S32 firstIte
 
    bool cw = isWoundClockwise(*firstItem->getOutline());       // Make sure all our polys are wound the same direction as the first
 
-   for(S32 i = firstItemIndex + 1; i < objList->size(); i++)   // Compare against remaining objects
+   for(S32 i = firstItemIndex + 1; i < objList->size(); ++i)   // Compare against remaining objects
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
       if(obj->getObjectTypeNumber() == firstItem->getObjectTypeNumber() && obj->isSelected())
@@ -3645,13 +3657,13 @@ BfObject *EditorUserInterface::doMergePolygons(BfObject *firstItem, S32 firstIte
          firstItem->deleteVert(firstItem->getVertCount() - 1);
 
       // Add the new points
-      for(S32 i = 0; i < outputPolygons[0].size(); i++)
+      for(S32 i = 0; i < outputPolygons[0].size(); ++i)
          ok &= firstItem->addVert(outputPolygons[0][i], true);
 
       if(ok)
       {
          // Delete the constituent parts; work backwards to avoid queering the deleteList indices
-         for(S32 i = deleteList.size() - 1; i >= 0; i--)
+         for(S32 i = deleteList.size() - 1; i >= 0; --i)
             deleteItem(deleteList[i]);
 
          return firstItem;
@@ -3668,7 +3680,7 @@ BfObject *EditorUserInterface::doMergeLines(BfObject *firstItem, S32 firstItemIn
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
    BfObject *joinedObj = NULL;
 
-   for(S32 i = firstItemIndex + 1; i < objList->size(); i++)              // Compare against remaining objects
+   for(S32 i = firstItemIndex + 1; i < objList->size(); ++i)              // Compare against remaining objects
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -3685,11 +3697,12 @@ BfObject *EditorUserInterface::doMergeLines(BfObject *firstItem, S32 firstItemIn
 
             joinedObj = firstItem;
 
-            for(S32 a = 1; a < obj->getVertCount(); a++)           // Skip first vertex, because it would be a dupe
+            for(S32 a = 1; a < obj->getVertCount(); ++a)           // Skip first vertex, because it would be a dupe
                firstItem->addVertFront(obj->getVert(a));
 
             deleteItem(i);
-            i--;
+            --i;
+
          }
 
          // First vertex coincides with final vertex 3 2 1 | 5 4 3
@@ -3700,11 +3713,12 @@ BfObject *EditorUserInterface::doMergeLines(BfObject *firstItem, S32 firstItemIn
 
             joinedObj = firstItem;
 
-            for(S32 a = obj->getVertCount() - 2; a >= 0; a--)
+            for(S32 a = obj->getVertCount() - 2; a >= 0; --a)
                firstItem->addVertFront(obj->getVert(a));
 
             deleteItem(i);    // i has been merged into firstItem; don't need i anymore!
-            i--;
+            --i;
+
          }
 
          // Last vertex coincides with first 1 2 3 | 3 4 5
@@ -3715,11 +3729,12 @@ BfObject *EditorUserInterface::doMergeLines(BfObject *firstItem, S32 firstItemIn
 
             joinedObj = firstItem;
 
-            for(S32 a = 1; a < obj->getVertCount(); a++)  // Skip first vertex, because it would be a dupe
+            for(S32 a = 1; a < obj->getVertCount(); ++a)  // Skip first vertex, because it would be a dupe
                firstItem->addVert(obj->getVert(a));
 
             deleteItem(i);
-            i--;
+            --i;
+
          }
 
          // Last vertices coincide  1 2 3 | 5 4 3
@@ -3730,11 +3745,12 @@ BfObject *EditorUserInterface::doMergeLines(BfObject *firstItem, S32 firstItemIn
 
             joinedObj = firstItem;
 
-            for(S32 j = obj->getVertCount() - 2; j >= 0; j--)
+            for(S32 j = obj->getVertCount() - 2; j >= 0; --j)
                firstItem->addVert(obj->getVert(j));
 
             deleteItem(i);
-            i--;
+            --i;
+
          }
       }
    }
@@ -3800,7 +3816,7 @@ void EditorUserInterface::insertNewItem(U8 itemTypeNumber)
    BfObject *newObject = NULL;
 
    // Find a dockItem to copy
-   for(S32 i = 0; i < mDockItems.size(); i++)
+   for(S32 i = 0; i < mDockItems.size(); ++i)
       if(mDockItems[i]->getObjectTypeNumber() == itemTypeNumber)
       {
          newObject = copyDockItem(mDockItems[i].get());
@@ -3968,7 +3984,8 @@ bool EditorUserInterface::onKeyDown(InputCode inputCode)
       if(mDockMode == DOCKMODE_PLUGINS && mouseOnDock())
       {
          if(mDockPluginScrollOffset > 0)
-            mDockPluginScrollOffset -= 1;
+            --mDockPluginScrollOffset;
+
       }
       else
          zoom(0.2f);
@@ -3978,7 +3995,8 @@ bool EditorUserInterface::onKeyDown(InputCode inputCode)
       if(mDockMode == DOCKMODE_PLUGINS && mouseOnDock())
       {
          if(mDockPluginScrollOffset < (S32) (mPluginInfos.size() - getDockHeight() / PLUGIN_LINE_SPACING))
-            mDockPluginScrollOffset += 1;
+            ++mDockPluginScrollOffset;
+
       }
       else
          zoom(-0.2f);
@@ -4410,7 +4428,7 @@ bool EditorUserInterface::checkPluginKeyBindings(string inputString)
 {
    GameSettings *settings = getGame()->getSettings();
 
-   for(S32 i = 0; i < mPluginInfos.size(); i++)
+   for(S32 i = 0; i < mPluginInfos.size(); ++i)
    {
       if(mPluginInfos[i].binding != "" && inputString == mPluginInfos[i].binding)
       {
@@ -4448,7 +4466,7 @@ void idEntryCallback(string text, BfObject *object)
    {
       const Vector<DatabaseObject *> *objList = clientGame->getUIManager()->getUI<EditorUserInterface>()->getDatabase()->findObjects_fast();
 
-      for(S32 i = 0; i < objList->size(); i++)
+      for(S32 i = 0; i < objList->size(); ++i)
       {
          BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -4506,7 +4524,7 @@ void EditorUserInterface::startSimpleTextEntryMenu(SimpleTextEntryType entryType
    S32 selectedIndex = NONE;
    BfObject *selectedObject = NULL;
    BfObject *obj = NULL;
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       obj = static_cast<BfObject *>(objList->get(i));
 
@@ -4533,7 +4551,7 @@ void EditorUserInterface::startSimpleTextEntryMenu(SimpleTextEntryType entryType
          const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
          // Unselect all objects but our first selected one
-         for(S32 i = 0; i < objList->size(); i++)
+         for(S32 i = 0; i < objList->size(); ++i)
          {
             if(i != selectedIndex)
                static_cast<BfObject *>(objList->get(i))->setSelected(false);
@@ -4622,7 +4640,7 @@ void EditorUserInterface::startAttributeEditor()
 {
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj_i = static_cast<BfObject *>(objList->get(i));
 
@@ -4632,7 +4650,7 @@ void EditorUserInterface::startAttributeEditor()
          // occur if you had different item types selected while you were editing attributes.   If you have multiple
          // items selected, all will end up with the same values, which only make sense if they are the same kind
          // of object.  So after this runs, there may be multiple items selected, but they'll all  be the same type.
-         for(S32 j = 0; j < objList->size(); j++)
+         for(S32 j = 0; j < objList->size(); ++j)
          {
             BfObject *obj_j = static_cast<BfObject *>(objList->get(j));
 
@@ -4664,7 +4682,7 @@ void EditorUserInterface::doneEditingAttributes(EditorAttributeMenuUI *editor, B
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
    // Find any other selected items of the same type of the item we just edited, and update their attributes too
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -4750,7 +4768,7 @@ void EditorUserInterface::onKeyUp(InputCode inputCode)
             getDatabase()->findObjects(fillVector);
 
 
-            for(S32 i = 0; i < fillVector.size(); i++)
+            for(S32 i = 0; i < fillVector.size(); ++i)
             {
                BfObject *obj = dynamic_cast<BfObject *>(fillVector[i]);
 
@@ -4758,7 +4776,7 @@ void EditorUserInterface::onKeyUp(InputCode inputCode)
                // item needs to be surrounded to be included in the selection
                S32 j;
 
-               for(j = 0; j < obj->getVertCount(); j++)
+               for(j = 0; j < obj->getVertCount(); ++j)
                   if(!r.contains(obj->getVert(j)))
                      break;
                if(j == obj->getVertCount())
@@ -4809,7 +4827,7 @@ void EditorUserInterface::onFinishedDragging()
          const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
          bool deletedSomething = false, deletedWall = false;
 
-         for(S32 i = 0; i < objList->size(); i++)    //  Delete all selected items
+         for(S32 i = 0; i < objList->size(); ++i)    //  Delete all selected items
          {
             BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -4819,7 +4837,8 @@ void EditorUserInterface::onFinishedDragging()
                   deletedWall = true;
 
                deleteItem(i, true);
-               i--;
+               --i;
+
                deletedSomething = true;
             }
          }
@@ -4853,7 +4872,7 @@ void EditorUserInterface::onFinishedDragging()
 
          const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-         for(S32 i = 0; i < objList->size(); i++)
+         for(S32 i = 0; i < objList->size(); ++i)
          {
             BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -4897,12 +4916,13 @@ S32 EditorUserInterface::getItemSelectedCount()
 
    S32 count = 0;
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
       if(obj->isSelected())
-         count++;
+         ++count;
+
    }
 
    return count;
@@ -4913,7 +4933,7 @@ bool EditorUserInterface::anythingSelected() const
 {
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objList->size(); i++)
+   for(S32 i = 0; i < objList->size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(objList->get(i));
       if(obj->isSelected() || obj->anyVertsSelected() )
@@ -5076,15 +5096,15 @@ string EditorUserInterface::getLevelText()
    result += getGame()->toLevelCode();    // Note that this toLevelCode appends a newline char; most don't
 
    // Next come the robots
-   for(S32 i = 0; i < mRobotLines.size(); i++)
+   for(S32 i = 0; i < mRobotLines.size(); ++i)
       result += mRobotLines[i] + "\n";
 
    // Write out all level items (do two passes; walls first, non-walls next, so turrets & forcefields have something to grab onto)
    const Vector<DatabaseObject *> *objList = getDatabase()->findObjects_fast();
 
-   for(S32 j = 0; j < 2; j++)
+   for(S32 j = 0; j < 2; ++j)
    {
-      for(S32 i = 0; i < objList->size(); i++)
+      for(S32 i = 0; i < objList->size(); ++i)
       {
          BfObject *obj = static_cast<BfObject *>(objList->get(i));
 
@@ -5163,10 +5183,10 @@ void EditorUserInterface::testLevel()
 
       string msg = "";
 
-      for(S32 i = 0; i < mLevelErrorMsgs.size(); i++)
+      for(S32 i = 0; i < mLevelErrorMsgs.size(); ++i)
          msg += mLevelErrorMsgs[i] + "\n";
 
-      for(S32 i = 0; i < mLevelWarnings.size(); i++)
+      for(S32 i = 0; i < mLevelWarnings.size(); ++i)
          msg += mLevelWarnings[i] + "\n";
 
       if(gameTypeError)
@@ -5268,9 +5288,9 @@ void EditorUserInterface::findPlugins()
    Vector<PluginBinding> &bindings = getGame()->getSettings()->getIniSettings()->pluginBindings;
 
    // Check for binding collision in INI.  If one is detected, set its key to empty
-   for(S32 i = 0; i < bindings.size(); i++)
+   for(S32 i = 0; i < bindings.size(); ++i)
    {
-      for(S32 j = 0; j < i; j++)  // Efficiency!
+      for(S32 j = 0; j < i; ++j)  // Efficiency!
       {
          if(bindings[i].key == bindings[j].key)
          {
@@ -5281,7 +5301,7 @@ void EditorUserInterface::findPlugins()
    }
 
    // Loop through all of our detected plugins
-   for(S32 i = 0; i < plugins.size(); i++)
+   for(S32 i = 0; i < plugins.size(); ++i)
    {
       // Try to find the title
       string title;
@@ -5299,7 +5319,7 @@ void EditorUserInterface::findPlugins()
       PluginInfo info(title, plugins[i], plugin.getDescription(), plugin.getRequestedBinding());
 
       // Check for a binding from the INI, if it exists set it for this plugin
-      for(S32 j = 0; j < bindings.size(); j++)
+      for(S32 j = 0; j < bindings.size(); ++j)
       {
          if(bindings[j].script == plugins[i])
          {
@@ -5316,7 +5336,7 @@ void EditorUserInterface::findPlugins()
 
          // Determine if this requested binding is already in use by a binding
          // in the INI
-         for(S32 j = 0; j < bindings.size(); j++)
+         for(S32 j = 0; j < bindings.size(); ++j)
          {
             if(bindings[j].key == info.requestedBinding)
             {
@@ -5327,7 +5347,7 @@ void EditorUserInterface::findPlugins()
 
          // Determine if this requested binding is already in use by a previously
          // loaded plugin
-         for(S32 j = 0; j < mPluginInfos.size(); j++)
+         for(S32 j = 0; j < mPluginInfos.size(); ++j)
          {
             if(mPluginInfos[j].binding == info.requestedBinding)
             {
@@ -5355,7 +5375,7 @@ void EditorUserInterface::findPlugins()
    // Now update all the bindings in the INI
    bindings.clear();
 
-   for(S32 i = 0; i < mPluginInfos.size(); i++)
+   for(S32 i = 0; i < mPluginInfos.size(); ++i)
    {
       PluginInfo info = mPluginInfos[i];
 
@@ -5377,7 +5397,7 @@ U32 EditorUserInterface::findPluginDockWidth()
 {
    U32 maxNameWidth = 0;
    U32 maxBindingWidth = 0;
-   for(S32 i = 0; i < mPluginInfos.size(); i++)
+   for(S32 i = 0; i < mPluginInfos.size(); ++i)
    {
       U32 nameWidth = getStringWidth(DOCK_LABEL_SIZE, mPluginInfos[i].prettyName.c_str());
       U32 bindingWidth = getStringWidth(DOCK_LABEL_SIZE, mPluginInfos[i].binding.c_str());

--- a/zap/UIEditor.cpp
+++ b/zap/UIEditor.cpp
@@ -901,9 +901,11 @@ void EditorUserInterface::runPlugin(const FolderManager *folderManager, const st
    // Restore previous values, if available
    string key = getPluginSignature();
 
-   if(mPluginMenuValues.count(key) == 1)    // i.e. the key exists; use count to avoid creating new entry if it does not exist
-      for(S32 i = 0; i < mPluginMenuValues[key].size(); ++i)
+   if(mPluginMenuValues.count(key) == 1) {   // i.e. the key exists; use count to avoid creating new entry if it does not exist
+      S32 menu_sz = mPluginMenuValues[key].size();
+      for(S32 i = 0; i < menu_sz; ++i)
          mPluginMenu->getMenuItem(i)->setValue(mPluginMenuValues[key].get(i));
+   }
 
    getGame()->getUIManager()->activate(mPluginMenu.get());
 }
@@ -3657,7 +3659,8 @@ BfObject *EditorUserInterface::doMergePolygons(BfObject *firstItem, S32 firstIte
          firstItem->deleteVert(firstItem->getVertCount() - 1);
 
       // Add the new points
-      for(S32 i = 0; i < outputPolygons[0].size(); ++i)
+      S32 polys_sz = outputPolygons[0].size();
+      for(S32 i = 0; i < polys_sz; ++i)
          ok &= firstItem->addVert(outputPolygons[0][i], true);
 
       if(ok)

--- a/zap/UIEditorInstructions.cpp
+++ b/zap/UIEditorInstructions.cpp
@@ -251,7 +251,7 @@ EditorInstructionsUserInterface::EditorInstructionsUserInterface(ClientGame *gam
 
    string tabstr = "[[TAB_STOP:200]]";
 
-   for(S32 i = 0; i < mPluginPageCount; i++)
+   for(S32 i = 0; i < mPluginPageCount; ++i)
    {
       UI::SymbolStringSet pluginSymbolSet(10);
 
@@ -274,7 +274,7 @@ EditorInstructionsUserInterface::EditorInstructionsUserInterface(ClientGame *gam
 
       S32 start = i + (PLUGINS_PER_PAGE * i);
       S32 end = MIN(i + (PLUGINS_PER_PAGE * (i + 1)), pluginInfos->size());
-      for(S32 j = start; j < end; j++)
+      for(S32 j = start; j < end; ++j)
       {
          string binding = pluginInfos->get(j).binding;
 
@@ -305,7 +305,7 @@ EditorInstructionsUserInterface::EditorInstructionsUserInterface(ClientGame *gam
 
    TNLAssert(mPageHeaders.size() == NonPluginPageCount, "Wrong number of headers!");
 
-   for(S32 i = 0; i < mPluginPageCount; i++)
+   for(S32 i = 0; i < mPluginPageCount; ++i)
       mPageHeaders.push_back("PLUGINS PAGE " + itos(i+1));
 }
 
@@ -441,7 +441,7 @@ void EditorInstructionsUserInterface::renderPageWalls() const
       Vector<Vector<Point> > segmentData;
       barrierLineToSegmentData(points, segmentData);
 
-      for(S32 i = 0; i < segmentData.size(); i++)
+      for(S32 i = 0; i < segmentData.size(); ++i)
       {
          // Create a new segment, and add it to the list.  The WallSegment constructor will add it to the specified database.
          WallSegment *newSegment = new WallSegment(mWallSegmentManager.getWallSegmentDatabase(),
@@ -452,7 +452,7 @@ void EditorInstructionsUserInterface::renderPageWalls() const
       Vector<Point> edges;
       mWallSegmentManager.clipAllWallEdges(&wallSegments, edges);      // Remove interior wall outline fragments
 
-      for(S32 i = 0; i < wallSegments.size(); i++)
+      for(S32 i = 0; i < wallSegments.size(); ++i)
       {
          WallSegment *wallSegment = static_cast<WallSegment *>(wallSegments[i]);
          wallSegment->renderFill(Point(0,0), Colors::EDITOR_WALL_FILL_COLOR);
@@ -460,7 +460,7 @@ void EditorInstructionsUserInterface::renderPageWalls() const
 
       renderWallEdges(edges, *getGame()->getSettings()->getWallOutlineColor());
 
-      for(S32 i = 0; i < wallSegments.size(); i++)
+      for(S32 i = 0; i < wallSegments.size(); ++i)
          delete wallSegments[i];
    }
 
@@ -472,7 +472,7 @@ void EditorInstructionsUserInterface::renderPageWalls() const
 
    FontManager::pushFontContext(OldSkoolContext);
 
-   for(S32 i = 0; i < points.size(); i++)
+   for(S32 i = 0; i < points.size(); ++i)
    {
       S32 vertNum = S32(((F32)i  / 2) + 0.5);     // Ick!
 
@@ -505,7 +505,8 @@ void EditorInstructionsUserInterface::onPageChanged()
 
 void EditorInstructionsUserInterface::nextPage()
 {
-   mCurPage++;
+   ++mCurPage;
+
    if(mCurPage == getPageCount())
       mCurPage = 0;
 
@@ -515,7 +516,8 @@ void EditorInstructionsUserInterface::nextPage()
 
 void EditorInstructionsUserInterface::prevPage()
 {
-   mCurPage--;
+   --mCurPage;
+
    if(mCurPage < 0)
       mCurPage = getPageCount() - 1;
 
@@ -530,7 +532,8 @@ void EditorInstructionsUserInterface::idle(U32 timeDelta)
    if(mAnimTimer.update(timeDelta))
    {
       mAnimTimer.reset();
-      mAnimStage++;
+      ++mAnimStage;
+
       if(mAnimStage >= 18)
          mAnimStage = 0;
    }

--- a/zap/UIEditorMenus.cpp
+++ b/zap/UIEditorMenus.cpp
@@ -140,7 +140,7 @@ void QuickMenuUI::render()
 
    S32 y = yStart;
 
-   for(S32 i = 0; i < getMenuItemCount(); i++)
+   for(S32 i = 0; i < getMenuItemCount(); ++i)
    {
       MenuItemSize size = getMenuItem(i)->getSize();
       S32 itemTextSize = getTextSize(size);
@@ -240,7 +240,7 @@ S32 QuickMenuUI::getMenuWidth()
 {
    S32 width = 0;
 
-   for(S32 i = 0; i < getMenuItemCount(); i++)
+   for(S32 i = 0; i < getMenuItemCount(); ++i)
    {
       S32 itemWidth = getMenuItem(i)->getWidth(getTextSize(getMenuItem(i)->getSize()));
 

--- a/zap/UIErrorMessage.cpp
+++ b/zap/UIErrorMessage.cpp
@@ -44,7 +44,7 @@ void AbstractMessageUserInterface::setMessage(const string &message)
 
    InputCodeManager *inputCodeManager = getGame()->getSettings()->getInputCodeManager();
 
-   for(S32 i = 0; i < wrappedLines.size(); i++)
+   for(S32 i = 0; i < wrappedLines.size(); ++i)
       mMessage[i] = SymbolShapePtr(new SymbolString(wrappedLines[i], inputCodeManager, Context, TextHeight, true));
 
    mMaxLines = wrappedLines.size();
@@ -86,7 +86,7 @@ void AbstractMessageUserInterface::quit()
 
 void AbstractMessageUserInterface::reset()
 {
-   for(S32 i = 0; i < MAX_LINES; i++)
+   for(S32 i = 0; i < MAX_LINES; ++i)
       mMessage[i] = SymbolShapePtr(new SymbolBlank());
 
    mMaxLines = MAX_LINES;

--- a/zap/UIGame.cpp
+++ b/zap/UIGame.cpp
@@ -82,7 +82,7 @@ GameUserInterface::GameUserInterface(ClientGame *game) :
 
    mFiring = false;
 
-   for(U32 i = 0; i < (U32)ShipModuleCount; i++)
+   for(U32 i = 0; i < (U32)ShipModuleCount; ++i)
    {
       mModPrimaryActivated[i] = false;
       mModSecondaryActivated[i] = false;
@@ -143,7 +143,7 @@ void GameUserInterface::onActivate()
 
    mHelperManager.reset();
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
    {
       mModPrimaryActivated[i]   = false;
       mModSecondaryActivated[i] = false;
@@ -163,7 +163,7 @@ void GameUserInterface::onReactivate()
    if(!isChatting())
       getGame()->setBusyChatting(false);
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
    {
       mModPrimaryActivated[i]   = false;
       mModSecondaryActivated[i] = false;
@@ -324,7 +324,7 @@ void GameUserInterface::idle(U32 timeDelta)
    if(mAnnouncementTimer.update(timeDelta))
       mAnnouncement = "";
 
-   for(U32 i = 0; i < (U32)ShipModuleCount; i++)
+   for(U32 i = 0; i < (U32)ShipModuleCount; ++i)
       mModuleDoubleTapTimer[i].update(timeDelta);
 
    // Messages
@@ -656,7 +656,7 @@ void GameUserInterface::renderMsgBox(const string *message, S32 msgLines) const
 {
    Vector<SymbolShapePtr> messages(msgLines);
 
-   for(S32 i = 0; i < msgLines; i++)
+   for(S32 i = 0; i < msgLines; ++i)
       messages.push_back(SymbolShapePtr(new SymbolString(message[i], NULL, ErrorMsgContext, 30, true)));
 
    // Use empty shared pointer instead of NULL
@@ -735,7 +735,7 @@ void GameUserInterface::prepareStars()
    static const Color starColor(0.8f, 0.8f, 1.0f);
 
    // Create some random stars
-   for(S32 i = 0; i < NumStars; i++)
+   for(S32 i = 0; i < NumStars; ++i)
    {
       // Positions
       mStars[i].set(TNL::Random::readF(), TNL::Random::readF());    // Between 0 and 1
@@ -758,7 +758,7 @@ void GameUserInterface::prepareStars()
    }
 
    // //Create some random hexagons
-   //for(U32 i = 0; i < NumStars; i++)
+   //for(U32 i = 0; i < NumStars; ++i)
    //{
    //   F32 x = TNL::Random::readF();
    //   F32 y = TNL::Random::readF();
@@ -766,7 +766,7 @@ void GameUserInterface::prepareStars()
    //   F32 size = TNL::Random::readF() * .1;
 
 
-   //   for(S32 j = 0; j < 6; j++)
+   //   for(S32 j = 0; j < 6; ++j)
    //   {
    //      mStars[i * 6 + j].x = x + sin(ang + Float2Pi / 6 * j) * size;      // Between 0 and 1
    //      mStars[i * 6 + j].y = y + cos(ang + Float2Pi / 6 * j) * size;
@@ -825,7 +825,7 @@ void GameUserInterface::renderProgressBar() const
       // whole mechanism is used for is to display something to the user, this should work fine.
       F32 barWidth = mShowProgressBar ? S32((F32) width * (F32) getGame()->mObjectsLoaded / (F32) gt->mObjectsExpected) : width;
 
-      for(S32 i = 1; i >= 0; i--)
+      for(S32 i = 1; i >= 0; --i)
       {
          F32 w = i ? width : barWidth;
 
@@ -1817,7 +1817,7 @@ Move *GameUserInterface::getCurrentMove()
 
       mCurrentMove.fire = mFiring;
 
-      for(U32 i = 0; i < (U32)ShipModuleCount; i++)
+      for(U32 i = 0; i < (U32)ShipModuleCount; ++i)
       {
          mCurrentMove.modulePrimary[i]   = mModPrimaryActivated[i];
          mCurrentMove.moduleSecondary[i] = mModSecondaryActivated[i];
@@ -1830,7 +1830,7 @@ Move *GameUserInterface::getCurrentMove()
 
       mCurrentMove.fire = mFiring;     // should be false?
 
-      for(U32 i = 0; i < (U32)ShipModuleCount; i++)
+      for(U32 i = 0; i < (U32)ShipModuleCount; ++i)
       {
          mCurrentMove.modulePrimary[i] = false;
          mCurrentMove.moduleSecondary[i] = false;
@@ -1952,7 +1952,7 @@ void GameUserInterface::renderTalkingClients() const
 {
    S32 y = 150;
 
-   for(S32 i = 0; i < getGame()->getClientCount(); i++)
+   for(S32 i = 0; i < getGame()->getClientCount(); ++i)
    {
       ClientInfo *client = ((Game *)getGame())->getClientInfo(i);
 
@@ -2099,7 +2099,7 @@ void GameUserInterface::renderGameNormal()
 
    // Cast objects in rawRenderObjects and put them in renderObjects
    renderObjects.clear();
-   for(S32 i = 0; i < rawRenderObjects.size(); i++)
+   for(S32 i = 0; i < rawRenderObjects.size(); ++i)
       renderObjects.push_back(static_cast<BfObject *>(rawRenderObjects[i]));
 
    // Normally a big no-no, we'll access the server's bot zones directly if we are running locally
@@ -2116,12 +2116,12 @@ void GameUserInterface::renderGameNormal()
    // Render in three passes, to ensure some objects are drawn above others
    bool hasTileWalls = (GameType::getTilePolys().size() > 0);
 
-   for(S32 i = -1; i < 2; i++)
+   for(S32 i = -1; i < 2; ++i)
    {
       if(mDebugOverlayRenderer.renderingMeshZones())
          mDebugOverlayRenderer.renderMeshZones(i);
 
-      for(S32 j = 0; j < renderObjects.size(); j++)
+      for(S32 j = 0; j < renderObjects.size(); ++j)
          renderObjects[j]->renderLayer(i);
 
       mFxManager.render(i, getCommanderZoomFraction());
@@ -2178,8 +2178,8 @@ void GameUserInterface::renderInlineHelpItemOutlines(S32 playerTeam, F32 alpha) 
 
    const Vector<HighlightItem> *itemsToHighlight = mHelpItemManager.getItemsToHighlight();
 
-   for(S32 i = 0; i < itemsToHighlight->size(); i++)
-      for(S32 j = 0; j < renderObjects.size(); j++)
+   for(S32 i = 0; i < itemsToHighlight->size(); ++i)
+      for(S32 j = 0; j < renderObjects.size(); ++j)
          if(itemsToHighlight->get(i).type == renderObjects[j]->getObjectTypeNumber() &&
                                              renderObjects[j]->shouldRender())
          {
@@ -2215,7 +2215,7 @@ void GameUserInterface::renderInlineHelpItemOutlines(S32 playerTeam, F32 alpha) 
       fillVector.clear();
       getGame()->getGameObjDatabase()->findObjects(itemTypes, fillVector, *getGame()->getWorldExtents());
       polygons.clear();
-      for(S32 i = 0; i < fillVector.size(); i++)
+      for(S32 i = 0; i < fillVector.size(); ++i)
          if(static_cast<BfObject *>(fillVector[i])->shouldRender())
             polygons.push_back(fillVector[i]->getOutline());
    }
@@ -2227,7 +2227,7 @@ void GameUserInterface::renderInlineHelpItemOutlines(S32 playerTeam, F32 alpha) 
 
       offsetPolygons(polygons, outlines, HIGHLIGHTED_OBJECT_BUFFER_WIDTH);
 
-      for(S32 j = 0; j < outlines.size(); j++)
+      for(S32 j = 0; j < outlines.size(); ++j)
          renderPolygonOutline(&outlines[j], &Colors::green, alpha);
    }
 }
@@ -2294,7 +2294,7 @@ void GameUserInterface::renderGameCommander()
    renderObjects.clear();
 
    // Copy rawRenderObjects into renderObjects
-   for(S32 i = 0; i < rawRenderObjects.size(); i++)
+   for(S32 i = 0; i < rawRenderObjects.size(); ++i)
       renderObjects.push_back(static_cast<BfObject *>(rawRenderObjects[i]));
 
    // Add extra bots if we're showing them
@@ -2315,7 +2315,7 @@ void GameUserInterface::renderGameCommander()
          playerTeam = ship->getTeam();
          Color teamColor = *ship->getColor();
 
-         for(S32 i = 0; i < renderObjects.size(); i++)
+         for(S32 i = 0; i < renderObjects.size(); ++i)
          {
             // Render ship visibility range, and that of our teammates
             if(isShipType(renderObjects[i]->getObjectTypeNumber()))
@@ -2338,7 +2338,7 @@ void GameUserInterface::renderGameCommander()
          const Vector<DatabaseObject *> *spyBugs = getGame()->getGameObjDatabase()->findObjects_fast(SpyBugTypeNumber);
 
          // Render spy bug visibility range second, so ranges appear above ship scanner range
-         for(S32 i = 0; i < spyBugs->size(); i++)
+         for(S32 i = 0; i < spyBugs->size(); ++i)
          {
             SpyBug *sb = static_cast<SpyBug *>(spyBugs->get(i));
 
@@ -2361,7 +2361,7 @@ void GameUserInterface::renderGameCommander()
    bool hasTileWalls = (GameType::getTilePolys().size() > 0);
 
    // First pass
-   for(S32 i = 0; i < renderObjects.size(); i++)
+   for(S32 i = 0; i < renderObjects.size(); ++i)
       renderObjects[i]->renderLayer(0);
 
    // Render tiled wall geometry
@@ -2381,7 +2381,7 @@ void GameUserInterface::renderGameCommander()
    if(mDebugOverlayRenderer.renderingEdgeIds())
       mDebugOverlayRenderer.renderEdgeIds(getGame());
 
-   for(S32 i = 0; i < renderObjects.size(); i++)
+   for(S32 i = 0; i < renderObjects.size(); ++i)
    {
       // Keep our spy bugs from showing up on enemy commander maps, even if they're known
  //     if(!(renderObjects[i]->getObjectTypeMask() & SpyBugType && playerTeam != renderObjects[i]->getTeam()))
@@ -2457,16 +2457,16 @@ void GameUserInterface::renderGameCommander()
 //      mGameObjDatabase->findObjects((TestFunc)isVisibleOnCmdrsMapType, rawRenderObjects);
 //
 //   renderObjects.clear();
-//   for(S32 i = 0; i < rawRenderObjects.size(); i++)
+//   for(S32 i = 0; i < rawRenderObjects.size(); ++i)
 //      renderObjects.push_back(static_cast<BfObject *>(rawRenderObjects[i]));
 //
 //
 //   renderObjects.sort(renderSortCompare);
 //
-//   for(S32 i = 0; i < renderObjects.size(); i++)
+//   for(S32 i = 0; i < renderObjects.size(); ++i)
 //      renderObjects[i]->render(0);
 //
-//   for(S32 i = 0; i < renderObjects.size(); i++)
+//   for(S32 i = 0; i < renderObjects.size(); ++i)
 //      // Keep our spy bugs from showing up on enemy commander maps, even if they're known
 // //     if(!(renderObjects[i]->getObjectTypeMask() & SpyBugType && playerTeam != renderObjects[i]->getTeam()))
 //         renderObjects[i]->render(1);

--- a/zap/UIGameParameters.cpp
+++ b/zap/UIGameParameters.cpp
@@ -108,7 +108,7 @@ void GameParamUserInterface::clearCurrentGameTypeParams()
 {
    const Vector<string> keys = getGame()->getGameType()->getGameParameterMenuKeys();
 
-   for(S32 i = 0; i < keys.size(); i++)
+   for(S32 i = 0; i < keys.size(); ++i)
    {
       MenuItemMap::iterator iter = mMenuItemMap.find(keys[i]);
 
@@ -178,7 +178,7 @@ void GameParamUserInterface::updateMenuItems()
 
    const Vector<string> keys = gameType->getGameParameterMenuKeys();
 
-   for(S32 i = 0; i < keys.size(); i++)
+   for(S32 i = 0; i < keys.size(); ++i)
    {
       MenuItemMap::iterator iter = mMenuItemMap.find(keys[i]);
 
@@ -214,7 +214,7 @@ void GameParamUserInterface::onEscape()
 
    const Vector<string> keys = gameType->getGameParameterMenuKeys();
 
-   for(S32 i = 0; i < keys.size(); i++)
+   for(S32 i = 0; i < keys.size(); ++i)
    {
       MenuItemMap::iterator iter = mMenuItemMap.find(keys[i]);
 

--- a/zap/UIHighScores.cpp
+++ b/zap/UIHighScores.cpp
@@ -71,7 +71,7 @@ void HighScoresUserInterface::renderScores()
    S32 col = 0;   // 0 = left col, 1 = right col
    S32 yStart;
 
-   for(S32 i = 0; i < mScoreGroups.size(); i++)
+   for(S32 i = 0; i < mScoreGroups.size(); ++i)
    {
       yStart = y;    // For future reference
 
@@ -91,7 +91,7 @@ void HighScoresUserInterface::renderScores()
       S32 w = -1;
 
       // Now draw names
-      for(S32 j = 0; j < mScoreGroups[i].names.size(); j++)
+      for(S32 j = 0; j < mScoreGroups[i].names.size(); ++j)
       {
          r.setColor(Colors::cyan);
 
@@ -140,7 +140,7 @@ void HighScoresUserInterface::renderWaitingForScores()
       Vector<string> lines;
       wrapString("Retrieving scores from Master Server", UIManager::MessageBoxWrapWidth, 18, ErrorMsgContext, lines);
 
-      for(S32 i = 0; i < lines.size(); i++)
+      for(S32 i = 0; i < lines.size(); ++i)
          symbolSet.add(SymbolString::getSymbolText(lines[i], 30, ErrorMsgContext, &Colors::blue));
 
       symbolSet.add(SymbolString(SymbolString::getBlankSymbol(0, 10)));
@@ -174,7 +174,7 @@ void HighScoresUserInterface::setHighScores(Vector<StringTableEntry> groupNames,
 
    S32 scoresPerGroup = names.size() / groupNames.size();
 
-   for(S32 i = 0; i < groupNames.size(); i++)
+   for(S32 i = 0; i < groupNames.size(); ++i)
    {
       ScoreGroup scoreGroup;
       Vector<string> currNames;
@@ -183,7 +183,7 @@ void HighScoresUserInterface::setHighScores(Vector<StringTableEntry> groupNames,
 
       scoreGroup.title = string(groupNames[i].getString());
 
-      for(S32 j = 0; j < scoresPerGroup; j++)
+      for(S32 j = 0; j < scoresPerGroup; ++j)
       {
          currNames .push_back(names [i * scoresPerGroup + j]);
          currScores.push_back(scores[i * scoresPerGroup + j]);

--- a/zap/UIInstructions.cpp
+++ b/zap/UIInstructions.cpp
@@ -398,7 +398,7 @@ static void initPage2Block(const char **block, S32 blockSize, S32 fontSize, cons
 {
    Vector<SymbolShapePtr> symbols;
 
-   for(S32 i = 0; i < blockSize; i++)
+   for(S32 i = 0; i < blockSize; ++i)
    {
       if(i == 0)  // First line is a little different than the rest
       {
@@ -520,7 +520,7 @@ static S32 renderBadges(S32 y, S32 textSize, S32 descSize)
       { BADGE_LAST_SECOND_WIN,     "Last-Second Win",     "Win a CTF match by scoring in the last second" },
    };
 
-   for(U32 i = 0; i < ARRAYSIZE(badgeDescrs); i++)
+   for(U32 i = 0; i < ARRAYSIZE(badgeDescrs); ++i)
    {
       renderBadgeLine(y, textSize, badgeDescrs[i].badge, radius, badgeDescrs[i].name, badgeDescrs[i].descr);
       y += 26;
@@ -567,7 +567,7 @@ void InstructionsUserInterface::renderModulesPage() const
 
    r.setColor(Colors::white);
 
-   for(U32 i = 0; i < ARRAYSIZE(moduleInstructions); i++)
+   for(U32 i = 0; i < ARRAYSIZE(moduleInstructions); ++i)
    {
       if(i == 2)
          r.setColor(Colors::green);
@@ -584,7 +584,7 @@ void InstructionsUserInterface::renderModulesPage() const
    y += 35;
 
 
-   for(U32 i = 0; i < ARRAYSIZE(moduleDescriptions); i++)
+   for(U32 i = 0; i < ARRAYSIZE(moduleDescriptions); ++i)
    {
       S32 x = 235;
       r.setColor(Colors::yellow);
@@ -738,7 +738,7 @@ void InstructionsUserInterface::renderPageObjectDesc(U32 index) const
 
    static const S32 FontSize = 20;
 
-   for(U32 i = startIndex; i < endIndex; i++)
+   for(U32 i = startIndex; i < endIndex; ++i)
    {
       const char *text = gGameObjectInfo[i * 2];
       Vector<string> desc = wrapString(gGameObjectInfo[i * 2 + 1], 350, FontSize);
@@ -753,7 +753,7 @@ void InstructionsUserInterface::renderPageObjectDesc(U32 index) const
       renderCenteredString(start, FontSize, text);
 
       r.setColor(Colors::white);
-      for(S32 j = 0; j < desc.size(); j++)
+      for(S32 j = 0; j < desc.size(); ++j)
          renderCenteredString(start + Point(0, 25 + j * FontSize * 1.2), 17, desc[j].c_str());
 
       r.pushMatrix();
@@ -997,7 +997,7 @@ void InstructionsUserInterface::renderPageCommands(U32 page, const char *msg) co
    bool first = true;
    S32 section = -1;
 
-   for(S32 i = 0; i < ChatHelper::chatCmdSize && U32(chatCmds[i].helpCategory) <= page; i++)
+   for(S32 i = 0; i < ChatHelper::chatCmdSize && U32(chatCmds[i].helpCategory) <= page; ++i)
    {
       if(U32(chatCmds[i].helpCategory) < page)
          continue;
@@ -1026,7 +1026,7 @@ void InstructionsUserInterface::renderPageCommands(U32 page, const char *msg) co
       string cmdString = "/" + chatCmds[i].cmdName;
       string args = "";
 
-      for(S32 j = 0; j < chatCmds[i].cmdArgCount; j++)
+      for(S32 j = 0; j < chatCmds[i].cmdArgCount; ++j)
          args += " " + chatCmds[i].helpArgString[j];
 
       S32 w = drawStringAndGetWidth(cmdCol, ypos, cmdSize, cmdString.c_str());
@@ -1067,7 +1067,7 @@ void InstructionsUserInterface::initGameTypesPage()
    symbols.push_back(SymbolString::getBlankSymbol(0, 10));
    mGameTypeInstrs.add(SymbolString(symbols));
 
-   for(U32 i = 0; i < ARRAYSIZE(typeDescriptions); i++)
+   for(U32 i = 0; i < ARRAYSIZE(typeDescriptions); ++i)
    {
       if(typeDescriptions[i].isTeamGame && !foundTeamGame)
       {
@@ -1080,7 +1080,7 @@ void InstructionsUserInterface::initGameTypesPage()
       }
 
       Vector<string> lines = wrapString(typeDescriptions[i].description, 600, FontSize);
-      for(S32 j = 0; j < lines.size(); j++)
+      for(S32 j = 0; j < lines.size(); ++j)
       {
          symbols.clear();
 
@@ -1112,7 +1112,8 @@ void InstructionsUserInterface::renderPageGameTypes() const
 
 void InstructionsUserInterface::nextPage()
 {
-   mCurPage++;
+   ++mCurPage;
+
 
    if(mCurPage > InstructionMaxPages - 1)
       mCurPage = 0;
@@ -1121,7 +1122,8 @@ void InstructionsUserInterface::nextPage()
 
 void InstructionsUserInterface::prevPage()
 {
-   mCurPage--;
+   --mCurPage;
+
 
    if(mCurPage < 0)
       mCurPage = InstructionMaxPages - 1;

--- a/zap/UIKeyDefMenu.cpp
+++ b/zap/UIKeyDefMenu.cpp
@@ -178,7 +178,7 @@ void KeyDefMenuUserInterface::onActivate()
 
    S32 itemCount[] = { 0, 0 };
 
-   for(S32 i = 0; i < menuItems.size(); i++)
+   for(S32 i = 0; i < menuItems.size(); ++i)
       itemCount[menuItems[i].column - 1]++;
 
    maxMenuItemsInAnyCol = MAX(itemCount[0], itemCount[1]);
@@ -202,9 +202,10 @@ bool KeyDefMenuUserInterface::isDuplicate(S32 key, const Vector<KeyDefMenuItem> 
 
    InputCode targetInputCode = getInputCode(settings, menuItems[key].primaryControl);
 
-   for(S32 i = 0; i < size && count < 2; i++)
+   for(S32 i = 0; i < size && count < 2; ++i)
       if(getInputCode(settings, menuItems[i].primaryControl) == targetInputCode)
-         count++;
+         ++count;
+
 
    return count >= 2;
 }
@@ -234,7 +235,7 @@ void KeyDefMenuUserInterface::render()
 
    S32 size = menuItems.size();
 
-   for(S32 i = 0; i < size; i++)
+   for(S32 i = 0; i < size; ++i)
    {
       S32 y = yStart + (i - ((i < firstItemInCol2) ? 0 : firstItemInCol2)) * height;
 
@@ -360,7 +361,8 @@ bool KeyDefMenuUserInterface::onKeyDown(InputCode inputCode)
       {
          selectedIndex -= firstItemInCol2;
          while(menuItems[selectedIndex].column == 2)
-            selectedIndex--;
+            --selectedIndex;
+
       }
 
       Cursor::disableCursor();                    // Turn off cursor
@@ -376,7 +378,8 @@ bool KeyDefMenuUserInterface::onKeyDown(InputCode inputCode)
    {
       playBoop();
 
-      selectedIndex--;
+      --selectedIndex;
+
       if(selectedIndex < 0)
          selectedIndex = menuItems.size() - 1;
 
@@ -386,7 +389,8 @@ bool KeyDefMenuUserInterface::onKeyDown(InputCode inputCode)
    {
       playBoop();
 
-      selectedIndex++;
+      ++selectedIndex;
+
       if(selectedIndex >= menuItems.size())
          selectedIndex = 0;
 
@@ -421,10 +425,12 @@ void KeyDefMenuUserInterface::onMouseMoved()
    // section of the controls.
    if(col == 0)
       while(menuItems[selectedIndex].column == 2)
-         selectedIndex--;
+         --selectedIndex;
+
    else
       while(menuItems[selectedIndex].column == 1)
-         selectedIndex++;
+         ++selectedIndex;
+
 }
 
 

--- a/zap/UIManager.cpp
+++ b/zap/UIManager.cpp
@@ -135,7 +135,7 @@ bool UIManager::hasPrevUI()
 
 void UIManager::clearPrevUIs()
 {
-   //for(UiIterator it = mUis.begin(); it != mUis.end(); it++)
+   //for(UiIterator it = mUis.begin(); it != mUis.end(); ++it)
    //   delete it->second;
 
    mUis.clear();
@@ -156,7 +156,7 @@ void UIManager::renderPrevUI(const UserInterface *ui)
       return;
    }
 
-   for(S32 i = mPrevUIs.size() - 1; i > 0; i--)    // Not >= 0, because of the [i-1] below
+   for(S32 i = mPrevUIs.size() - 1; i > 0; --i)    // Not >= 0, because of the [i-1] below
       if(mPrevUIs[i] == ui)
       {
          mPrevUIs[i-1]->render();
@@ -218,7 +218,7 @@ void UIManager::printUIStack()
          logprintf("%s (current)", x.first->name());
 
    // Print stack, starting from most recent UI
-   for(int i = mPrevUIs.size() - 1; i > 0; i--)
+   for(int i = mPrevUIs.size() - 1; i > 0; --i)
       for(auto const& x : mUis)
          if(x.second.get() == mPrevUIs[i])
             logprintf("%s", x.first->name());
@@ -776,7 +776,7 @@ void UIManager::displayMessageBox(const StringTableEntry &title, const StringTab
                                   const Vector<StringTableEntry> &messages)
 {
    string msg = "";
-   for(S32 i = 0; i < messages.size(); i++)
+   for(S32 i = 0; i < messages.size(); ++i)
       msg += string(messages[i].getString()) + "\n";
 
    displayMessageBox(title.getString(), instr.getString(), msg);
@@ -787,7 +787,7 @@ void UIManager::displayMessageBox(const string &title, const string &instr, cons
 {
    string msg = "";
 
-   for(S32 i = 0; i < messages.size(); i++)
+   for(S32 i = 0; i < messages.size(); ++i)
       msg += messages[i] + "\n";
 
    displayMessageBox(title, instr, msg);

--- a/zap/UIManager.h
+++ b/zap/UIManager.h
@@ -111,7 +111,7 @@ public:
    template <typename T>
    bool cameFrom()
    {
-      for(S32 i = 0; i < mPrevUIs.size(); i++)
+      for(S32 i = 0; i < mPrevUIs.size(); ++i)
          if(mPrevUIs[i] == mUis[getTypeInfo<T>()].get())
             return true;
 

--- a/zap/UIMenuItems.cpp
+++ b/zap/UIMenuItems.cpp
@@ -464,7 +464,7 @@ bool ToggleMenuItem::handleKey(InputCode inputCode)
 void ToggleMenuItem::handleTextInput(char ascii)
 {
    if(ascii)     // Check for the first key of a menu entry.
-      for(S32 i = 0; i < mOptions.size(); i++)
+      for(S32 i = 0; i < mOptions.size(); ++i)
       {
          S32 index = (i + mIndex + 1) % mOptions.size();
          if(toLower(ascii) == toLower(mOptions[index].data()[0]))

--- a/zap/UIMenus.cpp
+++ b/zap/UIMenus.cpp
@@ -286,7 +286,7 @@ static void renderArrow(S32 pos, bool pointingUp)
          F32(canvasWidth) / 2,               F32(y)
    };
 
-   for(S32 i = 1; i >= 0; i--)
+   for(S32 i = 1; i >= 0; --i)
    {
       // First create a black poly to blot out what's behind, then the arrow itself
       r.setColor(i ? Colors::black : Colors::blue);
@@ -352,7 +352,7 @@ void MenuUserInterface::render()
 
    S32 y = yStart;
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       MenuItemSize size = getMenuItem(i)->getSize();
       S32 textsize = getTextSize(size);
@@ -442,7 +442,7 @@ S32 MenuUserInterface::getMaxFirstItemIndex()
 // Fill responses with values from each menu item in turn
 void MenuUserInterface::getMenuResponses(Vector<string> &responses)
 {
-   for(S32 i = 0; i < mMenuItems.size(); i++)
+   for(S32 i = 0; i < mMenuItems.size(); ++i)
       responses.push_back(mMenuItems[i]->getValue());
 }
 
@@ -483,7 +483,7 @@ S32 MenuUserInterface::getSelectedMenuItem()
       return mFirstVisibleItem;
 
    // Mouse is on the menu
-   for(S32 i = 0; i < getMenuItemCount() - 1; i++)
+   for(S32 i = 0; i < getMenuItemCount() - 1; ++i)
    {
       MenuItemSize size = getMenuItem(i)->getSize();
       S32 height = getGap(size) / 2 + getTextSize(size);
@@ -509,7 +509,8 @@ void MenuUserInterface::processMouse()
       {
          if(!mScrollTimer.getCurrent() && mFirstVisibleItem > 0)
          {
-            mFirstVisibleItem--;
+            --mFirstVisibleItem;
+
             mScrollTimer.reset(MOUSE_SCROLL_INTERVAL);
          }
          selectedIndex = mFirstVisibleItem;
@@ -518,7 +519,8 @@ void MenuUserInterface::processMouse()
       {
          if(!mScrollTimer.getCurrent() && selectedIndex > mFirstVisibleItem + mMaxMenuSize - 2)
          {
-            mFirstVisibleItem++;
+            ++mFirstVisibleItem;
+
             mScrollTimer.reset(MOUSE_SCROLL_INTERVAL);
          }
          selectedIndex = mFirstVisibleItem + mMaxMenuSize - 1;
@@ -627,7 +629,7 @@ bool MenuUserInterface::processMenuSpecificKeys(InputCode inputCode)
       return false;
 
    // Check for some shortcut keys
-   for(S32 i = 0; i < mMenuItems.size(); i++)
+   for(S32 i = 0; i < mMenuItems.size(); ++i)
    {
       if(inputCode == mMenuItems[i]->key1 || inputCode == mMenuItems[i]->key2)
       {
@@ -646,7 +648,7 @@ bool MenuUserInterface::processMenuSpecificKeys(InputCode inputCode)
 S32 MenuUserInterface::getTotalMenuItemHeight()
 {
    S32 height = 0;
-   for(S32 i = 0; i < mMenuItems.size(); i++)
+   for(S32 i = 0; i < mMenuItems.size(); ++i)
    {
       MenuItemSize size = mMenuItems[i]->getSize();
       height += getTextSize(size) + getGap(size);
@@ -704,7 +706,8 @@ bool MenuUserInterface::processKeys(InputCode inputCode)
    }
    else if(inputCode == KEY_UP || (inputCode == KEY_TAB && InputCodeManager::checkModifier(KEY_SHIFT)))   // Prev item
    {
-      selectedIndex--;
+      --selectedIndex;
+
       itemSelectedWithMouse = false;
 
       if(selectedIndex < 0)                        // Scrolling off the top
@@ -752,7 +755,8 @@ void MenuUserInterface::renderExtras() const
 
 void MenuUserInterface::advanceItem()
 {
-   selectedIndex++;
+   ++selectedIndex;
+
    itemSelectedWithMouse = false;
 
    if(selectedIndex >= mMenuItems.size())     // Scrolling off the bottom
@@ -1463,7 +1467,7 @@ void SoundOptionsMenuUserInterface::setupMenus()
 
    GameSettings *settings = getGame()->getSettings();
 
-   for(S32 i = 0; i <= 10; i++)
+   for(S32 i = 0; i <= 10; ++i)
       opts.push_back(getVolMsg( F32(i) / 10 ));
 
    addMenuItem(new ToggleMenuItem("SFX VOLUME:",        opts, U32((settings->getIniSettings()->sfxVolLevel + 0.05) * 10.0), false,
@@ -1865,11 +1869,13 @@ void NameEntryUserInterface::renderExtras() const
 
    Renderer::get().setColor(Colors::menuHelpColor);
 
-   row++;
+   ++row;
+
 
    drawCenteredString(canvasHeight - vertMargin - instrGap - (rows - row) * size - (rows - row) * gap, size,
             "A password is only needed if you are using a reserved name.  You can reserve your");
-   row++;
+   ++row;
+
 
    drawCenteredString(canvasHeight - vertMargin - instrGap - (rows - row) * size - (rows - row) * gap, size,
             "nickname by registering for the bitfighter.org forums.  Registration is free.");
@@ -2263,11 +2269,11 @@ void LevelMenuUserInterface::onActivate()
    addMenuItem(new MenuItem(ALL_LEVELS_MENUID, ALL_LEVELS, selectLevelTypeCallback, "", InputCodeManager::stringToInputCode(c)));
 
    // Cycle through all levels, looking for unique type strings
-   for(S32 i = 0; i < gc->mLevelInfos.size(); i++)
+   for(S32 i = 0; i < gc->mLevelInfos.size(); ++i)
    {
       bool found = false;
 
-      for(S32 j = 0; j < getMenuItemCount(); j++)
+      for(S32 j = 0; j < getMenuItemCount(); ++j)
          if(strcmp(gc->mLevelInfos[i].getLevelTypeName(), "") == 0 ||
             strcmp(gc->mLevelInfos[i].getLevelTypeName(), getMenuItem(j)->getPrompt().c_str()) == 0)
          {
@@ -2452,14 +2458,14 @@ void LevelMenuSelectUserInterface::onActivate()
       // Get all the playable levels in levelDir
       mLevels = getGame()->getSettings()->getLevelList();
 
-      for(S32 i = 0; i < mLevels.size(); i++)
+      for(S32 i = 0; i < mLevels.size(); ++i)
       {
          c[0] = mLevels[i].c_str()[0];
          addMenuItem(new MenuItem(i | UPLOAD_LEVELS_BIT, mLevels[i].c_str(), processLevelSelectionCallback, "", InputCodeManager::stringToInputCode(c)));
       }
    }
 
-   for(S32 i = 0; i < gc->mLevelInfos.size(); i++)
+   for(S32 i = 0; i < gc->mLevelInfos.size(); ++i)
    {
       if(gc->mLevelInfos[i].mLevelName == "")   // Skip levels with blank names --> but all should have names now!
          continue;
@@ -2520,7 +2526,7 @@ bool LevelMenuSelectUserInterface::processMenuSpecificKeys(InputCode inputCode)
    MenuItemSize size = getMenuItem(getOffset())->getSize();
    S32 y = getYStart();
 
-   for(S32 j = getOffset(); j < selectedIndex; j++)
+   for(S32 j = getOffset(); j < selectedIndex; ++j)
    {
       size = getMenuItem(j)->getSize();
       y += getTextSize(size) + getGap(size);
@@ -2569,7 +2575,8 @@ S32 LevelMenuSelectUserInterface::getIndexOfNext(const string &startingWithLc)
       if(offset == 0 && !first)
          break;
 
-      offset++;
+      ++offset;
+
       first = false;
    }
 
@@ -2611,7 +2618,7 @@ void PlayerMenuUserInterface::playerSelected(U32 index)
    // When we created the menu, names were not sorted, and item indices were assigned in "natural order".  Then
    // the menu items were sorted by name, and now the indices are now jumbled.  This bit here tries to get the
    // new, actual list index of an item given its original index.
-   for(S32 i = 0; i < getMenuItemCount(); i++)
+   for(S32 i = 0; i < getMenuItemCount(); ++i)
       if(getMenuItem(i)->getIndex() == (S32)index)
       {
          index = i;
@@ -2647,7 +2654,7 @@ void PlayerMenuUserInterface::render()
       return;
 
    char c[] = "A";      // Dummy shortcut key
-   for(S32 i = 0; i < getGame()->getClientCount(); i++)
+   for(S32 i = 0; i < getGame()->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = ((Game *)getGame())->getClientInfo(i);      // Lame!
 
@@ -2731,7 +2738,7 @@ void TeamMenuUserInterface::render()
    getGame()->countTeamPlayers();                     // Make sure numPlayers is correctly populated
 
    char c[] = "A";                                    // Dummy shortcut key, will change below
-   for(S32 i = 0; i < getGame()->getTeamCount(); i++)
+   for(S32 i = 0; i < getGame()->getTeamCount(); ++i)
    {
       AbstractTeam *team = getGame()->getTeam(i);
       strncpy(c, team->getName().getString(), 1);     // Grab first char of name for a shortcut key

--- a/zap/UIMessage.cpp
+++ b/zap/UIMessage.cpp
@@ -48,7 +48,7 @@ void MessageUserInterface::reset()
    mVertOffset = 0;
    mBox = true;
 
-   for(S32 i = 0; i < mNumLines; i++)
+   for(S32 i = 0; i < mNumLines; ++i)
       mMessage[i] = (char*)"";
 }
 
@@ -159,7 +159,7 @@ void MessageUserInterface::render()
    if(strcmp(mTitle, ""))  // If they are different
       drawCenteredString(vertMargin + hInset + mVertOffset, 30, mTitle);
 
-   for(S32 i = 0; i < mNumLines; i++)
+   for(S32 i = 0; i < mNumLines; ++i)
       drawCenteredString(vertMargin + 40 + hInset + i * 24 + mVertOffset, 18, mMessage[i]);
 
    if (!mFadeTime)

--- a/zap/UINameEntry.cpp
+++ b/zap/UINameEntry.cpp
@@ -189,7 +189,7 @@ void LevelNameEntryUserInterface::onActivate()
    mLevels = getGame()->getSettings()->getLevelList();
 
    // Remove the extension from the level file
-   for(S32 i = 0; i < mLevels.size(); i++)
+   for(S32 i = 0; i < mLevels.size(); ++i)
        mLevels[i] = stripExtension(mLevels[i]);
 
    mFoundLevel = setLevelIndex();
@@ -199,7 +199,7 @@ void LevelNameEntryUserInterface::onActivate()
 // See if the current level is on the list -- if so, set mLevelIndex to that level and return true
 bool LevelNameEntryUserInterface::setLevelIndex()
 {
-   for(S32 i = 0; i < mLevels.size(); i++)
+   for(S32 i = 0; i < mLevels.size(); ++i)
    {
       // Exact match
       if(mLevels[i] == lineEditor.getString())
@@ -209,7 +209,7 @@ bool LevelNameEntryUserInterface::setLevelIndex()
       }
    }
    // is mLevels sorted correctly?
-   for(S32 i = 0; i < mLevels.size(); i++)
+   for(S32 i = 0; i < mLevels.size(); ++i)
    {
       // No exact match, but we just passed the item and have selected the closest one alphabetically following
       if(mLevels[i] > lineEditor.getString())
@@ -239,10 +239,11 @@ bool LevelNameEntryUserInterface::onKeyDown(InputCode inputCode)
       {
          completePartial();      // Resets mFoundLevel
          if(!mFoundLevel)
-            mLevelIndex--;       // Counteract increment below
+            --mLevelIndex;       // Counteract increment below
       }
 
-      mLevelIndex++;
+      ++mLevelIndex;
+
       if(mLevelIndex >= mLevels.size())
          mLevelIndex = 0;
 
@@ -257,7 +258,8 @@ bool LevelNameEntryUserInterface::onKeyDown(InputCode inputCode)
       if(!mFoundLevel)
          completePartial();
 
-      mLevelIndex--;
+      --mLevelIndex;
+
       if(mLevelIndex < 0)
          mLevelIndex = mLevels.size() - 1;
 
@@ -314,7 +316,7 @@ void LevelNameEntryUserInterface::render()
    Renderer::get().setColor(Colors::gray20);
    FontManager::pushFontContext(MenuContext);
 
-   for(S32 i = startIndex; i <= endIndex; i++)
+   for(S32 i = startIndex; i <= endIndex; ++i)
    {
       if(i != mLevelIndex)
          drawCenteredString(TextEntryYPos + F32(i - mLevelIndex) * ((F32)fontSize * 2.0f), getFontSize(), mLevels[i].c_str());

--- a/zap/UIQueryServers.cpp
+++ b/zap/UIQueryServers.cpp
@@ -122,7 +122,8 @@ U32 QueryServersUserInterface::ServerRef::getNextId()
 {
    static U32 nextId = 0;
 
-   nextId++;
+   ++nextId;
+
    return nextId;
 }
 
@@ -225,7 +226,7 @@ void QueryServersUserInterface::onActivate()
 
 #if 0
    // Populate server list with dummy data to see how it looks
-   for(U32 i = 0; i < 512; i++)
+   for(U32 i = 0; i < 512; ++i)
    {
       char name[128];
       dSprintf(name, MaxServerNameLen, "Dummy Svr%8x", Random::readI());
@@ -268,7 +269,7 @@ void QueryServersUserInterface::contactEveryone()
    // Always ping these servers -- typically a local server
    Vector<string> *pingList = &getGame()->getSettings()->getIniSettings()->alwaysPingList;
 
-   for(S32 i = 0; i < pingList->size(); i++)
+   for(S32 i = 0; i < pingList->size(); ++i)
    {
       Address address(pingList->get(i).c_str());
       getGame()->getNetInterface()->sendPing(address, mLocalServerNonce);
@@ -279,7 +280,7 @@ void QueryServersUserInterface::contactEveryone()
    {
       Vector<string> *serverList = &getGame()->getSettings()->getIniSettings()->prevServerListFromMaster;
 
-      for(S32 i = 0; i < serverList->size(); i++)
+      for(S32 i = 0; i < serverList->size(); ++i)
          getGame()->getNetInterface()->sendPing(Address(serverList->get(i).c_str()), mRemoteServerNonce);
 
       mGivenUpOnMaster = true;
@@ -309,7 +310,7 @@ void QueryServersUserInterface::contactEveryone()
 // Returns index of found server, -1 if it found none
 static S32 findServerByAddress(const Vector<ServerAddr> &serverList, const Address &address)
 {
-   for(S32 i = 0; i < serverList.size(); i++)
+   for(S32 i = 0; i < serverList.size(); ++i)
       if(Address(serverList[i].ipAddress) == address)
          return i;
 
@@ -321,7 +322,7 @@ static S32 findServerByAddress(const Vector<ServerAddr> &serverList, const Addre
 static S32 findServerByAddressOrId(const Vector<QueryServersUserInterface::ServerRef> &serverList,
                                    const Address &address, S32 serverId)
 {
-   for(S32 i = 0; i < serverList.size(); i++)
+   for(S32 i = 0; i < serverList.size(); ++i)
       if(serverList[i].serverAddress == address || (serverId != 0 && serverList[i].serverId == serverId))
          return i;
 
@@ -333,7 +334,7 @@ static S32 findServerByAddressOrId(const Vector<QueryServersUserInterface::Serve
 static S32 findServerByServerId(const Vector<QueryServersUserInterface::ServerRef> &serverList, S32 serverId)
 {
    if(serverId != 0)
-      for(S32 i = 0; i < serverList.size(); i++)
+      for(S32 i = 0; i < serverList.size(); ++i)
          if(serverList[i].serverId == serverId)
             return i;
 
@@ -345,7 +346,7 @@ static S32 findServerByServerId(const Vector<QueryServersUserInterface::ServerRe
 static S32 findServerByAddressNonceState(const Vector<QueryServersUserInterface::ServerRef> &serverList, const Address &address,
                                          const Nonce &nonce, QueryServersUserInterface::ServerRef::State state)
 {
-   for(S32 i = 0; i < serverList.size(); i++)
+   for(S32 i = 0; i < serverList.size(); ++i)
       if(serverList[i].serverAddress == address && serverList[i].sendNonce == nonce && serverList[i].state == state)
          return i;
 
@@ -357,7 +358,7 @@ static S32 findServerByAddressNonceState(const Vector<QueryServersUserInterface:
 // not on the updated list from the master.  These will be servers that were alive, but have now disappeared.
 void QueryServersUserInterface::forgetServersNoLongerOnList(const Vector<ServerAddr> &serverListFromMaster)
 {
-   for(S32 i = servers.size() - 1; i >= 0; i--)
+   for(S32 i = servers.size() - 1; i >= 0; --i)
    {
       if(servers[i].isLocalServer)  // Skip local servers
          continue;
@@ -378,7 +379,7 @@ static void saveServerListToIni(GameSettings *settings, const Vector<ServerAddr>
       Vector<string> &prevServerList = settings->getIniSettings()->prevServerListFromMaster;
       prevServerList.clear();    // Only clear the saved list if we have something to add...
 
-      for(S32 i = 0; i < serverListFromMaster.size(); i++)
+      for(S32 i = 0; i < serverListFromMaster.size(); ++i)
          prevServerList.push_back(Address(serverListFromMaster[i].ipAddress).toString());
    }
 }
@@ -401,7 +402,7 @@ void QueryServersUserInterface::addServersToPingList(const Vector<ServerAddr> &s
    forgetServersNoLongerOnList(serverList);
 
    // Add any new servers to the server display
-   for(S32 i = 0; i < serverList.size(); i++)
+   for(S32 i = 0; i < serverList.size(); ++i)
    {
       // Is this server already in our list?
       S32 index = findServerByAddressOrId(servers, Address(serverList[i].ipAddress), serverList[i].id);
@@ -471,7 +472,8 @@ void QueryServersUserInterface::gotPingResponse(const Address &address, const No
          s.identityToken = clientIdentityToken;
          s.state = ServerRef::ReceivedPing;
 
-         pendingPings--;
+         --pendingPings;
+
       }
    }
 
@@ -483,7 +485,7 @@ void QueryServersUserInterface::gotQueryResponse(const Address &address, S32 ser
                                                  const char *serverName, const char *serverDescr, U32 playerCount,
                                                  U32 maxPlayers, U32 botCount, bool dedicated, bool test, bool passwordRequired)
 {
-   for(S32 i = 0; i < servers.size(); i++)
+   for(S32 i = 0; i < servers.size(); ++i)
    {
       ServerRef &s = servers[i];
       if(s.sendNonce == clientNonce && s.serverAddress == address && s.state == ServerRef::SentQuery)
@@ -525,7 +527,8 @@ void QueryServersUserInterface::gotQueryResponse(const Address &address, S32 ser
          if(s.state == ServerRef::SentQuery)
          {
             s.state = ServerRef::ReceivedQuery;
-            pendingQueries--;
+            --pendingQueries;
+
          }
       }
    }
@@ -543,24 +546,26 @@ void QueryServersUserInterface::idle(U32 timeDelta)
    mouseScrollTimer.update(timeDelta);
 
    // Timeout old pings and queries
-   for(S32 i = 0; i < servers.size(); i++)
+   for(S32 i = 0; i < servers.size(); ++i)
    {
       ServerRef &s = servers[i];
 
       if(s.state == ServerRef::SentPing && (time - s.lastSendTime) > PingQueryTimeout)
       {
          s.state = ServerRef::Start;
-         pendingPings--;
+         --pendingPings;
+
       }
       else if(s.state == ServerRef::SentQuery && (time - s.lastSendTime) > PingQueryTimeout)
       {
          s.state = ServerRef::ReceivedPing;
-         pendingQueries--;
+         --pendingQueries;
+
       }
    }
 
    // Send new pings
-   for(S32 i = 0; i < servers.size() ; i++)
+   for(S32 i = 0; i < servers.size() ; ++i)
    {
       if(pendingPings < MaxPendingPings)
       {
@@ -568,7 +573,8 @@ void QueryServersUserInterface::idle(U32 timeDelta)
          if(s.state == ServerRef::Start)     // This server is at the beginning of the process
          {
             s.pingTimedOut = false;
-            s.sendCount++;
+            ++s.sendCount;
+
             if(s.sendCount > PingQueryRetryCount)     // Ping has timed out, sadly
             {
                s.setDescr("No information: Server not responding to pings", Colors::red);
@@ -586,7 +592,8 @@ void QueryServersUserInterface::idle(U32 timeDelta)
                s.lastSendTime = time;
                s.sendNonce.getRandom();
                getGame()->getNetInterface()->sendPing(s.serverAddress, s.sendNonce);
-               pendingPings++;
+               ++pendingPings;
+
 
                if(pendingPings >= MaxPendingPings)
                   break;
@@ -597,14 +604,15 @@ void QueryServersUserInterface::idle(U32 timeDelta)
 
    // When all pings have been answered or have timed out, send out server status queries ... too slow
    // Want to start query immediately, to display server name / current players faster
-   for(S32 i = servers.size() - 1; i >= 0; i--)
+   for(S32 i = servers.size() - 1; i >= 0; --i)
    {
       if(pendingQueries < MaxPendingQueries)
       {
          ServerRef &s = servers[i];
          if(s.state == ServerRef::ReceivedPing)
          {
-            s.sendCount++;
+            ++s.sendCount;
+
             if(s.sendCount > PingQueryRetryCount)
             {
                // If this is a local server, remove it from the list if the query times out...
@@ -626,7 +634,8 @@ void QueryServersUserInterface::idle(U32 timeDelta)
                s.state = ServerRef::SentQuery;
                s.lastSendTime = time;
                getGame()->getNetInterface()->sendQuery(s.serverAddress, s.sendNonce, s.identityToken);
-               pendingQueries++;
+               ++pendingQueries;
+
 
                if(pendingQueries >= MaxPendingQueries)
                   break;
@@ -636,7 +645,7 @@ void QueryServersUserInterface::idle(U32 timeDelta)
    }
 
    // Every so often, send out a new batch of queries
-   for(S32 i = 0; i < servers.size(); i++)
+   for(S32 i = 0; i < servers.size(); ++i)
    {
       ServerRef &s = servers[i];
       if(s.state == ServerRef::ReceivedQuery && time - s.lastSendTime > RequeryTime)
@@ -657,7 +666,8 @@ void QueryServersUserInterface::idle(U32 timeDelta)
 
    // Go to previous page if a server has gone away and the last server has disappeared from the current screen
    while(getFirstServerIndexOnCurrentPage() >= servers.size() && mPage > 0)
-       mPage--;
+       --mPage;
+
 
    if(mShouldSort)
    {
@@ -711,7 +721,7 @@ S32 QueryServersUserInterface::getSelectedIndex()
    }
    else
    {
-      for(S32 i = 0; i < servers.size(); i++)
+      for(S32 i = 0; i < servers.size(); ++i)
          if(servers[i].id == selectedId)
             return i;
       return -1;                 // Can't find selected server; return dummy
@@ -812,7 +822,7 @@ void QueryServersUserInterface::render()
    // Render buttons
    const Point *mousePos = DisplayManager::getScreenInfo()->getMousePos();
 
-   for(S32 i = 0; i < buttons.size(); i++)
+   for(S32 i = 0; i < buttons.size(); ++i)
       buttons[i].render(mJustMovedMouse ? mousePos->x : -1, mJustMovedMouse ? mousePos->y : -1);
 
    MasterServerConnection *masterConn = getGame()->getConnectionToMaster();
@@ -874,7 +884,7 @@ void QueryServersUserInterface::render()
       // Color background of local servers
       S32 lastServer = min(servers.size() - 1, (mPage + 1) * getServersPerPage() - 1);
 
-      for(S32 i = getFirstServerIndexOnCurrentPage(); i <= lastServer; i++)
+      for(S32 i = getFirstServerIndexOnCurrentPage(); i <= lastServer; ++i)
       {
          U32 y = TOP_OF_SERVER_LIST + (i - getFirstServerIndexOnCurrentPage()) * SERVER_ENTRY_HEIGHT + 1;
          ServerRef &s = servers[i];
@@ -895,7 +905,7 @@ void QueryServersUserInterface::render()
       drawMenuItemHighlight(0, y + highlightVertAdjustment, canvasWidth, y + SERVER_ENTRY_TEXTSIZE + 4 + highlightVertAdjustment, disabled);
 
 
-      for(S32 i = getFirstServerIndexOnCurrentPage(); i <= lastServer; i++)
+      for(S32 i = getFirstServerIndexOnCurrentPage(); i <= lastServer; ++i)
       {
          y = TOP_OF_SERVER_LIST + (i - getFirstServerIndexOnCurrentPage()) * SERVER_ENTRY_HEIGHT + 2;
          ServerRef &s = servers[i];
@@ -915,7 +925,7 @@ void QueryServersUserInterface::render()
          if(getStringWidth(SERVER_ENTRY_TEXTSIZE, s.serverName.c_str()) < colwidth)
             sname = s.serverName;
          else
-            for(std::size_t j = 0; j < s.serverName.length(); j++)
+            for(std::size_t j = 0; j < s.serverName.length(); ++j)
                if(getStringWidth(SERVER_ENTRY_TEXTSIZE, (sname + s.serverName.substr(j, 1)).c_str() ) < colwidth)
                   sname += s.serverName[j];
                else
@@ -1021,7 +1031,7 @@ void QueryServersUserInterface::renderColumnHeaders()
    // Draw vertical dividing lines
    r.setColor(0.7f);
 
-   for(S32 i = 1; i < columns.size(); i++)
+   for(S32 i = 1; i < columns.size(); ++i)
       drawVertLine(columns[i].xStart - 4, COLUMN_HEADER_TOP, TOP_OF_SERVER_LIST + getServersPerPage() * SERVER_ENTRY_HEIGHT + 2);
 
    // Horizontal lines under column headers
@@ -1039,7 +1049,7 @@ void QueryServersUserInterface::renderColumnHeaders()
    drawFilledRect(x1, COLUMN_HEADER_TOP, x2, COLUMN_HEADER_TOP + COLUMN_HEADER_HEIGHT + 1, Colors::gray20, Colors::white);
 
    // And now the column header text itself
-   for(S32 i = 0; i < columns.size(); i++)
+   for(S32 i = 0; i < columns.size(); ++i)
       drawString(columns[i].xStart, COLUMN_HEADER_TOP + 3, COLUMN_HEADER_TEXTSIZE, columns[i].name);
 
    // Highlight selected column
@@ -1173,7 +1183,7 @@ bool QueryServersUserInterface::onKeyDown(InputCode inputCode)
       else if(inputCode == MOUSE_LEFT && mousePos->y < COLUMN_HEADER_TOP)
       {
          // Check buttons -- they're all up here for the moment
-         for(S32 i = 0; i < buttons.size(); i++)
+         for(S32 i = 0; i < buttons.size(); ++i)
             buttons[i].onClick(mousePos->x, mousePos->y);
       }
       else if(inputCode == MOUSE_LEFT && isMouseOverDivider())
@@ -1221,7 +1231,8 @@ bool QueryServersUserInterface::onKeyDown(InputCode inputCode)
    }
    else if(inputCode == KEY_LEFT)
    {
-      mHighlightColumn--;
+      --mHighlightColumn;
+
       if(mHighlightColumn < 0)
          mHighlightColumn = 0;
 
@@ -1230,7 +1241,8 @@ bool QueryServersUserInterface::onKeyDown(InputCode inputCode)
    }
    else if(inputCode == KEY_RIGHT)
    {
-      mHighlightColumn++;
+      ++mHighlightColumn;
+
       if(mHighlightColumn >= columns.size())
          mHighlightColumn = columns.size() - 1;
 
@@ -1292,7 +1304,8 @@ bool QueryServersUserInterface::onKeyDown(InputCode inputCode)
 
 void QueryServersUserInterface::backPage()
 {
-   mPage--;
+   --mPage;
+
 
    if(mPage < 0)
       mPage = getLastPage();      // Last page
@@ -1303,7 +1316,8 @@ void QueryServersUserInterface::backPage()
 
 void QueryServersUserInterface::advancePage()
 {
-   mPage++;
+   ++mPage;
+
    if(mPage > getLastPage())
       mPage = 0;                 // First page
 
@@ -1394,7 +1408,7 @@ void QueryServersUserInterface::onMouseMoved()
    if(mouseInHeaderRow(mousePos))
    {
       mHighlightColumn = 0;
-      for(S32 i = columns.size()-1; i >= 0; i--)
+      for(S32 i = columns.size()-1; i >= 0; --i)
          if(mousePos->x > columns[i].xStart)
          {
             mHighlightColumn = i;
@@ -1543,7 +1557,7 @@ void QueryServersUserInterface::sort()
       S32 size = servers.size() / 2;
       S32 totalSize = servers.size();
 
-      for(S32 i = 0; i < size; i++)
+      for(S32 i = 0; i < size; ++i)
       {
          ServerRef temp = servers[i];
          servers[i] = servers[totalSize - i - 1];

--- a/zap/UITeamDefMenu.cpp
+++ b/zap/UITeamDefMenu.cpp
@@ -129,7 +129,7 @@ void TeamDefUserInterface::onActivate()
 
    ui->mOldTeams.resize(teamCount);  // Avoid unnecessary reallocations
 
-   for(S32 i = 0; i < teamCount; i++)
+   for(S32 i = 0; i < teamCount; ++i)
    {
       EditorTeam *team = ui->getTeam(i);
 
@@ -208,7 +208,7 @@ void TeamDefUserInterface::render()
    r.setColor(Colors::HostileTeamColor);
    drawCenteredStringf(yStart + fontsize + fontgap, fontsize, "Hostile Team (can't change)");
 
-   for(S32 j = 0; j < size; j++)
+   for(S32 j = 0; j < size; ++j)
    {
       S32 i = j + 2;    // Take account of the two fixed teams (neutral & hostile)
 
@@ -424,7 +424,8 @@ bool TeamDefUserInterface::onKeyDown(InputCode inputCode)
       EditorTeam *team = new EditorTeam(gTeamPresets[presetIndex]);
       ui->addTeam(team, teamCount);
 
-      selectedIndex++;
+      ++selectedIndex;
+
 
       if(selectedIndex < 0)      // It can happen with too many deletes
          selectedIndex = 0;
@@ -472,7 +473,8 @@ bool TeamDefUserInterface::onKeyDown(InputCode inputCode)
    }
    else if(inputCode == KEY_UP || inputCode == BUTTON_DPAD_UP)        // Prev item
    {
-      selectedIndex--;
+      --selectedIndex;
+
       if(selectedIndex < 0)
          selectedIndex = ui->getTeamCount() - 1;
       playBoop();
@@ -481,7 +483,8 @@ bool TeamDefUserInterface::onKeyDown(InputCode inputCode)
    }
    else if(inputCode == KEY_DOWN || inputCode == BUTTON_DPAD_DOWN)    // Next item
    {
-      selectedIndex++;
+      ++selectedIndex;
+
       if(selectedIndex >= ui->getTeamCount())
          selectedIndex = 0;
       playBoop();
@@ -496,7 +499,7 @@ bool TeamDefUserInterface::onKeyDown(InputCode inputCode)
       {
          U32 count = (inputCode - KEY_1) + 1;
          ui->clearTeams();
-         for(U32 i = 0; i < count; i++)
+         for(U32 i = 0; i < count; ++i)
          {
             EditorTeam *team = new EditorTeam(gTeamPresets[i]);
             ui->addTeam(team);

--- a/zap/UIXtankHelper.cpp
+++ b/zap/UIXtankHelper.cpp
@@ -125,7 +125,7 @@ HelperMenu::HelperMenuType UIXtankHelper::getType() { return XtankHelperType; }
 void UIXtankHelper::buildBodyItems()
 {
    mBodyItems.clear();
-   for(S32 i = 0; i < XtankBodyCount; i++)
+   for(S32 i = 0; i < XtankBodyCount; ++i)
    {
       const TankPhysicsInfo &physics = xtankPhysicsInfos[i];
       S32 turrets = xtankTurretInfos[i].count;
@@ -166,7 +166,7 @@ void UIXtankHelper::buildEngineItems()
 {
    mEngineItems.clear();
 
-   for(S32 e = 0; e < XtankEngineCount; e++)
+   for(S32 e = 0; e < XtankEngineCount; ++e)
    {
       const XtankEngineInfo &info = xtankEngineInfos[e];
 
@@ -198,7 +198,7 @@ void UIXtankHelper::buildTreadItems()
 {
    mTreadItems.clear();
 
-   for(S32 t = 0; t < XtankTreadCount; t++)
+   for(S32 t = 0; t < XtankTreadCount; ++t)
    {
       const XtankTreadInfo &info = xtankTreadInfos[t];
 
@@ -229,7 +229,7 @@ void UIXtankHelper::buildArmorItems()
    mArmorItems.clear();
    static string armorHelpTexts[XtankArmorCount];
 
-   for(S32 a = 0; a < XtankArmorCount; a++)
+   for(S32 a = 0; a < XtankArmorCount; ++a)
    {
       const XtankArmorInfo &info = xtankArmorInfos[a];
       char buf[128];
@@ -257,7 +257,7 @@ void UIXtankHelper::buildArmorSidesItems()
 {
    static const char *sideNames[4] = { "Front", "Back", "Left", "Right" };
    mArmorSidesItems.clear();
-   for(S32 i = 0; i < 4; i++)
+   for(S32 i = 0; i < 4; ++i)
    {
       OverlayMenuItem item;
       item.key                 = KEY_NONE;
@@ -280,7 +280,7 @@ void UIXtankHelper::buildSuspensionItems()
    mSuspensionItems.clear();
    static string suspHelpTexts[XtankSuspensionCount];
 
-   for(S32 s = 0; s < XtankSuspensionCount; s++)
+   for(S32 s = 0; s < XtankSuspensionCount; ++s)
    {
       const SuspensionStat &info = suspensionStat[s];
       char buf[128];
@@ -308,7 +308,7 @@ void UIXtankHelper::buildBumperItems()
    mBumperItems.clear();
    static string bumperHelpTexts[XtankBumperCount];
 
-   for(S32 b = 0; b < XtankBumperCount; b++)
+   for(S32 b = 0; b < XtankBumperCount; ++b)
    {
       const BumperStat &info = bumperStat[b];
       char buf[128];
@@ -336,7 +336,7 @@ void UIXtankHelper::buildSpecialsItems()
    mSpecialsItems.clear();
    static string specHelpTexts[XtankSpecialCount];
 
-   for(S32 s = 0; s < XtankSpecialCount; s++)
+   for(S32 s = 0; s < XtankSpecialCount; ++s)
    {
       const XtankSpecialInfo &info = xtankSpecialInfos[s];
       char buf[128];
@@ -365,7 +365,7 @@ void UIXtankHelper::buildHeatSinkItems()
    mHeatSinkItems.clear();
    static string hsHelpTexts[XtankHeatSinkMax];  // persistent storage
 
-   for(S32 n = XtankHeatSinkMin; n <= XtankHeatSinkMax; n++)
+   for(S32 n = XtankHeatSinkMin; n <= XtankHeatSinkMax; ++n)
    {
       S32 idx = n - XtankHeatSinkMin;
       F32 mult = xtankHeatSinkFireDelayMult(n);
@@ -417,7 +417,7 @@ void UIXtankHelper::buildWeaponItems()
    }
 
    // One entry per weapon (dynamically assigned keys 1-9, A-P).
-   for(S32 w = 0; w < XtankWeaponCount; w++)
+   for(S32 w = 0; w < XtankWeaponCount; ++w)
    {
       OverlayMenuItem item;
       item.key                 = getKeyForIndex(w);  // Use dynamic key assignment
@@ -439,7 +439,7 @@ void UIXtankHelper::buildWeaponItems()
 // all others get the unselected color.
 void UIXtankHelper::updateItemColors(Vector<OverlayMenuItem> &items)
 {
-   for(S32 i = 0; i < items.size(); i++)
+   for(S32 i = 0; i < items.size(); ++i)
    {
       if(i == mHighlightedIndex)
       {
@@ -577,11 +577,11 @@ void UIXtankHelper::commitHighlightedSelection()
          mDesignInProgress.bodyIndex = (S8)bodyIdx;
          mSlotCount = xtankTurretInfos[bodyIdx].count;
          // Clamp weapons to the new slot count (extra slots become None).
-         for(S32 i = mSlotCount; i < kXtankMaxWeaponSlots; i++)
+         for(S32 i = mSlotCount; i < kXtankMaxWeaponSlots; ++i)
             mDesignInProgress.weapons[i] = XtankWeaponNone;
          // Reset per-side armor budget for the new body.
          S32 sideDefault = (kArmorPointsPerBodySize * body_stat[bodyIdx].size) / 4;
-         for(S32 i = 0; i < 4; i++)
+         for(S32 i = 0; i < 4; ++i)
             mDesignInProgress.armorSides[i] = (U8)sideDefault;
       }
    }
@@ -739,7 +739,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    // Hotkey presses: commit the specific item then animate forward.
    if(mPhase == PHASE_BODY)
    {
-      for(S32 i = 0; i < mBodyItems.size(); i++)
+      for(S32 i = 0; i < mBodyItems.size(); ++i)
       {
          if(inputCode == mBodyItems[i].key)
          {
@@ -747,11 +747,11 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
             // Update body only — preserve other components.
             mDesignInProgress.bodyIndex = (S8)bodyIdx;
             mSlotCount = xtankTurretInfos[bodyIdx].count;
-            for(S32 j = mSlotCount; j < kXtankMaxWeaponSlots; j++)
+            for(S32 j = mSlotCount; j < kXtankMaxWeaponSlots; ++j)
                mDesignInProgress.weapons[j] = XtankWeaponNone;
             // Reset armor budget for the new body.
             S32 sideDefault = (kArmorPointsPerBodySize * body_stat[bodyIdx].size) / 4;
-            for(S32 k = 0; k < 4; k++)
+            for(S32 k = 0; k < 4; ++k)
                mDesignInProgress.armorSides[k] = (U8)sideDefault;
             mHighlightedIndex = i;
             navigateForward();
@@ -765,13 +765,15 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
       if(inputCode == KEY_EQUALS)
       {
          S32 to = mHighlightedIndex;
-         for(S32 k = 1; k <= 3; k++)
+         for(S32 k = 1; k <= 3; ++k)
          {
             S32 from = (to + k) % 4;
             if(mDesignInProgress.armorSides[from] > 0)
             {
-               mDesignInProgress.armorSides[from]--;
-               mDesignInProgress.armorSides[to]++;
+               --mDesignInProgress.armorSides[from];
+
+               ++mDesignInProgress.armorSides[to];
+
                break;
             }
          }
@@ -784,15 +786,17 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
          if(mDesignInProgress.armorSides[from] > 0)
          {
             S32 to = (from + 1) % 4;
-            mDesignInProgress.armorSides[from]--;
-            mDesignInProgress.armorSides[to]++;
+            --mDesignInProgress.armorSides[from];
+
+            ++mDesignInProgress.armorSides[to];
+
          }
          return true;
       }
    }
    else if(mPhase == PHASE_ENGINE)
    {
-      for(S32 e = 0; e < mEngineItems.size(); e++)
+      for(S32 e = 0; e < mEngineItems.size(); ++e)
       {
          if(inputCode == mEngineItems[e].key)
          {
@@ -805,7 +809,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    }
    else if(mPhase == PHASE_TREADS)
    {
-      for(S32 t = 0; t < mTreadItems.size(); t++)
+      for(S32 t = 0; t < mTreadItems.size(); ++t)
       {
          if(inputCode == mTreadItems[t].key)
          {
@@ -818,7 +822,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    }
    else if(mPhase == PHASE_ARMOR)
    {
-      for(S32 a = 0; a < mArmorItems.size(); a++)
+      for(S32 a = 0; a < mArmorItems.size(); ++a)
       {
          if(inputCode == mArmorItems[a].key)
          {
@@ -831,7 +835,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    }
    else if(mPhase == PHASE_SUSPENSION)
    {
-      for(S32 s = 0; s < mSuspensionItems.size(); s++)
+      for(S32 s = 0; s < mSuspensionItems.size(); ++s)
       {
          if(inputCode == mSuspensionItems[s].key)
          {
@@ -844,7 +848,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    }
    else if(mPhase == PHASE_BUMPERS)
    {
-      for(S32 b = 0; b < mBumperItems.size(); b++)
+      for(S32 b = 0; b < mBumperItems.size(); ++b)
       {
          if(inputCode == mBumperItems[b].key)
          {
@@ -857,7 +861,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    }
    else if(mPhase == PHASE_SPECIALS)
    {
-      for(S32 s = 0; s < mSpecialsItems.size(); s++)
+      for(S32 s = 0; s < mSpecialsItems.size(); ++s)
       {
          if(inputCode == mSpecialsItems[s].key)
          {
@@ -869,7 +873,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    }
    else if(mPhase == PHASE_HEATSINK)
    {
-      for(S32 n = 0; n < mHeatSinkItems.size(); n++)
+      for(S32 n = 0; n < mHeatSinkItems.size(); ++n)
       {
          if(inputCode == mHeatSinkItems[n].key)
          {
@@ -884,7 +888,7 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
    {
       // Hotkeys assign a weapon to the current side/slot and advance to the next slot,
       // or navigate forward if the last slot has been assigned.
-      for(S32 i = 0; i < mWeaponItems.size(); i++)
+      for(S32 i = 0; i < mWeaponItems.size(); ++i)
       {
          if(inputCode == mWeaponItems[i].key)
          {
@@ -896,7 +900,8 @@ bool UIXtankHelper::processInputCode(InputCode inputCode)
             // Advance to next slot, or leave weapon phase if last slot done.
             if(mSlotCount > 1 && mWeaponSide < mSlotCount - 1)
             {
-               mWeaponSide++;
+               ++mWeaponSide;
+
                setHighlightedIndexForPhase(PHASE_WEAPONS);
             }
             else
@@ -1015,7 +1020,7 @@ void UIXtankHelper::setHighlightedIndexForPhase(S32 phase)
    {
       // Position cursor on the first active special, or 0 if none active.
       mHighlightedIndex = 0;
-      for(S32 i = 0; i < XtankSpecialCount; i++)
+      for(S32 i = 0; i < XtankSpecialCount; ++i)
       {
          if(hasSpecial(mDesignInProgress.specials, (XtankSpecial)i))
          {
@@ -1043,7 +1048,7 @@ void UIXtankHelper::setHighlightedIndexForPhase(S32 phase)
          return;
       }
       mHighlightedIndex = 0;
-      for(S32 i = 1; i < mWeaponItems.size(); i++)
+      for(S32 i = 1; i < mWeaponItems.size(); ++i)
       {
          if((S32)mWeaponItems[i].itemIndex == (S32)w)
          {
@@ -1122,9 +1127,10 @@ std::string UIXtankHelper::getSelectedLabelForPhase(S32 phase) const
    if(phase == PHASE_SPECIALS)
    {
       S32 count = 0;
-      for(S32 i = 0; i < XtankSpecialCount; i++)
+      for(S32 i = 0; i < XtankSpecialCount; ++i)
          if(hasSpecial(mDesignInProgress.specials, (XtankSpecial)i))
-            count++;
+            ++count;
+
       return count == 0 ? "None" : itos(count) + " selected";
    }
    if(phase == PHASE_HEATSINK)
@@ -1138,7 +1144,7 @@ std::string UIXtankHelper::getSelectedLabelForPhase(S32 phase) const
    {
       // Show a summary of how many weapon slots are filled.
       S32 filled = 0;
-      for(S32 i = 0; i < mSlotCount && i < kXtankMaxWeaponSlots; i++)
+      for(S32 i = 0; i < mSlotCount && i < kXtankMaxWeaponSlots; ++i)
          if(mDesignInProgress.weapons[i] != XtankWeaponNone) filled++;
       return itos(filled) + "/" + itos(mSlotCount) + " armed";
    }
@@ -1208,14 +1214,14 @@ void UIXtankHelper::renderItemStatsColumn(S32 left, S32 right, S32 yTop, F32 alp
    else if(mPhase == PHASE_ARMOR_SIDES)
    {
       S32 total = 0;
-      for(S32 i = 0; i < 4; i++)
+      for(S32 i = 0; i < 4; ++i)
          total += (S32)mDesignInProgress.armorSides[i];
       drawStringf(left, y, STAT_SZ, "Budget: %d pts", total); y += GAP;
       r.setColor(Color(0.7f * alpha, 0.7f * alpha, 0.7f * alpha));
       drawString (left, y, STAT_SZ, "+/- to shift pts"); y += GAP;
       r.setColor(Color(0.0f, alpha, alpha));
       const char *sideLabels[4] = { "Front", "Back", "Left", "Right" };
-      for(S32 i = 0; i < 4; i++)
+      for(S32 i = 0; i < 4; ++i)
       {
          bool hl = (i == mHighlightedIndex);
          r.setColor(hl ? Colors::yellow : Color(0.0f, alpha, alpha));
@@ -1391,7 +1397,7 @@ void UIXtankHelper::renderCard(S32 left, S32 top, S32 right, S32 bot, S32 phase,
    const S32 NAME_X    = isCenter ? (left + 30) : (left + 6);
    const S32 STATS_DIV = left + w * 54 / 100;
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       S32 y = listTop + i * rowGap;
       // Stop drawing if we've run out of space (items after this will be blank).
@@ -1514,7 +1520,7 @@ void UIXtankHelper::renderFloatingMenus(F32 /*unused*/)
    // "toSlot" is where each card ends up; "fromSlot" is where it starts.
    // phaseAtSlot[i]: which phase lives in the i-th slot in the "to" arrangement.
    S32 phaseAtSlot[5];
-   for(S32 i = 0; i < 5; i++)
+   for(S32 i = 0; i < 5; ++i)
       phaseAtSlot[i] = (mPhase + (i - 2) + totalPhases * 10) % totalPhases;
 
    struct CardAnim { S32 phase; S32 fromSlot; S32 toSlot; };
@@ -1523,21 +1529,21 @@ void UIXtankHelper::renderFloatingMenus(F32 /*unused*/)
    if(mTransitionTimer.getCurrent() > 0 && mTransitionFromPhase >= 0)
    {
       if(mTransitionForward)
-         for(S32 i = 0; i < 5; i++)
+         for(S32 i = 0; i < 5; ++i)
          { cards[i] = { phaseAtSlot[i], MIN(i + 1, 4), i }; }
       else
-         for(S32 i = 0; i < 5; i++)
+         for(S32 i = 0; i < 5; ++i)
          { cards[i] = { phaseAtSlot[i], MAX(i - 1, 0), i }; }
    }
    else
-      for(S32 i = 0; i < 5; i++)
+      for(S32 i = 0; i < 5; ++i)
          cards[i] = { phaseAtSlot[i], i, i };
 
    FontManager::pushFontContext(HelperMenuContext);
 
    // Draw back-to-front so center card is always on top.
    static const S32 drawOrder[5] = { 0, 4, 1, 3, 2 };
-   for(S32 di = 0; di < 5; di++)
+   for(S32 di = 0; di < 5; ++di)
    {
       S32 ci = drawOrder[di];
       const CardAnim &ca = cards[ci];
@@ -1636,7 +1642,7 @@ void UIXtankHelper::renderPreviewPanel() const
       bodyPreview.treadType = preview.treadType;
       bodyPreview.heatSinkCount = preview.heatSinkCount;
       bodyPreview.armorType = preview.armorType;
-      for(S32 i = 0; i < MIN(xtankTurretInfos[bodyIdx].count, kXtankMaxWeaponSlots); i++)
+      for(S32 i = 0; i < MIN(xtankTurretInfos[bodyIdx].count, kXtankMaxWeaponSlots); ++i)
          bodyPreview.weapons[i] = preview.weapons[i];
       preview = bodyPreview;
    }
@@ -1686,7 +1692,7 @@ void UIXtankHelper::renderPreviewPanel() const
    S32 totalWeight = body_stat[bodyIdx].weight + eng.weight + heatSinkStat.weight * heatSinks;
    S32 totalCost   = body_stat[bodyIdx].cost   + eng.cost   + trd.cost + heatSinkStat.cost * heatSinks;
    S32 slotCount   = xtankTurretInfos[bodyIdx].count;
-   for(S32 i = 0; i < slotCount && i < kXtankMaxWeaponSlots; i++)
+   for(S32 i = 0; i < slotCount && i < kXtankMaxWeaponSlots; ++i)
    {
       XtankWeapon w = preview.weapons[i];
       if(w == XtankWeaponNone) continue;
@@ -1698,7 +1704,7 @@ void UIXtankHelper::renderPreviewPanel() const
    // Armor cost and weight: per-side armor points * per-point stats
    S32 armorIdx = MAX(0, MIN((S32)preview.armorType, XtankArmorCount - 1));
    S32 totalArmorPoints = 0;
-   for(S32 i = 0; i < 4; i++)
+   for(S32 i = 0; i < 4; ++i)
       totalArmorPoints += preview.armorSides[i];
    totalWeight += totalArmorPoints * xtankArmorInfos[armorIdx].weight;
    totalCost   += totalArmorPoints * xtankArmorInfos[armorIdx].cost;
@@ -1708,7 +1714,7 @@ void UIXtankHelper::renderPreviewPanel() const
    totalCost += bumperStat[MAX(0, MIN((S32)preview.bumperType, XtankBumperCount - 1))].cost;
 
    // Specials costs and weights
-   for(S32 s = 0; s < XtankSpecialCount; s++)
+   for(S32 s = 0; s < XtankSpecialCount; ++s)
    {
       if(hasSpecial(preview.specials, (XtankSpecial)s))
       {
@@ -1722,13 +1728,13 @@ void UIXtankHelper::renderPreviewPanel() const
    S32 totalSpace = eng.space;
    totalSpace += totalArmorPoints * xtankArmorInfos[armorIdx].space;
    totalSpace += heatSinkStat.space * heatSinks;
-   for(S32 i = 0; i < slotCount && i < kXtankMaxWeaponSlots; i++)
+   for(S32 i = 0; i < slotCount && i < kXtankMaxWeaponSlots; ++i)
    {
       XtankWeapon w = preview.weapons[i];
       if(w == XtankWeaponNone || (S32)w < 0 || (S32)w >= XtankWeaponCount) continue;
       totalSpace += xtankWeaponInfos[(S32)w].space;
    }
-   for(S32 s = 0; s < XtankSpecialCount; s++)
+   for(S32 s = 0; s < XtankSpecialCount; ++s)
       if(hasSpecial(preview.specials, (XtankSpecial)s))
          totalSpace += xtankSpecialInfos[s].space;
 
@@ -1785,7 +1791,7 @@ void UIXtankHelper::renderPreviewPanel() const
    r.setColor(Colors::gray70);
    drawCenteredString(PNL_CX, ty, STAT_SZ - 1, "Weapons");
    ty += LINE_GAP;
-   for(S32 i = 0; i < slotCount && i < kXtankMaxWeaponSlots; i++)
+   for(S32 i = 0; i < slotCount && i < kXtankMaxWeaponSlots; ++i)
    {
       XtankWeapon w = preview.weapons[i];
       // Highlight whichever slot is being edited in PHASE_WEAPONS.
@@ -1803,9 +1809,10 @@ void UIXtankHelper::renderPreviewPanel() const
 
    // Active specials count
    S32 specialCount = 0;
-   for(S32 s = 0; s < XtankSpecialCount; s++)
+   for(S32 s = 0; s < XtankSpecialCount; ++s)
       if(hasSpecial(preview.specials, (XtankSpecial)s))
-         specialCount++;
+         ++specialCount;
+
    if(specialCount > 0)
    {
       r.setColor(Colors::cyan);
@@ -1843,7 +1850,7 @@ void UIXtankHelper::renderCarouselDots(S32 cx, S32 y) const
    Renderer &r = Renderer::get();
    static const S32 SEG = 12;  // polygon segments for each circle
 
-   for(S32 i = 0; i < totalPhases; i++)
+   for(S32 i = 0; i < totalPhases; ++i)
    {
       F32 dx  = dotsLeft + F32(i) * DOT_STEP;
       F32 rad = (i == mPhase) ? DOT_R : DOT_R_SM;
@@ -1861,7 +1868,7 @@ void UIXtankHelper::renderCarouselDots(S32 cx, S32 y) const
          F32 verts[2 + (SEG + 1) * 2];
          verts[0] = dx;
          verts[1] = F32(y);
-         for(S32 s = 0; s <= SEG; s++)
+         for(S32 s = 0; s <= SEG; ++s)
          {
             F32 a = FloatPi * 2.0f * F32(s % SEG) / F32(SEG);
             verts[2 + s * 2]     = dx + rad * cosf(a);
@@ -1872,7 +1879,7 @@ void UIXtankHelper::renderCarouselDots(S32 cx, S32 y) const
       else
       {
          F32 verts[SEG * 2];
-         for(S32 s = 0; s < SEG; s++)
+         for(S32 s = 0; s < SEG; ++s)
          {
             F32 a = FloatPi * 2.0f * F32(s) / F32(SEG);
             verts[s * 2]     = dx + rad * cosf(a);

--- a/zap/VideoSystem.cpp
+++ b/zap/VideoSystem.cpp
@@ -577,7 +577,7 @@ void VideoSystem::updateDisplayState(GameSettings *settings, StateReason reason)
    // Notify all active UIs that the screen has changed state.  May cause problems
    // in split-screen mode
    const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
       if(clientGames->get(i)->getUIManager()->getCurrentUI())
          clientGames->get(i)->getUIManager()->getCurrentUI()->onDisplayModeChange();
 }

--- a/zap/VoiceRecorder.cpp
+++ b/zap/VoiceRecorder.cpp
@@ -73,7 +73,7 @@ void VoiceRecorder::render() const
       static F32 colorArray[400];
       static F32 vertexArray[200];
 
-      for(U32 i = 1; i < full; i++)
+      for(U32 i = 1; i < full; ++i)
       {
          if(i < halfway)
          {
@@ -168,7 +168,8 @@ void VoiceRecorder::process()
 
    if(mWantToStopRecordingAudio != 0)
    {
-      mWantToStopRecordingAudio--;
+      --mWantToStopRecordingAudio;
+
       if(mWantToStopRecordingAudio == 0)
       {
          stopNow();
@@ -185,7 +186,7 @@ void VoiceRecorder::process()
    S16 *samplePtr = (S16 *) mUnusedAudio->getBuffer();
    mMaxAudioSample = 0;
 
-   for(U32 i = preSampleCount; i < sampleCount; i++)
+   for(U32 i = preSampleCount; i < sampleCount; ++i)
    {
       if(samplePtr[i] > mMaxAudioSample)
          mMaxAudioSample = samplePtr[i];
@@ -201,7 +202,7 @@ void VoiceRecorder::process()
    if(mMaxForGain > MaxDetectionThreshold)
    {
       F32 gain = 0x7FFF / F32(mMaxForGain);
-      for(U32 i = preSampleCount; i < sampleCount; i++)
+      for(U32 i = preSampleCount; i < sampleCount; ++i)
       {
          F32 sample = gain * samplePtr[i];
          if(sample > 0x7FFF)

--- a/zap/WallSegmentManager.cpp
+++ b/zap/WallSegmentManager.cpp
@@ -88,7 +88,7 @@ void WallSegmentManager::finishedChangingWalls(GridDatabase *editorObjectDatabas
    fillVector.clear();
    editorObjectDatabase->findObjects((TestFunc)isEngineeredType, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       EngineeredItem *engrItem = static_cast<EngineeredItem *>(fillVector[i]);
 
@@ -162,7 +162,7 @@ void WallSegmentManager::buildAllWallSegmentEdgesAndPoints(GridDatabase *databas
    database->findObjects((TestFunc)isEngineeredType, engrObjects);   // All engineered objects
 
    // Iterate over all our wall objects
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
       buildWallSegmentEdgesAndPoints(database, fillVector[i], engrObjects);
 }
 
@@ -182,11 +182,11 @@ void WallSegmentManager::buildWallSegmentEdgesAndPoints(GridDatabase *database, 
    S32 count = mWallSegmentDatabase->getObjectCount();
 
    // Loop through all the walls, and, for each, see if any of the engineered objects we were given are mounted to it
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       WallSegment *wallSegment = static_cast<WallSegment *>(mWallSegmentDatabase->getObjectByIndex(i));
       if(wallSegment->getOwner() == wall->getSerialNumber())       // Segment belongs to wall
-         for(S32 j = 0; j < engrObjects.size(); j++)               // Loop through all engineered objects checking the mount seg
+         for(S32 j = 0; j < engrObjects.size(); ++j)               // Loop through all engineered objects checking the mount seg
          {
             EngineeredItem *engrObj = static_cast<EngineeredItem *>(engrObjects[j]);
 
@@ -216,7 +216,7 @@ void WallSegmentManager::buildWallSegmentEdgesAndPoints(GridDatabase *database, 
       Vector<Vector<Point> > segmentData;
       barrierLineToSegmentData(*(wallItem->getOutline()), segmentData);
 
-      for(S32 i = 0; i < segmentData.size(); i++)
+      for(S32 i = 0; i < segmentData.size(); ++i)
       {
          // Create the segment; the WallSegment constructor will add it to the specified database
          WallSegment *newSegment = new WallSegment(mWallSegmentDatabase, segmentData[i],
@@ -233,7 +233,7 @@ void WallSegmentManager::buildWallSegmentEdgesAndPoints(GridDatabase *database, 
    }
 
    // Remount all turrets & forcefields mounted on or terminating on any of the wall segments we deleted and potentially recreated
-   for(S32 i = 0; i < toBeRemounted.size(); i++)
+   for(S32 i = 0; i < toBeRemounted.size(); ++i)
       toBeRemounted[i]->mountToWall(toBeRemounted[i]->getVert(0), database->getWallSegmentManager(), NULL);
 
 #endif
@@ -248,7 +248,7 @@ void WallSegmentManager::clipAllWallEdges(const Vector<DatabaseObject *> *wallSe
 
    S32 count = wallSegments->size();
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       WallSegment *wallSegment = static_cast<WallSegment *>(wallSegments->get(i));
       inputPolygons.push_back(wallSegment->getCorners());
@@ -268,7 +268,7 @@ void WallSegmentManager::updateAllMountedItems(GridDatabase *database)
    fillVector.clear();
    database->findObjects((TestFunc)isEngineeredType, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       EngineeredItem *engrItem = static_cast<EngineeredItem *>(fillVector[i]);
       engrItem->mountToWall(engrItem->getVert(0), database->getWallSegmentManager(), NULL);
@@ -300,7 +300,7 @@ void WallSegmentManager::clearSelected()
 {
    S32 count = mWallSegmentDatabase->getObjectCount();
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       WallSegment *wallSegment = static_cast<WallSegment *>(mWallSegmentDatabase->getObjectByIndex(i));
       wallSegment->setSelected(false);
@@ -325,7 +325,7 @@ void WallSegmentManager::setSelected(S32 owner, bool selected)
 {
    S32 count = mWallSegmentDatabase->getObjectCount();
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       WallSegment *wallSegment = static_cast<WallSegment *>(mWallSegmentDatabase->getObjectByIndex(i));
       if(wallSegment->getOwner() == owner)
@@ -340,7 +340,7 @@ void WallSegmentManager::rebuildSelectedOutline()
 
    S32 count = mWallSegmentDatabase->getObjectCount();
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       WallSegment *wallSegment = static_cast<WallSegment *>(mWallSegmentDatabase->getObjectByIndex(i));
       if(wallSegment->isSelected())
@@ -362,14 +362,14 @@ void WallSegmentManager::deleteSegments(S32 owner)
 
    Vector<DatabaseObject *> toBeDeleted;     // Use DatabaseObject to match args for removeFromDatabase
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       WallSegment *wallSegment = static_cast<WallSegment *>(mWallSegmentDatabase->getObjectByIndex(i));
       if(wallSegment->getOwner() == owner)
          toBeDeleted.push_back(wallSegment);
    }
 
-   for(S32 i = 0; i < toBeDeleted.size(); i++)
+   for(S32 i = 0; i < toBeDeleted.size(); ++i)
       mWallSegmentDatabase->removeFromDatabase(toBeDeleted[i], true);
 }
 

--- a/zap/WeaponInfo.cpp
+++ b/zap/WeaponInfo.cpp
@@ -61,7 +61,7 @@ WeaponType WeaponInfo::getWeaponTypeFromObject(BfObject *bfObject)
 WeaponType WeaponInfo::getWeaponTypeFromString(const char *name)
 {
    // String compares the given name with a WeaponType name (case-insensitive)
-   for(U32 w = 0; w < WeaponCount; w++)
+   for(U32 w = 0; w < WeaponCount; ++w)
       if(stricmp(weaponInfo[w].name.getString(), name) == 0)
          return (WeaponType) w;
 

--- a/zap/Zone.cpp
+++ b/zap/Zone.cpp
@@ -89,7 +89,7 @@ bool Zone::processArguments(S32 argc2, const char **argv2, Game *game)
    // so a possible future version can add parameters without compatibility problem.
    S32 argc = 0;
    const char *argv[Geometry::MAX_POLY_POINTS * 2 + 1];
-   for(S32 i = 0; i < argc2; i++)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char c = argv2[i][0];
       //switch(c)
@@ -100,7 +100,8 @@ bool Zone::processArguments(S32 argc2, const char **argv2, Game *game)
       {
          if(argc < Geometry::MAX_POLY_POINTS * 2 + 1)
          {  argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }

--- a/zap/barrier.cpp
+++ b/zap/barrier.cpp
@@ -41,7 +41,7 @@ namespace Zap
 
       this->verts.resize(verts.size());
 
-      for(S32 i = 0; i < verts.size(); i++)
+      for(S32 i = 0; i < verts.size(); ++i)
          this->verts[i] = verts[i];
    }
 
@@ -52,7 +52,7 @@ namespace Zap
       width = (F32) wallItem->getWidth();
       solid = false;
 
-      for(S32 i = 0; i < wallItem->getVertCount(); i++)
+      for(S32 i = 0; i < wallItem->getVertCount(); ++i)
       {
          verts.push_back(wallItem->getVert(i).x);
          verts.push_back(wallItem->getVert(i).y);
@@ -70,7 +70,7 @@ namespace Zap
       solid = true;
       destructible = polyWall->mDestructible;
 
-      for(S32 i = 0; i < polyWall->getVertCount(); i++)
+      for(S32 i = 0; i < polyWall->getVertCount(); ++i)
       {
          verts.push_back(polyWall->getVert(i).x);
          verts.push_back(polyWall->getVert(i).y);
@@ -112,7 +112,7 @@ namespace Zap
          Vector<Vector<Point> > segmentData;
          barrierLineToSegmentData(vec, segmentData);
 
-         for(S32 i = 0; i < segmentData.size(); i++)
+         for(S32 i = 0; i < segmentData.size(); ++i)
          {
             Barrier *b = Barrier::createBarrier(segmentData[i], width, false);    // false = not solid
             if(b)
@@ -262,7 +262,7 @@ namespace Zap
 
              Vector<DatabaseObject *> ffps;
              game->getGameObjDatabase()->findObjects(ForceFieldProjectorTypeNumber, ffps);
-             for(S32 i = 0; i < ffps.size(); i++)
+             for(S32 i = 0; i < ffps.size(); ++i)
              {
                 ForceFieldProjector *ffp = static_cast<ForceFieldProjector *>(ffps[i]);
                 if(!ffp || !ffp->isEnabled())
@@ -307,7 +307,7 @@ namespace Zap
           // bot zones reads forcefield endpoints, so they must be updated
           // first to avoid stale geometry in the nav mesh.
           // Skip any projectors that were deleted by removeMountedItems().
-          for(S32 i = 0; i < affectedProjectors.size(); i++)
+          for(S32 i = 0; i < affectedProjectors.size(); ++i)
              if(affectedProjectors[i].isValid())
                 affectedProjectors[i]->recomputeFieldGeometry();
 
@@ -338,7 +338,7 @@ namespace Zap
        static const F32 MOUNT_MARGIN = 5.0f;
        F32 tolerance_squared = sq((mSolid ? 0.0f : mWidth / 2.0f) + MOUNT_MARGIN);
 
-       for(S32 i = 0; i < mountedItems.size(); i++)
+       for(S32 i = 0; i < mountedItems.size(); ++i)
        {
           EngineeredItem *item = dynamic_cast<EngineeredItem *>(mountedItems[i]);
           if(!item)
@@ -349,7 +349,7 @@ namespace Zap
 
           if(mSolid)  // Polywall — check each edge of the polygon (mPoints == outline == centerline)
           {
-             for(S32 j = 0; j < mPoints.size(); j++)
+             for(S32 j = 0; j < mPoints.size(); ++j)
              {
                 const Point &a = mPoints[j];
                 const Point &b = mPoints[(j + 1) % mPoints.size()];
@@ -451,7 +451,7 @@ namespace Zap
       const Point &destroyedStart = destroyedBarrier->mPoints[1];
       const Point &destroyedEnd   = destroyedBarrier->mPoints[2];
 
-      for(S32 i = 0; i < barriers.size(); i++)
+      for(S32 i = 0; i < barriers.size(); ++i)
       {
          Barrier *b = dynamic_cast<Barrier *>(barriers[i]);
          if(!b || b == destroyedBarrier || b->mSolid)
@@ -490,7 +490,7 @@ namespace Zap
       Vector<const Vector<Point> *> inputPolygons;
       Vector<Point> points;
 
-      for(S32 i = 0; i < barriers.size(); i++)
+      for(S32 i = 0; i < barriers.size(); ++i)
       {
          if(barriers[i]->getObjectTypeNumber() != BarrierTypeNumber)
             continue;
@@ -560,11 +560,13 @@ namespace Zap
       if(argv[argIdx][0] == 'D' && argv[argIdx][1] == '\0')
       {
          destructible = true;
-         argIdx++;
+         ++argIdx;
+
       }
 
       setWidth(atoi(argv[argIdx]));
-      argIdx++;
+      ++argIdx;
+
 
       // Read remaining args as geometry (x,y pairs)
       readGeom(argc, argv, argIdx, game->getLegacyGridSize());
@@ -940,7 +942,8 @@ namespace Zap
       if(argv[argIdx][0] == 'D' && argv[argIdx][1] == '\0')
       {
          mDestructible = true;
-         argIdx++;
+         ++argIdx;
+
       }
 
       readGeom(argc, argv, argIdx, game->getLegacyGridSize());

--- a/zap/config.cpp
+++ b/zap/config.cpp
@@ -36,7 +36,7 @@ namespace Zap
 // Constructor
 UserSettings::UserSettings()
 {
-   for(S32 i = 0; i < LevelCount; i++)
+   for(S32 i = 0; i < LevelCount; ++i)
       levelupItemsAlreadySeen[i] = false;
 }
 
@@ -194,7 +194,7 @@ IniSettings::~IniSettings()
 // Set all bits in items[] to false
 void IniSettings::clearbits(bool *bitArray, S32 itemCount)
 {
-   for(S32 i = 0; i < itemCount; i++)
+   for(S32 i = 0; i < itemCount; ++i)
       bitArray[i] = false;
 }
 
@@ -205,7 +205,7 @@ string IniSettings::bitArrayToIniString(const bool *bitArray, S32 itemCount)
 {
    string s = "";
 
-   for(S32 i = 0; i < itemCount; i++)
+   for(S32 i = 0; i < itemCount; ++i)
       s += bitArray[i] ? "Y" : "N";
 
    return s;
@@ -219,7 +219,7 @@ void IniSettings::iniStringToBitArray(const string &vals, bool *bitArray, S32 it
 
    S32 count = MIN((S32)vals.size(), itemCount);
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
       if(vals.at(i) == 'Y')
          bitArray[i] = true;
 }
@@ -236,7 +236,7 @@ Vector<PluginBinding> IniSettings::getDefaultPluginBindings() const
    Vector<string> words;
 
    // Parse the retrieved strings.  They'll be in the form "Key Script Help"
-   for(S32 i = 0; i < plugins.size(); i++)
+   for(S32 i = 0; i < plugins.size(); ++i)
    {
       parseString(trim(plugins[i]), words, '|');
 
@@ -312,7 +312,7 @@ static void writeLoadoutPresets(CIniFile *ini, GameSettings *settings)
       addComment("----------------");
    }
 
-   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; i++)
+   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; ++i)
    {
       string presetStr = settings->getLoadoutPreset(i).toString(true);
 
@@ -344,7 +344,7 @@ static void writePluginBindings(CIniFile *ini, IniSettings *iniSettings)
 
    Vector<string> plugins;
    PluginBinding binding;
-   for(S32 i = 0; i < iniSettings->pluginBindings.size(); i++)
+   for(S32 i = 0; i < iniSettings->pluginBindings.size(); ++i)
    {
       binding = iniSettings->pluginBindings[i];
       plugins.push_back(string(binding.key + "|" + binding.script + "|" + binding.help));
@@ -399,13 +399,13 @@ static void writeForeignServerInfo(CIniFile *ini, IniSettings *iniSettings)
       S32 numLevels = ini->GetNumEntries("Levels");
       Vector<string> levelValNames;
 
-      for(S32 i = 0; i < numLevels; i++)
+      for(S32 i = 0; i < numLevels; ++i)
          levelValNames.push_back(ini->ValueName("Levels", i));
 
       levelValNames.sort(alphaSort);
 
       string level;
-      for(S32 i = 0; i < numLevels; i++)
+      for(S32 i = 0; i < numLevels; ++i)
       {
          level = ini->GetValue("Levels", levelValNames[i], "");
          if (level != "")
@@ -436,7 +436,7 @@ static void loadGeneralSettings(CIniFile *ini, IniSettings *iniSettings)
 
    // Read all settings defined in the new modern manner
    Vector<AbstractSetting *> settings = iniSettings->mSettings.getSettingsInSection(section);
-   for(S32 i = 0; i < settings.size(); i++)
+   for(S32 i = 0; i < settings.size(); ++i)
       settings[i]->setValFromString(ini->GetValue(section, settings[i]->getKey(), settings[i]->getDefaultValueString()));
 
    // Now read the settings still defined all old school
@@ -494,7 +494,7 @@ static void loadEditorSettings(CIniFile *ini, IniSettings *iniSettings)
 
    // Read all settings defined in the new modern manner
    Vector<AbstractSetting *> settings = iniSettings->mSettings.getSettingsInSection(section);
-   for(S32 i = 0; i < settings.size(); i++)
+   for(S32 i = 0; i < settings.size(); ++i)
       settings[i]->setValFromString(ini->GetValue(section, settings[i]->getKey(), settings[i]->getDefaultValueString()));
 }
 
@@ -542,10 +542,10 @@ static void loadLoadoutPresets(CIniFile *ini, GameSettings *settings)
 {
    Vector<string> rawPresets(GameSettings::LoadoutPresetCount);
 
-   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; i++)
+   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; ++i)
       rawPresets.push_back(ini->GetValue("LoadoutPresets", "Preset" + itos(i + 1), ""));
 
-   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; i++)
+   for(S32 i = 0; i < GameSettings::LoadoutPresetCount; ++i)
    {
       LoadoutTracker loadout(rawPresets[i]);
       if(loadout.isValid())
@@ -562,7 +562,7 @@ static void loadPluginBindings(CIniFile *ini, IniSettings *iniSettings)
    ini->GetAllValues("EditorPlugins", values);
 
    // Parse the retrieved strings.  They'll be in the form "Key Script Help"
-   for(S32 i = 0; i < values.size(); i++)
+   for(S32 i = 0; i < values.size(); ++i)
    {
       parseString(trim(values[i]), words, '|');
 
@@ -890,7 +890,7 @@ static void loadQuickChatMessages(CIniFile *ini)
 
    // Next, read any top-level messages
    Vector<string> messages;
-   for(S32 i = 0; i < keys; i++)
+   for(S32 i = 0; i < keys; ++i)
    {
       string keyName = ini->getSectionName(i);
       if(keyName.substr(0, 17) == "QuickChat_Message")   // Found message group
@@ -899,7 +899,7 @@ static void loadQuickChatMessages(CIniFile *ini)
 
    messages.sort(alphaSort);
 
-   for(S32 i = messages.size() - 1; i >= 0; i--)
+   for(S32 i = messages.size() - 1; i >= 0; --i)
    {
       QuickChatNode node;
       node.depth = 1;   // This is a top-level message node
@@ -914,7 +914,7 @@ static void loadQuickChatMessages(CIniFile *ini)
       QuickChatHelper::nodeTree.push_back(node);
    }
 
-   for(S32 i = 0; i < keys; i++)
+   for(S32 i = 0; i < keys; ++i)
    {
       string keyName = ini->getSectionName(i);
       if(keyName.substr(0, 22) == "QuickChatMessagesGroup" && keyName.find("_") == string::npos)   // Found message group
@@ -927,10 +927,10 @@ static void loadQuickChatMessages(CIniFile *ini)
    // quickChat render functions were designed to work with the messages sorted in reverse.  Rather than
    // reenigneer those, let's just iterate backwards and leave the render functions alone.
 
-   for(S32 i = groups.size()-1; i >= 0; i--)
+   for(S32 i = groups.size()-1; i >= 0; --i)
    {
       Vector<string> messages;
-      for(S32 j = 0; j < keys; j++)
+      for(S32 j = 0; j < keys; ++j)
       {
          string keyName = ini->getSectionName(j);
          if(keyName.substr(0, groups[i].length() + 1) == groups[i] + "_")
@@ -951,7 +951,7 @@ static void loadQuickChatMessages(CIniFile *ini)
       node.isMsgItem = false;
       QuickChatHelper::nodeTree.push_back(node);
 
-      for(S32 j = messages.size()-1; j >= 0; j--)
+      for(S32 j = messages.size()-1; j >= 0; --j)
       {
          node.depth = 2;   // This is a message node
          node.inputCode =  InputCodeManager::stringToInputCode(ini->GetValue(messages[j], "Key", "A").c_str());
@@ -1018,7 +1018,7 @@ static void writeDefaultQuickChatMessages(CIniFile *ini, IniSettings *iniSetting
    // Are there any QuickChatMessageGroups?  If not, we'll write the defaults.
    S32 keys = ini->GetNumSections();
 
-   for(S32 i = 0; i < keys; i++)
+   for(S32 i = 0; i < keys; ++i)
    {
       string keyName = ini->getSectionName(i);
       if(keyName.substr(0, 22) == "QuickChatMessagesGroup" && keyName.find("_") == string::npos)
@@ -1354,32 +1354,32 @@ static void writeDefaultQuickChatMessages(CIniFile *ini, IniSettings *iniSetting
 //void readJoystick()
 //{
 //   gJoystickMapping.enable = ini->GetValueYN("Joystick", "Enable", false);
-//   for(U32 i=0; i<MaxJoystickAxes*2; i++)
+//   for(U32 i=0; i<MaxJoystickAxes*2; ++i)
 //   {
 //      Vector<string> buttonList;
 //      parseString(ini->GetValue("Joystick", "Axes" + itos(i), i<8 ? itos(i+16) : ""), buttonList, ',');
 //      gJoystickMapping.axes[i] = 0;
-//      for(S32 j=0; j<buttonList.size(); j++)
+//      for(S32 j=0; j<buttonList.size(); ++j)
 //      {
 //         gJoystickMapping.axes[i] |= 1 << atoi(buttonList[j].c_str());
 //      }
 //   }
-//   for(U32 i=0; i<32; i++)
+//   for(U32 i=0; i<32; ++i)
 //   {
 //      Vector<string> buttonList;
 //      parseString(ini->GetValue("Joystick", "Button" + itos(i), i<10 ? itos(i) : ""), buttonList, ',');
 //      gJoystickMapping.button[i] = 0;
-//      for(S32 j=0; j<buttonList.size(); j++)
+//      for(S32 j=0; j<buttonList.size(); ++j)
 //      {
 //         gJoystickMapping.button[i] |= 1 << atoi(buttonList[j].c_str());
 //      }
 //   }
-//   for(U32 i=0; i<4; i++)
+//   for(U32 i=0; i<4; ++i)
 //   {
 //      Vector<string> buttonList;
 //      parseString(ini->GetValue("Joystick", "Pov" + itos(i), itos(i+10)), buttonList, ',');
 //      gJoystickMapping.pov[i] = 0;
-//      for(S32 j=0; j<buttonList.size(); j++)
+//      for(S32 j=0; j<buttonList.size(); ++j)
 //      {
 //         gJoystickMapping.pov[i] |= 1 << atoi(buttonList[j].c_str());
 //      }
@@ -1390,30 +1390,30 @@ static void writeDefaultQuickChatMessages(CIniFile *ini, IniSettings *iniSetting
 //{
 //   ini->setValueYN("Joystick", "Enable", gJoystickMapping.enable);
 //   ///for(listToString(alwaysPingList, ',')
-//   for(U32 i=0; i<MaxJoystickAxes*2; i++)
+//   for(U32 i=0; i<MaxJoystickAxes*2; ++i)
 //   {
 //      Vector<string> buttonList;
-//      for(U32 j=0; j<32; j++)
+//      for(U32 j=0; j<32; ++j)
 //      {
 //         if(gJoystickMapping.axes[i] & (1 << j))
 //            buttonList.push_back(itos(j));
 //      }
 //      ini->SetValue("Joystick", "Axes" + itos(i), listToString(buttonList, ','));
 //   }
-//   for(U32 i=0; i<32; i++)
+//   for(U32 i=0; i<32; ++i)
 //   {
 //      Vector<string> buttonList;
-//      for(U32 j=0; j<32; j++)
+//      for(U32 j=0; j<32; ++j)
 //      {
 //         if(gJoystickMapping.button[i] & (1 << j))
 //            buttonList.push_back(itos(j));
 //      }
 //      ini->SetValue("Joystick", "Button" + itos(i), listToString(buttonList, ','));
 //   }
-//   for(U32 i=0; i<4; i++)
+//   for(U32 i=0; i<4; ++i)
 //   {
 //      Vector<string> buttonList;
-//      for(U32 j=0; j<32; j++)
+//      for(U32 j=0; j<32; ++j)
 //      {
 //         if(gJoystickMapping.pov[i] & (1 << j))
 //            buttonList.push_back(itos(j));
@@ -1517,7 +1517,7 @@ void IniSettings::loadUserSettingsFromINI(CIniFile *ini, GameSettings *settings)
    // Get a list of sections... we should have one per user
    S32 sections = ini->GetNumSections();
 
-   for(S32 i = 0; i < sections; i++)
+   for(S32 i = 0; i < sections; ++i)
    {
       userSettings.name = ini->getSectionName(i);
 
@@ -1641,7 +1641,7 @@ static void writeSettings(CIniFile *ini, IniSettings *iniSettings)
       ini->sectionComment(section, " Settings entries contain a number of different options");
 
       // Write all our section comments for items defined in the new manner
-      for(S32 i = 0; i < settings.size(); i++)
+      for(S32 i = 0; i < settings.size(); ++i)
          ini->sectionComment(section, " " + settings[i]->getKey() + " - " + settings[i]->getComment());
 
 
@@ -1666,7 +1666,7 @@ static void writeSettings(CIniFile *ini, IniSettings *iniSettings)
    }
 
    // Write all settings defined in the new modern manner
-   for(S32 i = 0; i < settings.size(); i++)
+   for(S32 i = 0; i < settings.size(); ++i)
       ini->SetValue(section, settings[i]->getKey(), settings[i]->getValueString());
 
 
@@ -1717,14 +1717,14 @@ static void writeEditorSettings(CIniFile *ini, IniSettings *iniSettings)
       ini->sectionComment(section, " EditorSettings entries relate to items in the editor");
 
       // Write all our section comments for items defined in the new manner
-      for(S32 i = 0; i < settings.size(); i++)
+      for(S32 i = 0; i < settings.size(); ++i)
          ini->sectionComment(section, " " + settings[i]->getKey() + " - " + settings[i]->getComment());
 
       ini->sectionComment(section, "----------------");
    }
 
    // Write all settings defined in the new modern manner
-   for(S32 i = 0; i < settings.size(); i++)
+   for(S32 i = 0; i < settings.size(); ++i)
       ini->SetValue(section, settings[i]->getKey(), settings[i]->getValueString());
 }
 
@@ -1996,7 +1996,7 @@ void writeSkipList(CIniFile *ini, const Vector<string> *levelSkipList)
 
    Vector<string> normalizedSkipList;
 
-   for(S32 i = 0; i < levelSkipList->size(); i++)
+   for(S32 i = 0; i < levelSkipList->size(); ++i)
    {
       // "Normalize" the name a little before writing it
       string filename = lcase(levelSkipList->get(i));
@@ -2238,12 +2238,13 @@ static string checkName(const string &filename, const Vector<string> &folders, c
    string name;
    if(filename.find('.') != string::npos)       // filename has an extension
    {
-      for(S32 i = 0; i < folders.size(); i++)
+      for(S32 i = 0; i < folders.size(); ++i)
       {
          name = strictjoindir(folders[i], filename);
          if(fileExists(name))
             return name;
-         i++;
+         ++i;
+
       }
    }
    else
@@ -2251,13 +2252,14 @@ static string checkName(const string &filename, const Vector<string> &folders, c
       S32 i = 0;
       while(strcmp(extensions[i], ""))
       {
-         for(S32 j = 0; j < folders.size(); j++)
+         for(S32 j = 0; j < folders.size(); ++j)
          {
             name = strictjoindir(folders[j], filename + extensions[i]);
             if(fileExists(name))
                return name;
          }
-         i++;
+         ++i;
+
       }
    }
 

--- a/zap/controlObjectConnection.cpp
+++ b/zap/controlObjectConnection.cpp
@@ -59,7 +59,7 @@ void ControlObjectConnection::packetReceived(PacketNotify *notify)
 {
    if(isConnectionToServer())  // only client needs to handle this
    {
-      for(/* empty */; S8(firstMoveIndex - ((Zap::ControlObjectConnection::GamePacketNotify *) notify)->firstUnsentMoveIndex) < 0; firstMoveIndex++)
+      for(/* empty */; S8(firstMoveIndex - ((Zap::ControlObjectConnection::GamePacketNotify *) notify)->firstUnsentMoveIndex) < 0; ++firstMoveIndex)
          pendingMoves.erase(U32(0));
    }
    mServerPosition = ((GamePacketNotify *) notify)->lastControlObjectPosition;
@@ -152,7 +152,7 @@ void ControlObjectConnection::writePacket(BitStream *bstream, PacketNotify *noti
       // The first time through this loop, we'll be comparing the move to be packed with our empty move, and
       // so pack() only really has an effect when our move is actually doing something, either moving,
       // firing, or activating a module.  See the Move constructor and the pack() fn for more details.
-      for(S32 i = skipCount; i < pendingMoves.size(); i++)
+      for(S32 i = skipCount; i < pendingMoves.size(); ++i)
       {
          pendingMoves[i].pack(bstream, lastMove, true);
          lastMove = &pendingMoves[i];
@@ -210,13 +210,14 @@ void ControlObjectConnection::readPacket(BitStream *bstream)
 
       Move theMove;
 
-      for(/* empty */; S8(firstMove - firstMoveIndex) < 0 && count > 0; firstMove++)
+      for(/* empty */; S8(firstMove - firstMoveIndex) < 0 && count > 0; ++firstMove)
       {
          // Looks like we'll be ignoring these moves
-         count--;
+         --count;
+
          theMove.unpack(bstream, true);
       }
-      for(/* empty */; count > 0; count--)
+      for(/* empty */; count > 0; --count)
       {
          theMove.unpack(bstream, true);
          // Process the move, including crediting time to the client and all that joy.
@@ -230,7 +231,8 @@ void ControlObjectConnection::readPacket(BitStream *bstream)
             onGotNewMove(theMove);
          }
 
-         firstMoveIndex++;
+         ++firstMoveIndex;
+
       }
    }
    else     // Is connection to server (i.e. we're on the client, I think)
@@ -272,7 +274,7 @@ void ControlObjectConnection::readPacket(BitStream *bstream)
 
    if(mNeedReplayMoves && controlObject.isValid())
    {
-      for(S32 i = 0; i < pendingMoves.size(); i++)
+      for(S32 i = 0; i < pendingMoves.size(); ++i)
       {
          if(controlObject.isValid() && controlObject->getObjectTypeNumber() == PlayerShipTypeNumber)
             ((Ship*)controlObject.getPointer())->getState(&pendingMoves[i]);

--- a/zap/dataConnection.cpp
+++ b/zap/dataConnection.cpp
@@ -248,7 +248,8 @@ void DataSender::sendNextLine()
    if(mLineCtr < mLines.size())
    {
       connection->s2rSendLine(mLines[mLineCtr].c_str());
-      mLineCtr++;
+      ++mLineCtr;
+
    }
    else
    {

--- a/zap/engineerHelper.cpp
+++ b/zap/engineerHelper.cpp
@@ -78,7 +78,7 @@ HelperMenu::HelperMenuType EngineerHelper::getType() { return EngineerHelperType
 
 void EngineerHelper::setSelectedEngineeredObject(U32 objectType)
 {
-   for(U32 i = 0; i < ARRAYSIZE(engineerItemInfo); i++)
+   for(U32 i = 0; i < ARRAYSIZE(engineerItemInfo); ++i)
       if(engineerItemInfo[i].itemIndex == objectType)
          mSelectedIndex = i;
 }
@@ -133,7 +133,7 @@ bool EngineerHelper::processInputCode(InputCode inputCode)
 
    if(isMenuBeingDisplayed())    // Menu is being displayed, so interpret keystrokes as menu items
    {
-      for(U32 i = 0; i < ARRAYSIZE(engineerItemInfo); i++)
+      for(U32 i = 0; i < ARRAYSIZE(engineerItemInfo); ++i)
       {
          // Disallow selecting unselectable items
          if(!engineerItemInfo[i].showOnMenu)

--- a/zap/flagItem.cpp
+++ b/zap/flagItem.cpp
@@ -324,7 +324,7 @@ void FlagItem::removeOccupiedSpawnPoints(Vector<AbstractSpawn *> &spawnPoints) /
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
    // Now remove the occupied spots from our list of potential spawns
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
       if(flag->isAtHome() && (flag->getTeam() <= TEAM_NEUTRAL || flag->getTeam() == getTeam() || !isTeamGame))
@@ -332,7 +332,7 @@ void FlagItem::removeOccupiedSpawnPoints(Vector<AbstractSpawn *> &spawnPoints) /
          // Need to remove this flag's spawnpoint from the list of potential spawns... it's occupied, after all...
          // Note that if two spawnpoints are on top of one another, this will remove the first, leaving the other
          // on the unoccupied list, unless a second flag at this location removes it from the list on a subsequent pass.
-         for(S32 j = 0; j < spawnPoints.size(); j++)
+         for(S32 j = 0; j < spawnPoints.size(); ++j)
             if(spawnPoints[j]->getPos() == flag->mInitialPos)
             {
                spawnPoints.erase_fast(j);

--- a/zap/game.cpp
+++ b/zap/game.cpp
@@ -228,9 +228,10 @@ S32 Game::getPlayerCount() const
 S32 Game::getAuthenticatedPlayerCount() const
 {
    S32 count = 0;
-   for(S32 i = 0; i < mClientInfos.size(); i++)
+   for(S32 i = 0; i < mClientInfos.size(); ++i)
       if(!mClientInfos[i]->isRobot() && mClientInfos[i]->isAuthenticated())
-         count++;
+         ++count;
+
 
    return count;
 }
@@ -261,7 +262,7 @@ void Game::addToClientList(ClientInfo *clientInfo)
    //
    // NOTE - This can happen when a Robot line is found in a level file.  For some reason
    // it tries to get added twice to the game
-   for(S32 i = 0; i < mClientInfos.size(); i++)
+   for(S32 i = 0; i < mClientInfos.size(); ++i)
    {
       if(mClientInfos[i] == clientInfo)
          return;
@@ -270,16 +271,18 @@ void Game::addToClientList(ClientInfo *clientInfo)
    mClientInfos.push_back(clientInfo);
 
    if(clientInfo->isRobot())
-      mRobotCount++;
+      ++mRobotCount;
+
    else
-      mPlayerCount++;
+      ++mPlayerCount;
+
 }
 
 
 // Helper function for other find functions
 S32 Game::findClientIndex(const StringTableEntry &name)
 {
-   for(S32 i = 0; i < mClientInfos.size(); i++)
+   for(S32 i = 0; i < mClientInfos.size(); ++i)
    {
       if(mClientInfos[i]->getName() == name)
          return i;
@@ -296,9 +299,11 @@ void Game::removeFromClientList(const StringTableEntry &name)
    if(index >= 0)
    {
       if(mClientInfos[index]->isRobot())
-         mRobotCount--;
+         --mRobotCount;
+
       else
-         mPlayerCount--;
+         --mPlayerCount;
+
 
       mClientInfos.erase_fast(index);
    }
@@ -307,13 +312,15 @@ void Game::removeFromClientList(const StringTableEntry &name)
 
 void Game::removeFromClientList(ClientInfo *clientInfo)
 {
-   for(S32 i = 0; i < mClientInfos.size(); i++)
+   for(S32 i = 0; i < mClientInfos.size(); ++i)
       if(mClientInfos[i] == clientInfo)
       {
          if(mClientInfos[i]->isRobot())
-            mRobotCount--;
+            --mRobotCount;
+
          else
-            mPlayerCount--;
+            --mPlayerCount;
+
 
          mClientInfos.erase_fast(i);
          return;
@@ -490,7 +497,7 @@ bool          Game::getTeamHasFlag(S32 teamIndex) const { return mActiveTeamMana
 
 S32 Game::getTeamIndexFromTeamName(const char *teamName) const
 {
-   for(S32 i = 0; i < mActiveTeamManager->getTeamCount(); i++)
+   for(S32 i = 0; i < mActiveTeamManager->getTeamCount(); ++i)
       if(stricmp(teamName, getTeamName(i).getString()) == 0)
          return i;
 
@@ -509,13 +516,13 @@ S32 Game::getTeamIndexFromTeamName(const char *teamName) const
 // Rating may only work on server... not tested on client
 void Game::countTeamPlayers() const
 {
-   for(S32 i = 0; i < getTeamCount(); i++)
+   for(S32 i = 0; i < getTeamCount(); ++i)
    {
       TNLAssert(dynamic_cast<Team *>(getTeam(i)), "Invalid team");      // Assert for safety
       static_cast<Team *>(getTeam(i))->clearStats();                    // static_cast for speed
    }
 
-   for(S32 i = 0; i < getClientCount(); i++)
+   for(S32 i = 0; i < getClientCount(); ++i)
    {
       ClientInfo *clientInfo = getClientInfo(i);
 
@@ -551,7 +558,7 @@ S32 Game::findLargestTeamWithBots() const
    S32 largestTeamCount = 0;
    S32 largestTeamIndex = NONE;
 
-   for(S32 i = 0; i < getTeamCount(); i++)
+   for(S32 i = 0; i < getTeamCount(); ++i)
    {
       TNLAssert(dynamic_cast<Team *>(getTeam(i)), "Invalid team");
       Team *team = static_cast<Team *>(getTeam(i));
@@ -617,7 +624,7 @@ void Game::parseLevelLine(const char *line, GridDatabase *database, const string
       }
    }
 
-   for(U32 i = 0; i < argc; i++)
+   for(U32 i = 0; i < argc; ++i)
       argv[i] = args[i].c_str();
 
    try
@@ -641,7 +648,8 @@ void Game::loadLevelFromString(const string &contents, GridDatabase *database, c
    while(std::getline(iss, line))
    {
       parseLevelLine(line.c_str(), database, filename, lineNum);
-      lineNum++;
+      ++lineNum;
+
    }
 }
 
@@ -923,7 +931,7 @@ string Game::toLevelCode() const
    if(getLevelDatabaseId())
       str += string("LevelDatabaseId ") + itos(getLevelDatabaseId()) + "\n";
 
-   for(S32 i = 0; i < mActiveTeamManager->getTeamCount(); i++)
+   for(S32 i = 0; i < mActiveTeamManager->getTeamCount(); ++i)
       str += mActiveTeamManager->getTeam(i)->toLevelCode() + "\n";
 
    str += gameType->getSpecialsLine() + "\n";
@@ -968,7 +976,7 @@ void Game::onReadTeamChangeParam(S32 argc, const char **argv)
 
 void Game::onReadSpecialsParam(S32 argc, const char **argv, S32 lineNum)
 {
-   for(S32 i = 1; i < argc; i++)
+   for(S32 i = 1; i < argc; ++i)
       if(!getGameType()->processSpecialsParam(argv[i]))
          logprintf(LogConsumer::LogLevelError, "Invalid specials parameter: %s (line %d)", argv[i], lineNum);
 }
@@ -979,7 +987,7 @@ void Game::onReadScriptParam(S32 argc, const char **argv)
    Vector<string> args;
 
    // argv[0] is always "Script"
-   for(S32 i = 1; i < argc; i++)
+   for(S32 i = 1; i < argc; ++i)
       args.push_back(argv[i]);
 
    getGameType()->setScript(args);
@@ -989,7 +997,7 @@ void Game::onReadScriptParam(S32 argc, const char **argv)
 static string getString(S32 argc, const char **argv)
 {
    string s;
-   for(S32 i = 1; i < argc; i++)
+   for(S32 i = 1; i < argc; ++i)
    {
       s += argv[i];
       if(i < argc - 1)
@@ -1162,13 +1170,14 @@ void Game::addToDeleteList(BfObject *theObject, U32 delay)
 // Cycle through our pending delete list, and either delete an object or update its timer
 void Game::processDeleteList(U32 timeDelta)
 {
-   for(S32 i = 0; i < mPendingDeleteObjects.size(); i++)
+   for(S32 i = 0; i < mPendingDeleteObjects.size(); ++i)
       if(timeDelta > mPendingDeleteObjects[i].delay)
       {
          BfObject *g = mPendingDeleteObjects[i].theObject;
          delete g;
          mPendingDeleteObjects.erase_fast(i);
-         i--;
+         --i;
+
       }
       else
          mPendingDeleteObjects[i].delay -= timeDelta;
@@ -1180,7 +1189,7 @@ void Game::deleteObjects(U8 typeNumber)
 {
    fillVector.clear();
    mGameObjDatabase->findObjects(typeNumber, fillVector);
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(fillVector[i]);
       obj->deleteObject(0);
@@ -1193,7 +1202,7 @@ void Game::deleteObjects(TestFunc testFunc)
 {
    fillVector.clear();
    mGameObjDatabase->findObjects(testFunc, fillVector);
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(fillVector[i]);
       obj->deleteObject(0);
@@ -1214,7 +1223,7 @@ Rect Game::computeBarrierExtents()
    fillVector.clear();
    mGameObjDatabase->findObjects((TestFunc)isWallType, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
       extents.unionRect(fillVector[i]->getExtent());
 
    return extents;
@@ -1253,7 +1262,7 @@ string Game::makeUnique(const char *name)
    {
       unique = true;
 
-      for(S32 i = 0; i < getClientCount(); i++)
+      for(S32 i = 0; i < getClientCount(); ++i)
       {
          if(proposedName == getClientInfo(i)->getName().getString())     // Collision detected!
          {
@@ -1267,7 +1276,8 @@ string Game::makeUnique(const char *name)
             S32 maxNamePos = MAX_PLAYER_NAME_LENGTH - (S32)strlen(numstr);
             proposedName = string(name).substr(0, maxNamePos) + numstr;     // Make sure name won't grow too long
 
-            index++;
+            ++index;
+
 
             if(index == U32_MAX)
             {
@@ -1512,7 +1522,7 @@ void Game::seedRandomNumberGenerator(const string &name)
    buf[3] = U8(time >> 24);
 
    // Bytes from the name
-   for(S32 i = 0; i < nameBytes; i++)
+   for(S32 i = 0; i < nameBytes; ++i)
       buf[i + timeByteCount] = name.at(i);
 
    Random::addEntropy(buf, totalByteCount);     // May be some uninitialized bytes at the end of the buffer, but that's ok

--- a/zap/gameConnection.cpp
+++ b/zap/gameConnection.cpp
@@ -536,7 +536,8 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sSubmitPassword, (StringPtr pass), (pass),
 
       logprintf(LogConsumer::LogConnection, "%s - client \"%s\" provided incorrect password.",
                                                getNetAddressString(), mClientInfo->getName().getString());
-      mWrongPasswordCount++;
+      ++mWrongPasswordCount;
+
       if(mWrongPasswordCount > MAX_WRONG_PASSWORD)
          disconnect(NetConnection::ReasonError, "Too many wrong passwords");
    }
@@ -696,7 +697,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sSetParam,
       folderManager->levelDir = folder;
 
       // Send the new list of levels to all levelchangers
-      for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+      for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
       {
          ClientInfo *clientInfo = mServerGame->getClientInfo(i);
          GameConnection *conn = clientInfo->getConnection();
@@ -792,7 +793,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sSetParam,
       // If we're clearing the level change password, quietly grant access to anyone who doesn't already have it
       if(!strcmp(param.getString(), ""))
       {
-         for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+         for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
          {
             ClientInfo *clientInfo = mServerGame->getClientInfo(i);
             GameConnection *conn = clientInfo->getConnection();
@@ -810,7 +811,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sSetParam,
       }
       else  // If setting a password, remove everyone's permissions (except admins)
       {
-         for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+         for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
          {
             ClientInfo *clientInfo = mServerGame->getClientInfo(i);
             GameConnection *conn = clientInfo->getConnection();
@@ -834,7 +835,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sSetParam,
       // Revoke all admin permissions upon password change (except Owner)
       if(mClientInfo->isOwner())
       {
-         for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+         for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
          {
             ClientInfo *clientInfo = mServerGame->getClientInfo(i);
             GameConnection *conn = clientInfo->getConnection();
@@ -860,7 +861,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sSetParam,
       msg = serverNameChanged;
 
       // If we've changed the server name, notify all the clients
-      for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+      for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
          if(mServerGame->getClientInfo(i)->getConnection())
             mServerGame->getClientInfo(i)->getConnection()->s2cSetServerName(mSettings->getHostName());
    }
@@ -1164,7 +1165,7 @@ void GameConnection::sendLevelList()
    s2cAddLevel("", NoGameType);
 
    // Build list remotely by sending level names one-by-one
-   for(S32 i = 0; i < mServerGame->getLevelCount(); i++)
+   for(S32 i = 0; i < mServerGame->getLevelCount(); ++i)
    {
       LevelInfo levelInfo = mServerGame->getLevelInfo(i);
       s2cAddLevel(levelInfo.mLevelName, levelInfo.mLevelType);
@@ -1352,7 +1353,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sRequestShutdown, (U16 time, StringPtr reaso
    mServerGame->setShuttingDown(true, time, this, reason.getString());
 
    // Broadcast the message
-   for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+   for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
    {
       GameConnection *conn = mServerGame->getClientInfo(i)->getConnection();
       if(conn)
@@ -1378,7 +1379,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sRequestCancelShutdown, (), (), NetClassGrou
    logprintf(LogConsumer::ServerFilter, "User %s canceled shutdown", mClientInfo->getName().getString());
 
    // Broadcast the message
-   for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+   for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
    {
       GameConnection *conn = mServerGame->getClientInfo(i)->getConnection();
 
@@ -1424,7 +1425,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sSetIsBusy, (bool isBusy), (isBusy), NetClas
 
    mIsBusy = isBusy;
 
-   for(S32 i = 0; i < mServerGame->getClientCount(); i++)
+   for(S32 i = 0; i < mServerGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mServerGame->getClientInfo(i);
 
@@ -1507,7 +1508,7 @@ TNL_IMPLEMENT_RPC(GameConnection, s2rSendableFlags, (U8 flags), (flags), NetClas
       mLevelSource = levelSource;
 
       c2sRemoveLevel(-1); // clears all levels
-      for(S32 i = 0; i < levelSource->getLevelCount(); i++)
+      for(S32 i = 0; i < levelSource->getLevelCount(); ++i)
       {
          string filename = mSettings->getFolderManager()->findLevelFile(levelSource->getLevelFileName(i));
          levelSource->populateLevelInfoFromSource(filename, i);
@@ -1579,7 +1580,8 @@ void GameConnection::ReceivedLevelFile(const U8 *leveldata, U32 levelsize, const
                foundscript = true;
                break;
             }
-            c++;
+            ++c;
+
          }
          if(foundscript)
          {  // Found a line, write a modified Script filename we will soon write to.
@@ -1591,12 +1593,14 @@ void GameConnection::ReceivedLevelFile(const U8 *leveldata, U32 levelsize, const
             //fputc('"', f);  // End with quotation mark
             c += 6;
             while(c < levelsize && leveldata[c] == 32) // First one or more spaces.
-               c++;
+               ++c;
+
             bool isInQuote = false; // to ignore spaces while in quotoation marks
             while(c < levelsize && leveldata[c] >= 32 && (isInQuote || leveldata[c] != 32)) // Go to end of second arg
             {
                isInQuote = isInQuote != (leveldata[c] == '"');
-               c++;
+               ++c;
+
             }
          }
          else
@@ -1750,7 +1754,7 @@ TNL_IMPLEMENT_RPC(GameConnection, c2sRequestRecordedGameplay, (StringPtr file), 
       GameRecorderServer *g = mServerGame->getGameRecorder();
       if(g)
       {
-         for(S32 i = 0; i < levels.size(); i++)
+         for(S32 i = 0; i < levels.size(); ++i)
             if(levels[i] == g->mFileName)
             {
                levels.erase(i);
@@ -1848,7 +1852,7 @@ bool GameConnection::TransferLevelFile(const char *filename)
 
                   // Vector deleteAndClear doesn't work for SafePtr on OSX, so we do it the
                   // old-fashioned way
-                  for(S32 i = 0; i < mPendingTransferData.size(); i++)
+                  for(S32 i = 0; i < mPendingTransferData.size(); ++i)
                      delete mPendingTransferData[i].getPointer();
                   mPendingTransferData.clear();
 
@@ -1879,9 +1883,9 @@ bool GameConnection::TransferLevelFile(const char *filename)
       }
 
       s2rTransferFileSize(totalTransferSize);
-      for(U32 i=0; i < pendingleveltransfer; i++)
+      for(U32 i=0; i < pendingleveltransfer; ++i)
          s2rSendDataParts(TransmissionLevelFile, ByteBufferPtr(mPendingTransferData[i]));
-      for(U32 i=pendingleveltransfer; i < U32(mPendingTransferData.size()); i++)
+      for(U32 i=pendingleveltransfer; i < U32(mPendingTransferData.size()); ++i)
          s2rSendDataParts(TransmissionLevelGenFile, ByteBufferPtr(mPendingTransferData[i]));
 
       s2rSendDataParts(TransmissionDone, ByteBufferPtr(new ByteBuffer(0)));
@@ -1927,7 +1931,7 @@ bool GameConnection::TransferRecordedGameplay(const char *filename)
 
       s2cSetFilename(filename);
       s2rTransferFileSize(totalTransferSize);
-      for(U32 i=0; i < U32(mPendingTransferData.size()) - 1; i++)
+      for(U32 i=0; i < U32(mPendingTransferData.size()) - 1; ++i)
          s2rSendDataParts(TransmissionRecordedGame, ByteBufferPtr(mPendingTransferData[i]));
 
       s2rSendDataParts(TransmissionRecordedGame | TransmissionDone, ByteBufferPtr(new ByteBuffer(0)));
@@ -1950,9 +1954,10 @@ F32 GameConnection::getFileProgressMeter()
    {
       // Sent data becomes NULL, which we can use to see the upload progress.
       S32 numberOfNull = 0;
-      for(S32 i = 0; i < mPendingTransferData.size(); i++)
+      for(S32 i = 0; i < mPendingTransferData.size(); ++i)
          if(mPendingTransferData[i].isNull())
-            numberOfNull++;
+            ++numberOfNull;
+
       if(numberOfNull == mPendingTransferData.size())
          mPendingTransferData.resize(0); // Everything is now NULL, zero size the Vector.
       else
@@ -2058,14 +2063,17 @@ bool GameConnection::readConnectRequest(BitStream *stream, NetConnection::Termin
    char *name = buf;
    while(len && *name == ' ')
    {
-      name++;
-      len--;
+      ++name;
+
+      --len;
+
    }
    while(len && name[len-1] == ' ')
-      len--;
+      --len;
+
 
    // Remove invisible chars and quotes
-   for(std::size_t i = 0; i < len; i++)
+   for(std::size_t i = 0; i < len; ++i)
       if(name[i] < ' ' || name[i] > '~' || name[i] == '"')
          name[i] = 'X';
 
@@ -2146,7 +2154,8 @@ bool GameConnection::readConnectAccept(BitStream *stream, NetConnection::Termina
 void GameConnection::resetAuthenticationTimer()
 {
    mAuthenticationTimer.reset(MASTER_SERVER_FAILURE_RETRY_TIME + 1000);
-   mAuthenticationCounter++;
+   ++mAuthenticationCounter;
+
 }
 
 
@@ -2346,7 +2355,7 @@ void GameConnection::onConnectionEstablished_client()
       string addr = getNetAddressString();
       bool found = false;
 
-      for(S32 i = 0; i < mSettings->getIniSettings()->prevServerListFromMaster.size(); i++)
+      for(S32 i = 0; i < mSettings->getIniSettings()->prevServerListFromMaster.size(); ++i)
          if(mSettings->getIniSettings()->prevServerListFromMaster[i].compare(addr) == 0)
          {
             found = true;

--- a/zap/gameConnection.h
+++ b/zap/gameConnection.h
@@ -355,7 +355,7 @@ public:
          pending.clear();
          sentTiles.clear();
          sentTiles.resize(tileCount);
-         for(U32 i = 0; i < tileCount; i++)
+         for(U32 i = 0; i < tileCount; ++i)
             sentTiles[i] = false;
          totalTiles = tileCount;
       }

--- a/zap/gameObjectRender.cpp
+++ b/zap/gameObjectRender.cpp
@@ -124,7 +124,8 @@ void drawDashedLine(const Point &start, const Point &end, F32 period, F32 dutycy
       currentDashStart += periodSeg;
       currentDashEnd   += periodSeg;
       if(numPeriods != 0) // Don't wrap around
-         numPeriods--;
+         --numPeriods;
+
 
       firstDashStart = currentDashStart;
    }
@@ -140,7 +141,7 @@ void drawDashedLine(const Point &start, const Point &end, F32 period, F32 dutycy
 
 
    // Draw middles
-   for(U32 i = 0; i < numPeriods; i++)
+   for(U32 i = 0; i < numPeriods; ++i)
    {
       vertexArray.push_back(currentDashStart);
       vertexArray.push_back(currentDashEnd);
@@ -192,13 +193,15 @@ void drawArc(const Point &pos, F32 radius, F32 startAngle, F32 endAngle)
    {
       arcVertexArray[2*count]       = pos.x + cos(theta) * radius;
       arcVertexArray[(2*count) + 1] = pos.y + sin(theta) * radius;
-      count++;
+      ++count;
+
    }
 
    // Make sure arc makes it all the way to endAngle...  rounding errors look terrible!
    arcVertexArray[2*count]       = pos.x + cos(endAngle) * radius;
    arcVertexArray[(2*count) + 1] = pos.y + sin(endAngle) * radius;
-   count++;
+   ++count;
+
 
    Renderer::get().renderVertexArray(arcVertexArray, count, RenderType::LineStrip);
 }
@@ -208,7 +211,7 @@ void drawDashedArc(const Point &center, F32 radius, F32 arcTheta, S32 dashCount,
 {
    F32 interimAngle = arcTheta / dashCount;
 
-   for(S32 i = 0; i < dashCount; i++)
+   for(S32 i = 0; i < dashCount; ++i)
       drawArc(center, radius, interimAngle * i + offsetAngle, (interimAngle * (i + 1)) - dashSpaceCentralAngle + offsetAngle);
 }
 
@@ -240,7 +243,7 @@ void drawAngledRayArc(const Point &center, F32 innerRadius, F32 outerRadius, F32
 {
    F32 interimAngle = centralAngle / rayCount;
 
-   for(S32 i = 0; i < rayCount; i++)
+   for(S32 i = 0; i < rayCount; ++i)
       drawAngledRay(center, innerRadius, outerRadius, interimAngle * i + offsetAngle);
 }
 
@@ -325,17 +328,20 @@ void drawFilledArc(const Point &pos, F32 radius, F32 startAngle, F32 endAngle)
    {
       filledArcVertexArray[2*count]       = pos.x + cos(theta) * radius;
       filledArcVertexArray[(2*count) + 1] = pos.y + sin(theta) * radius;
-      count++;
+      ++count;
+
    }
 
    // Make sure arc makes it all the way to endAngle...  rounding errors look terrible!
    filledArcVertexArray[2*count]       = pos.x + cos(endAngle) * radius;
    filledArcVertexArray[(2*count) + 1] = pos.y + sin(endAngle) * radius;
-   count++;
+   ++count;
+
 
    filledArcVertexArray[2*count]       = pos.x;
    filledArcVertexArray[(2*count) + 1] = pos.y;
-   count++;
+   ++count;
+
 
    Renderer::get().renderVertexArray(filledArcVertexArray, count, RenderType::TriangleFan);
 }
@@ -388,7 +394,8 @@ void drawFilledEllipseUtil(const Point &pos, F32 width, F32 height, F32 angle, R
 
       vertexArray[2*count]     = pos.x + (width * cosalpha * cosbeta - height * sinalpha * sinbeta);
       vertexArray[(2*count)+1] = pos.y + (width * cosalpha * sinbeta + height * sinalpha * cosbeta);
-      count++;
+      ++count;
+
    }
 
    Renderer::get().renderVertexArray(vertexArray, ARRAYSIZE(vertexArray) / 2, mode);
@@ -407,7 +414,7 @@ void drawPolygon(const Point &pos, S32 sides, F32 radius, F32 angle)
 
    F32 theta = 0;
    F32 dTheta = FloatTau / sides;
-   for(S32 i = 0; i < sides; i++)
+   for(S32 i = 0; i < sides; ++i)
    {
       polygonVertexArray[2*i]       = pos.x + cos(theta + angle) * radius;
       polygonVertexArray[(2*i) + 1] = pos.y + sin(theta + angle) * radius;
@@ -466,7 +473,8 @@ void drawFilledSector(const Point &pos, F32 radius, F32 start, F32 end)
    {
       filledSectorVertexArray[2*count]       = pos.x + cos(theta) * radius;
       filledSectorVertexArray[(2*count) + 1] = pos.y + sin(theta) * radius;
-      count++;
+      ++count;
+
    }
 
    Renderer::get().renderVertexArray(filledSectorVertexArray, count, RenderType::TriangleFan);
@@ -494,7 +502,7 @@ void renderHealthBar(F32 health, const Point &center, const Point &dir, F32 leng
    Point segMid;                                   // Reusable container
 
    Vector<Point> vertexArray(2 * hatchCount);
-   for(F32 i = 0; i < hatchCount; i++)
+   for(F32 i = 0; i < hatchCount; ++i)
    {
       dirx = dir;                                  // Reset to original value
       segMid = base + dirx * (i + 0.5f) / F32(HATCH_COUNT) * length;      // Adding 0.5 causes hatches to be centered properly
@@ -568,8 +576,8 @@ static void renderShipFlame(ShipFlame *flames, S32 flameCount, F32 thrust, F32 a
 {
    Renderer& r = Renderer::get();
 
-   for(S32 i = 0; i < flameCount; i++)
-      for(S32 j = 0; j < flames[i].layerCount; j++)
+   for(S32 i = 0; i < flameCount; ++i)
+      for(S32 j = 0; j < flames[i].layerCount; ++j)
       {
          ShipFlameLayer *flameLayer = &flames[i].layers[j];
          r.setColor(flameLayer->color, alpha);
@@ -623,7 +631,7 @@ void renderShip(ShipShape::ShipShapeType shapeType, const Color *shipColor, cons
 
    // Inner hull with colored insides
    r.setColor(*shipColor, alpha);
-   for(S32 i = 0; i < shipShapeInfo->innerHullPieceCount; i++)
+   for(S32 i = 0; i < shipShapeInfo->innerHullPieceCount; ++i)
       r.renderVertexArray(shipShapeInfo->innerHullPieces[i].points, shipShapeInfo->innerHullPieces[i].pointCount, RenderType::LineStrip);
 
    // Render health bar
@@ -647,7 +655,7 @@ static void calcThrustComponents(const Point &velocity, F32 angle, F32 deltaAngl
    F32 len = vel.len();
 
    // Reset thrusts
-   for(U32 i = 0; i < 4; i++)
+   for(U32 i = 0; i < 4; ++i)
       thrusts[i] = 0;
 
    if(len > 0)
@@ -661,7 +669,7 @@ static void calcThrustComponents(const Point &velocity, F32 angle, F32 deltaAngl
       shipDirs[2].set( shipDirs[0].y, -shipDirs[0].x);
       shipDirs[3].set(-shipDirs[0].y,  shipDirs[0].x);
 
-      for(U32 i = 0; i < 4; i++)
+      for(U32 i = 0; i < 4; ++i)
          thrusts[i] = shipDirs[i].dot(vel);
    }
 
@@ -672,7 +680,7 @@ static void calcThrustComponents(const Point &velocity, F32 angle, F32 deltaAngl
       thrusts[2] += 0.25;
 
    if(boostActive)
-      for(U32 i = 0; i < 4; i++)
+      for(U32 i = 0; i < 4; ++i)
          thrusts[i] *= 1.3f;
 }
 
@@ -1054,14 +1062,14 @@ void renderShipRepairRays(const Point &pos, const Ship *ship, Vector<SafePtr<BfO
    r.setLineWidth(gLineWidth3);
    r.setColor(Colors::red, alpha);
 
-   for(S32 i = 0; i < repairTargets.size(); i++)
+   for(S32 i = 0; i < repairTargets.size(); ++i)
    {
       if(repairTargets[i] && repairTargets[i].getPointer() != ship)
       {
          Vector<Point> targetRepairLocations = repairTargets[i]->getRepairLocations(pos);
 
          Vector<Point> vertexArray(2 * targetRepairLocations.size());
-         for(S32 i = 0; i < targetRepairLocations.size(); i++)
+         for(S32 i = 0; i < targetRepairLocations.size(); ++i)
          {
             vertexArray.push_back(pos);
             vertexArray.push_back(targetRepairLocations[i]);
@@ -1182,7 +1190,7 @@ void renderTeleporter(const Point &pos, U32 type, bool spiralInwards, U32 time, 
    if(!trackerInit)
    {
       trackerInit = true;
-      for(U32 i = 0; i < MaxParticles; i++)
+      for(U32 i = 0; i < MaxParticles; ++i)
       {
          Tracker &t = particles[i];
 
@@ -1210,7 +1218,7 @@ void renderTeleporter(const Point &pos, U32 type, bool spiralInwards, U32 time, 
 //      glHint(GL_POLYGON_SMOOTH_HINT, GL_FASTEST);
 
       // Draw a different line for each destination
-      for(S32 i = 0; i < dests->size(); i++)
+      for(S32 i = 0; i < dests->size(); ++i)
       {
          F32 ang = pos.angleTo(dests->get(i));
          F32 sina = sin(ang);
@@ -1260,14 +1268,14 @@ void renderTeleporter(const Point &pos, U32 type, bool spiralInwards, U32 time, 
    // of the teleporter.  This makes the whole teleport look white when you move a
    // ship into it and it shrinks; then it expands and slowly fades back the colors
    Color liveColors[NumColors];
-   for(S32 i = 0; i < NumColors; i++)
+   for(S32 i = 0; i < NumColors; ++i)
    {
       Color c(colors[type][i][0], colors[type][i][1], colors[type][i][2]);
       liveColors[i].interp(radiusFraction, Colors::white, c);
    }
 
    Color deadColors[NumColors];
-   for(S32 i = 0; i < NumColors; i++)
+   for(S32 i = 0; i < NumColors; ++i)
    {
       Color c(colors[3][i][0], colors[3][i][1], colors[3][i][2]);
       deadColors[i].interp(radiusFraction, Colors::white, c);
@@ -1288,7 +1296,7 @@ void renderTeleporter(const Point &pos, U32 type, bool spiralInwards, U32 time, 
    F64 time_f64 = (F64)time * 0.001;
 
    // Draw the Trackers
-   for(U32 i = 0; i < MaxParticles; i++)
+   for(U32 i = 0; i < MaxParticles; ++i)
    {
       // Do some math first
       Tracker &t = particles[i];
@@ -1350,7 +1358,7 @@ void renderTeleporter(const Point &pos, U32 type, bool spiralInwards, U32 time, 
       teleporterColorArray[6] = currentColor->b;
       teleporterColorArray[7] = alpha * alphaMod;
 
-      for(U32 j = 0; j <= vertexCount; j++)
+      for(U32 j = 0; j <= vertexCount; ++j)
       {
          F32 frac = j / F32(vertexCount);
          F32 width = beamWidth * (1 - frac) * 0.5f;
@@ -1411,7 +1419,7 @@ void renderPolyLineVertices(BfObject *obj, bool snapping, F32 currentScale)
    // Draw the vertices of the wall or the polygon area
    S32 verts = obj->getVertCount();
 
-   for(S32 j = 0; j < verts; j++)
+   for(S32 j = 0; j < verts; ++j)
    {
       if(obj->vertSelected(j))
          renderVertex(SelectedVertex,     obj->getVert(j), j, currentScale, 1);   // Hollow yellow boxes with number
@@ -1467,7 +1475,7 @@ void renderTurret(const Color &c, const Color &hbc, Point anchor, Point normal, 
 
    // Render half-circle front
    Vector<Point> vertexArray;
-   for(S32 x = -10; x <= 10; x++)
+   for(S32 x = -10; x <= 10; ++x)
    {
       F32 theta = x * FloatHalfPi * 0.1f;
       Point pos = normal * cos(theta) + cross * sin(theta);
@@ -1482,7 +1490,7 @@ void renderTurret(const Color &c, const Color &hbc, Point anchor, Point normal, 
    if(healRate > 0)
    {
       Vector<Point> pointArray;
-      for(S32 x = -4; x <= 4; x++)
+      for(S32 x = -4; x <= 4; ++x)
       {
          F32 theta = x * FloatHalfPi * 0.2f;
          Point pos = normal * cos(theta) + cross * sin(theta);
@@ -1731,7 +1739,7 @@ void drawStar(const Point &pos, S32 points, F32 radius, F32 innerRadius)
    Point p;
 
    Vector<Point> pts;
-   for(S32 i = 0; i < points * 2; i++)
+   for(S32 i = 0; i < points * 2; ++i)
    {
       p.set(r * cos(a), r * sin(a));
       pts.push_back(p + pos);
@@ -1765,7 +1773,7 @@ void drawFilledStar(const Point &pos, S32 points, F32 radius, F32 innerRadius)
    core.clear();
    outline.clear();
 
-   for(S32 i = 0; i < points * 2; i++)
+   for(S32 i = 0; i < points * 2; ++i)
    {
       p.set(r * cos(a) + pos.x, r * sin(a) + pos.y);
 
@@ -1859,7 +1867,7 @@ void renderNavMeshBorders(const Vector<NeighboringZone> &borders)
    r.setColor(Colors::cyan);
 
    // Go through each border and render
-   for(S32 i = 0; i < borders.size(); i++)
+   for(S32 i = 0; i < borders.size(); ++i)
    {
       F32 vertices[] = {
             borders[i].borderStart.x, borders[i].borderStart.y,
@@ -2037,7 +2045,7 @@ static void drawInterruptedCircle(const Point &center, F32 radius, const F32 ang
    if(lastAngle >= FloatTau)
       lastAngle -= FloatTau;
 
-   for(S32 i = 0; i < 4; i++)
+   for(S32 i = 0; i < 4; ++i)
    {
       F32 gapStart = angles[i] - halfGap;
       F32 gapEnd = angles[i] + halfGap;
@@ -2594,7 +2602,7 @@ void renderTilePolys(const Vector<WallPoly> &wallPolys, const Color &fillColor, 
    // Pass 1: fill all polys using precomputed triangulation
    static const Color DEST_FILL(0.04f, 0.15f, 0.06f);  // green = destructible fill
    r.setColor(fillColor);
-   for(S32 i = 0; i < wallPolys.size(); i++)
+   for(S32 i = 0; i < wallPolys.size(); ++i)
    {
       const WallPoly &wallPoly = wallPolys[i];
       if(wallPoly.cachedFill.size() < 3)
@@ -2613,7 +2621,7 @@ void renderTilePolys(const Vector<WallPoly> &wallPolys, const Color &fillColor, 
    // destructible edges in DEST_COLOR (green)
    static const Color DEST_COLOR(0.0f, 1.0f, 0.0f);  // green = destructible outline
    r.setColor(outlineColor);
-   for(S32 i = 0; i < wallPolys.size(); i++)
+   for(S32 i = 0; i < wallPolys.size(); ++i)
    {
       const WallPoly &wallPoly = wallPolys[i];
       if(wallPoly.numVerts() < 3)
@@ -2637,7 +2645,7 @@ void renderSpeedZone(const Vector<Point> &points, U32 time)
    Renderer& r = Renderer::get();
    r.setColor(Colors::red);
 
-   for(S32 j = 0; j < 2; j++)
+   for(S32 j = 0; j < 2; ++j)
    {
       S32 start = j * points.size() / 2;    // GoFast comes in two equal shapes
       r.renderVertexArray((F32*)points.address(), points.size() / 2, RenderType::LineLoop, start, sizeof(Point));
@@ -2781,7 +2789,7 @@ void renderCore(const Point &pos, const Color *coreColor, const Color &hbc, U32 
 
    Point dir;   // Reusable container
 
-   for(S32 i = 0; i < CORE_PANELS; i++)
+   for(S32 i = 0; i < CORE_PANELS; ++i)
    {
       dir = (panelGeom->repair[i] - pos);
       dir.normalize();
@@ -2843,7 +2851,8 @@ void renderCore(const Point &pos, const Color *coreColor, const Color &hbc, U32 
          colorArray[(4*count)+1]  = coreColor->g;
          colorArray[(4*count)+2]  = coreColor->b;
          colorArray[(4*count)+3]  = theta / FloatTau;
-         count++;
+         ++count;
+
       }
       r.renderColored(vertexArray, colorArray, ARRAYSIZE(vertexArray)/2, RenderType::LineLoop);
    }
@@ -3365,7 +3374,7 @@ void drawCircle(F32 x, F32 y, F32 radius, const Color *color, F32 alpha)
    F32 vertexArray[2 * NUM_CIRCLE_SIDES];
 
    // This is a repeated rotation
-   for(S32 i = 0; i < NUM_CIRCLE_SIDES; i++)
+   for(S32 i = 0; i < NUM_CIRCLE_SIDES; ++i)
    {
       vertexArray[(2*i)]     = curX + x;
       vertexArray[(2*i) + 1] = curY + y;
@@ -3443,7 +3452,7 @@ void drawGear(const Point &center, S32 teeth, F32 radius1, F32 radius2, F32 ang1
    F32 a = Float2Pi / teeth;
    F32 theta  = -ang1rad / 2;    // Start a little rotated to get an outer tooth facing up!
 
-   for(S32 i = 0; i < teeth; i++)
+   for(S32 i = 0; i < teeth; ++i)
    {
       pts.push_back(Point(-radius1 * sin(theta), radius1 * cos(theta)));
       theta += ang1rad;
@@ -3875,8 +3884,8 @@ void renderStars(const Point *stars, const Color *colors, S32 numStars, F32 alph
    r.enableBlending();
 
    // The (F32(xPage + 1.f) == xPage) part becomes true, which could cause endless loop problem freezing game when way too far off the center.
-   for(F32 xPage = upperLeft.x + fx1; xPage < lowerRight.x + fx2 && !(F32(xPage + 1.f) == xPage); xPage++)
-      for(F32 yPage = upperLeft.y + fy1; yPage < lowerRight.y + fy2 && !(F32(yPage + 1.f) == yPage); yPage++)
+   for(F32 xPage = upperLeft.x + fx1; xPage < lowerRight.x + fx2 && !(F32(xPage + 1.f) == xPage); ++xPage)
+      for(F32 yPage = upperLeft.y + fy1; yPage < lowerRight.y + fy2 && !(F32(yPage + 1.f) == yPage); ++yPage)
       {
          r.pushMatrix();
             r.scale(starChunkSize);   // Creates points with coords btwn 0 and starChunkSize
@@ -3901,7 +3910,7 @@ void renderWalls(const GridDatabase *wallSegmentDatabase, const Vector<Point> &w
       // Render walls that have been moved first (i.e. render their shadows)
       if(moved)
       {
-         for(S32 i = 0; i < count; i++)
+         for(S32 i = 0; i < count; ++i)
          {
             WallSegment *wallSegment = static_cast<WallSegment *>(wallSegmentDatabase->getObjectByIndex(i));
             if(wallSegment->isSelected())
@@ -3909,7 +3918,7 @@ void renderWalls(const GridDatabase *wallSegmentDatabase, const Vector<Point> &w
          }
       }
 
-      for(S32 i = 0; i < count; i++)
+      for(S32 i = 0; i < count; ++i)
       {
          WallSegment *wallSegment = static_cast<WallSegment *>(wallSegmentDatabase->getObjectByIndex(i));
          if(!moved || !wallSegment->isSelected())
@@ -3925,7 +3934,7 @@ void renderWalls(const GridDatabase *wallSegmentDatabase, const Vector<Point> &w
             {
                S32 ownerId = wallSegment->getOwner();
                const Vector<DatabaseObject *> *objs = editorDb->findObjects_fast();
-               for(S32 o = 0; o < objs->size(); o++)
+               for(S32 o = 0; o < objs->size(); ++o)
                {
                   BfObject *obj = static_cast<BfObject *>(objs->get(o));
                   if(isWallType(obj->getObjectTypeNumber()) && obj->getSerialNumber() == ownerId)
@@ -3950,7 +3959,7 @@ void renderWalls(const GridDatabase *wallSegmentDatabase, const Vector<Point> &w
    }
    else  // Render selected/moving walls last so they appear on top; this is pass 2,
    {
-      for(S32 i = 0; i < count; i++)
+      for(S32 i = 0; i < count; ++i)
       {
          WallSegment *wallSegment = static_cast<WallSegment *>(wallSegmentDatabase->getObjectByIndex(i));
          if(wallSegment->isSelected())
@@ -3961,7 +3970,7 @@ void renderWalls(const GridDatabase *wallSegmentDatabase, const Vector<Point> &w
             {
                S32 ownerId = wallSegment->getOwner();
                const Vector<DatabaseObject *> *objs = editorDb->findObjects_fast();
-               for(S32 o = 0; o < objs->size(); o++)
+               for(S32 o = 0; o < objs->size(); ++o)
                {
                   BfObject *obj = static_cast<BfObject *>(objs->get(o));
                   if(isWallType(obj->getObjectTypeNumber()) && obj->getSerialNumber() == ownerId)
@@ -3991,7 +4000,7 @@ void renderWalls(const GridDatabase *wallSegmentDatabase, const Vector<Point> &w
       r.setLineWidth(gLineWidth1);
 
       //glColor(Colors::magenta);
-      for(S32 i = 0; i < wallEdgePoints.size(); i++)
+      for(S32 i = 0; i < wallEdgePoints.size(); ++i)
          renderSmallSolidVertex(currentScale, wallEdgePoints[i], dragMode);
 
       r.setLineWidth(gDefaultLineWidth);
@@ -4063,7 +4072,7 @@ void drawObjectiveArrow(const Point &nearestPoint, F32 zoomFraction, const Color
    vertices[2].set(p3.x, p3.y);
 
    // This loops twice: once to render the objective arrow, once to render the outline
-   for(S32 i = 0; i < 2; i++)
+   for(S32 i = 0; i < 2; ++i)
    {
       renderer.setColor(i == 1 ? fillColor : *outlineColor, alpha);
       renderer.renderVertexArray((F32 *)(vertices), ARRAYSIZE(vertices), i == 1 ? RenderType::TriangleFan : RenderType::LineLoop);
@@ -4145,7 +4154,7 @@ void renderHeavysetArrow(const Point &pos, const Point &dest, const Color &color
 {
    Renderer& r = Renderer::get();
 
-   for(S32 i = 1; i >= 0; i--)
+   for(S32 i = 1; i >= 0; --i)
    {
       // Draw heavy colored line with colored core
       r.setLineWidth(i ? gLineWidth4 : gDefaultLineWidth);

--- a/zap/gameStats.cpp
+++ b/zap/gameStats.cpp
@@ -137,7 +137,7 @@ char getResult(S32 scores, S32 score1, S32 score2, S32 currScore, bool isFirst)
 // Fills in some of the blanks in the gameStats struct; not everything is sent
 void processStatsResults(GameStats *gameStats)
 {
-   for(S32 i = 0; i < gameStats->teamStats.size(); i++)
+   for(S32 i = 0; i < gameStats->teamStats.size(); ++i)
    {
       Vector<PlayerStats> *playerStats = &gameStats->teamStats[i].playerStats;
 
@@ -145,7 +145,7 @@ void processStatsResults(GameStats *gameStats)
       if(! gameStats->isTeamGame)
       {
          playerStats->sort(playerScoreSort);
-         for(S32 j = 0; j < playerStats->size(); j++)
+         for(S32 j = 0; j < playerStats->size(); ++j)
             (*playerStats)[j].gameResult =
                getResult(playerStats->size(), (*playerStats)[0].points, playerStats->size() == 1 ?
                                                             0 : (*playerStats)[1].points, (*playerStats)[j].points, j == 0);
@@ -156,11 +156,11 @@ void processStatsResults(GameStats *gameStats)
    {
       Vector<TeamStats> *teams = &gameStats->teamStats;
       teams->sort(teamScoreSort);
-      for(S32 i = 0; i < teams->size(); i++)
+      for(S32 i = 0; i < teams->size(); ++i)
       {
          (*teams)[i].gameResult =
             getResult(teams->size(), (*teams)[0].score, teams->size() == 1 ? 0 : (*teams)[1].score, (*teams)[i].score, i == 0);
-         for(S32 j = 0; j < (*teams)[i].playerStats.size(); j++) // make all players in a team same gameResults
+         for(S32 j = 0; j < (*teams)[i].playerStats.size(); ++j) // make all players in a team same gameResults
             (*teams)[i].playerStats[j].gameResult = (*teams)[i].gameResult;
       }
    }
@@ -478,7 +478,7 @@ void read(TNL::BitStream &s, Zap::GameStats *val, U8 version)
 
    val->playerCount = 0;
 
-   for(S32 i = 0; i < val->teamStats.size(); i++)
+   for(S32 i = 0; i < val->teamStats.size(); ++i)
       val->playerCount += val->teamStats[i].playerStats.size();  // count number of players
 }
 
@@ -526,13 +526,13 @@ void write(TNL::BitStream &s, VersionedGameStats &val)
    U32 bitStart = s.getBitPosition();
 
 #ifdef TNL_ENABLE_ASSERTS
-   for(S32 i = -200; i < 200; i++)
+   for(S32 i = -200; i < 200; ++i)
    {  writeCompressedS32(s, i);
       s.setBitPosition(bitStart);
       TNLAssert(readCompressedS32(s) == i, "Problem with read / write CompressedS32");
       s.setBitPosition(bitStart);
    }
-   for(U32 i = 0; i < 400; i++)
+   for(U32 i = 0; i < 400; ++i)
    {  writeCompressedU32(s, i);
       s.setBitPosition(bitStart);
       TNLAssert(readCompressedU32(s) == i, "Problem with read / write CompressedU32");

--- a/zap/gameType.cpp
+++ b/zap/gameType.cpp
@@ -367,7 +367,7 @@ void GameType::setScript(const Vector<string> &args)
    mScriptName = args.size() > 0 ? args[0] : "";
 
    mScriptArgs.clear();       // Clear out any args from a previous Script line
-   for(S32 i = 1; i < args.size(); i++)
+   for(S32 i = 1; i < args.size(); ++i)
       mScriptArgs.push_back(args[i]);
 }
 
@@ -380,7 +380,7 @@ void GameType::printRules()
    printf("Bitfighter rules\n");
    printf("================\n\n");
    printf("Projectiles:\n\n");
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
    {
       WeaponInfo weaponInfo = WeaponInfo::getWeaponInfo(WeaponType(i));
 
@@ -396,7 +396,7 @@ void GameType::printRules()
    printf("\n\n");
    printf("Game Types:\n\n");
 
-   for(S32 i = 0; gameTypeClassNames[i]; i++)
+   for(S32 i = 0; gameTypeClassNames[i]; ++i)
    {
       TNL::Object *theObject = TNL::Object::create(gameTypeClassNames[i]);  // Instantiate a gameType object
       GameType *gameType = dynamic_cast<GameType*>(theObject);              // and cast it
@@ -417,7 +417,7 @@ void GameType::printRules()
       printf("Configure ship: %s",   gameType->isSpawnWithLoadoutGame() ? "By respawning (no need for loadout zones)" : "By entering loadout zone");
       printf("\nEvent: Individual Score / Team Score\n");
       printf(  "====================================\n");
-      for(S32 j = 0; j < ScoringEventsCount; j++)
+      for(S32 j = 0; j < ScoringEventsCount; ++j)
       {
          S32 teamScore = gameType->getEventScore(GameType::TeamScore,       (ScoringEvent) j, 0);
          S32 indScore =  gameType->getEventScore(GameType::IndividualScore, (ScoringEvent) j, 0);
@@ -527,7 +527,7 @@ const char *GameType::validateGameType(const char *gameTypeName)
    if(!stricmp(gameTypeName, "HuntersGameType"))
        return "NexusGameType";
 
-   for(S32 i = 0; gameTypeClassNames[i]; i++)    // Repeat until we hit NULL
+   for(S32 i = 0; gameTypeClassNames[i]; ++i)    // Repeat until we hit NULL
       if(stricmp(gameTypeClassNames[i], gameTypeName) == 0)
          return gameTypeClassNames[i];
 
@@ -582,7 +582,7 @@ void GameType::idle_server(U32 deltaT)
          updateClientScoreboard(gc);
    }
 
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mGame->getClientInfo(i);
       // Respawn dead players
@@ -805,7 +805,7 @@ VersionedGameStats GameType::getGameStats()
    gameStats->teamStats.resize(mGame->getTeamCount());
 
 
-   for(S32 i = 0; i < mGame->getTeamCount(); i++)
+   for(S32 i = 0; i < mGame->getTeamCount(); ++i)
    {
       TeamStats *teamStats = &gameStats->teamStats[i];
 
@@ -817,7 +817,7 @@ VersionedGameStats GameType::getGameStats()
       teamStats->score = ((Team *)(mGame->getTeam(i)))->getScore();
       teamStats->gameResult = 0;  // will be filled in later
 
-      for(S32 j = 0; j < mGame->getClientCount(); j++)
+      for(S32 j = 0; j < mGame->getClientCount(); ++j)
       {
          ClientInfo *clientInfo = mGame->getClientInfo(j);
 
@@ -885,7 +885,7 @@ VersionedGameStats GameType::getGameStats()
          Vector<U32> shots = statistics->getShotsVector();
          Vector<U32> hits = statistics->getHitsVector();
 
-         for(S32 k = 0; k < shots.size(); k++)
+         for(S32 k = 0; k < shots.size(); ++k)
          {
             WeaponStats weaponStats;
             weaponStats.weaponType = WeaponType(k);
@@ -897,7 +897,7 @@ VersionedGameStats GameType::getGameStats()
                playerStats->weaponStats.push_back(weaponStats);
          }
 
-         for(S32 k = 0; k < ModuleCount; k++)
+         for(S32 k = 0; k < ModuleCount; ++k)
          {
             ModuleStats moduleStats;
             moduleStats.shipModule = ShipModule(k);
@@ -909,7 +909,7 @@ VersionedGameStats GameType::getGameStats()
 
          Vector<U32> loadouts = statistics->getLoadouts();
 
-         for(S32 i = 0; i < loadouts.size(); i++)
+         for(S32 i = 0; i < loadouts.size(); ++i)
          {
             LoadoutStats loadoutStats;
             loadoutStats.loadoutHash = loadouts[i];
@@ -917,7 +917,8 @@ VersionedGameStats GameType::getGameStats()
                playerStats->loadoutStats.push_back(loadoutStats);
          }
 
-         gameStats->playerCount++;
+         ++gameStats->playerCount;
+
       }
    }
    return stats;
@@ -934,7 +935,7 @@ S32 QSORT_CALLBACK playerScoreSort(ClientInfo **a, ClientInfo **b)
 // Client only
 void GameType::getSortedPlayersByScore(S32 teamIndex, Vector<ClientInfo *> &playerInfos) const
 {
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *info = mGame->getClientInfo(i);
 
@@ -1059,7 +1060,7 @@ void GameType::onGameOver()
    {
       S32 teamWinner = 0;
       S32 winningScore = ((Team *)(mGame->getTeam(0)))->getScore();
-      for(S32 i = 1; i < mGame->getTeamCount(); i++)
+      for(S32 i = 1; i < mGame->getTeamCount(); ++i)
       {
          if(((Team *)(mGame->getTeam(i)))->getScore() == winningScore)
             tied = true;
@@ -1084,7 +1085,7 @@ void GameType::onGameOver()
       {
          ClientInfo *winningClient = mGame->getClientInfo(0);
 
-         for(S32 i = 1; i < clientCount; i++)
+         for(S32 i = 1; i < clientCount; ++i)
          {
             ClientInfo *clientInfo = mGame->getClientInfo(i);
 
@@ -1218,7 +1219,7 @@ void GameType::buildMapTiles(const Rect *fixedLevelBounds)
    // per-edge style classification.
    Vector<const Vector<Point> *> inputPolygons;
    Vector<bool> inputDestructible;       // Parallel: which input polygons are destructible
-   for(S32 i = 0; i < barriers.size(); i++)
+   for(S32 i = 0; i < barriers.size(); ++i)
    {
       Barrier *barrier = dynamic_cast<Barrier *>(barriers[i]);
       if(barrier)
@@ -1234,7 +1235,7 @@ void GameType::buildMapTiles(const Rect *fixedLevelBounds)
 
    MapTileBuilder builder(levelBounds, 200);
 
-   for(S32 i = 0; i < inputPolygons.size(); i++)
+   for(S32 i = 0; i < inputPolygons.size(); ++i)
       builder.addWallPolygon(*inputPolygons[i], inputDestructible[i]);
 
    builder.build(mMapTiles);
@@ -1259,11 +1260,11 @@ static bool wallPolyEqual(const WallPoly &a, const WallPoly &b)
    if(a.edges.size() != b.edges.size())
       return false;
 
-   for(S32 i = 0; i < a.verts.size(); i++)
+   for(S32 i = 0; i < a.verts.size(); ++i)
       if(a.verts[i] != b.verts[i])
          return false;
 
-   for(S32 i = 0; i < a.edges.size(); i++)
+   for(S32 i = 0; i < a.edges.size(); ++i)
       if(a.edges[i] != b.edges[i])
          return false;
 
@@ -1277,7 +1278,7 @@ static bool mapTilePolyEqual(const MapTile &a, const MapTile &b)
    if(a.polys.size() != b.polys.size())
       return false;
 
-   for(S32 i = 0; i < a.polys.size(); i++)
+   for(S32 i = 0; i < a.polys.size(); ++i)
       if(!wallPolyEqual(a.polys[i], b.polys[i]))
          return false;
 
@@ -1320,13 +1321,13 @@ void GameType::rebuildWallTilesAndBotZones()
    // the same.  Therefore tileId maps to the same world position in both
    // oldTiles and mMapTiles, and we can use a simple O(n²) lookup.
    Vector<U16> changedTileIds;
-   for(S32 t = 0; t < mMapTiles.size(); t++)
+   for(S32 t = 0; t < mMapTiles.size(); ++t)
    {
       const MapTile &newTile = mMapTiles[t];
 
       // Find matching old tile by tileId
       const MapTile *oldTile = NULL;
-      for(S32 i = 0; i < oldTiles.size(); i++)
+      for(S32 i = 0; i < oldTiles.size(); ++i)
          if(oldTiles[i].tileId == newTile.tileId)
          {
             oldTile = &oldTiles[i];
@@ -1340,10 +1341,10 @@ void GameType::rebuildWallTilesAndBotZones()
    // Find tiles that existed in the old set but no longer exist in the new
    // set — these need to be sent as empty tiles so the client erases them.
    Vector<U16> removedTileIds;
-   for(S32 i = 0; i < oldTiles.size(); i++)
+   for(S32 i = 0; i < oldTiles.size(); ++i)
    {
       bool found = false;
-      for(S32 j = 0; j < mMapTiles.size(); j++)
+      for(S32 j = 0; j < mMapTiles.size(); ++j)
          if(mMapTiles[j].tileId == oldTiles[i].tileId)
          {
             found = true;
@@ -1357,7 +1358,7 @@ void GameType::rebuildWallTilesAndBotZones()
       changedTileIds.size(), removedTileIds.size());
 
    // Reset delivery state for all non-robot connections
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mGame->getClientInfo(i);
       if(!clientInfo || clientInfo->isRobot())
@@ -1376,7 +1377,7 @@ void GameType::rebuildWallTilesAndBotZones()
       conn->mWallDelivery.init(tileCount);
 
       // Enqueue changed tiles
-      for(S32 i = 0; i < changedTileIds.size(); i++)
+      for(S32 i = 0; i < changedTileIds.size(); ++i)
       {
          // In FOW mode, let the per-tick scope enqueue handle changed tiles;
          // sentTiles is reset so they'll be picked up when in range.
@@ -1387,7 +1388,7 @@ void GameType::rebuildWallTilesAndBotZones()
       // Enqueue removed tiles that the client may have already seen.
       // In FOW mode, these tiles are no longer in mMapTiles so the scope
       // enqueue won't find them — we must explicitly send empty tiles.
-      for(S32 i = 0; i < removedTileIds.size(); i++)
+      for(S32 i = 0; i < removedTileIds.size(); ++i)
       {
          if(!isFogOfWarEnabled() || (removedTileIds[i] < wasSent.size() && wasSent[removedTileIds[i]]))
             conn->mWallDelivery.pending.push_back(removedTileIds[i]);
@@ -1407,11 +1408,11 @@ void GameType::rebuildWallTilesAndBotZones()
             // Precompute distance for each pending tileId
             Vector<F32> dists;
             dists.reserve(conn->mWallDelivery.pending.size());
-            for(S32 p = 0; p < conn->mWallDelivery.pending.size(); p++)
+            for(S32 p = 0; p < conn->mWallDelivery.pending.size(); ++p)
             {
                U16 tid = conn->mWallDelivery.pending[p];
                bool found = false;
-               for(S32 t = 0; t < mMapTiles.size(); t++)
+               for(S32 t = 0; t < mMapTiles.size(); ++t)
                {
                   if(mMapTiles[t].tileId == tid)
                   {
@@ -1429,7 +1430,7 @@ void GameType::rebuildWallTilesAndBotZones()
 
             // Insertion sort: reorder pending and dists together by ascending distance
             Vector<U16> &pending = conn->mWallDelivery.pending;
-            for(S32 i = 1; i < pending.size(); i++)
+            for(S32 i = 1; i < pending.size(); ++i)
             {
                U16 keyTid = pending[i];
                F32 keyDist = dists[i];
@@ -1438,7 +1439,8 @@ void GameType::rebuildWallTilesAndBotZones()
                {
                   pending[j + 1] = pending[j];
                   dists[j + 1] = dists[j];
-                  j--;
+                  --j;
+
                }
                pending[j + 1] = keyTid;
                dists[j + 1] = keyDist;
@@ -1526,7 +1528,7 @@ bool GameType::spawnShip(ClientInfo *clientInfo)
          Vector<DatabaseObject *> loadoutZones;
          getGame()->getGameObjDatabase()->findObjects(LoadoutZoneTypeNumber, loadoutZones);
          LoadoutZone *zone;
-         for(S32 i = 0; i < loadoutZones.size(); i++)
+         for(S32 i = 0; i < loadoutZones.size(); ++i)
          {
             zone = static_cast<LoadoutZone*>(loadoutZones.get(i));
             if(newShip->isOnObject(zone))
@@ -1569,7 +1571,7 @@ Vector<AbstractSpawn *> GameType::getSpawnPoints(TypeNumber typeNumber, S32 team
 
    const Vector<DatabaseObject *> *objects = getGame()->getGameObjDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objects->size(); i++)
+   for(S32 i = 0; i < objects->size(); ++i)
    {
       if(objects->get(i)->getObjectTypeNumber() == typeNumber)
       {
@@ -1632,7 +1634,7 @@ void GameType::makeRequestedLoadoutActiveIfShipIsInLoadoutZone(ClientInfo *clien
 
 static void markAllMountedItemsAsBeingInScope(Ship *ship, GameConnection *conn)
 {
-   for(S32 i = 0; i < ship->getMountedItemCount(); i++)
+   for(S32 i = 0; i < ship->getMountedItemCount(); ++i)
    {
       TNLAssert(ship->getMountedItem(i), "When would this item be NULL?  Do we really need to check this?");
       if(ship->getMountedItem(i))
@@ -1659,7 +1661,7 @@ void GameType::performScopeQuery(GhostConnection *connection)
    const Vector<SafePtr<BfObject> > &scopeAlwaysList = mGame->getScopeAlwaysList();
 
    // Make sure the "always-in-scope" objects are actually in scope
-   for(S32 i = 0; i < scopeAlwaysList.size(); i++)
+   for(S32 i = 0; i < scopeAlwaysList.size(); ++i)
       if(!scopeAlwaysList[i].isNull())
          if(scopeAlwaysList[i]->getObjectTypeNumber() != FlagTypeNumber || !((MountableItem*)(((SafePtr<BfObject> *)&scopeAlwaysList[i])->getPointer()))->isMounted())
             conn->objectInScope(scopeAlwaysList[i]);
@@ -1678,7 +1680,7 @@ void GameType::performScopeQuery(GhostConnection *connection)
    const Vector<DatabaseObject *> *spyBugs = mGame->getGameObjDatabase()->findObjects_fast(SpyBugTypeNumber);
    const Point scopeRange(SpyBug::SPY_BUG_RADIUS, SpyBug::SPY_BUG_RADIUS * FloatSqrt3Half);  // Bounding box of hexagon
 
-   for(S32 i = spyBugs->size() - 1; i >= 0; i--)
+   for(S32 i = spyBugs->size() - 1; i >= 0; --i)
    {
       SpyBug *sb = static_cast<SpyBug *>(spyBugs->get(i));
 //      shared_ptr<SpyBug> sb = shared_ptr<SpyBug>(sb);
@@ -1694,7 +1696,7 @@ void GameType::performScopeQuery(GhostConnection *connection)
          mGame->getGameObjDatabase()->findObjects((TestFunc)isAnyObjectType, fillVector, queryRect, sameQuery);
          sameQuery = true;
 
-         for(S32 j = 0; j < fillVector.size(); j++)
+         for(S32 j = 0; j < fillVector.size(); ++j)
          {
             // Some objects don't have geometry (ForceFields).  Is this a bug?
             if(!fillVector[j]->hasGeometry())
@@ -1721,7 +1723,7 @@ void GameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clientI
    //if(isTeamGame())
    //{
    //   // Start by scanning over all items located in queryItemsOfInterest()
-   //   for(S32 i = 0; i < mItemsOfInterest.size(); i++)
+   //   for(S32 i = 0; i < mItemsOfInterest.size(); ++i)
    //   {
    //      if(mItemsOfInterest[i].teamVisMask & (1 << scopeObject->getTeam()))    // Item is visible to scopeObject's team
    //      {
@@ -1746,7 +1748,7 @@ void GameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clientI
       fillVector.clear();
       bool sameQuery = false;  // helps speed up by not repeatedly finding same objects
 
-      for(S32 i = 0; i < mGame->getClientCount(); i++)
+      for(S32 i = 0; i < mGame->getClientCount(); ++i)
       {
          ClientInfo *clientInfo = mGame->getClientInfo(i);
 
@@ -1788,7 +1790,7 @@ void GameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clientI
    }
 
    // Set object-in-scope for all objects found above
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       connection->objectInScope(static_cast<BfObject *>(fillVector[i]));
       if(isShipType(fillVector[i]->getObjectTypeNumber()))
@@ -1797,7 +1799,7 @@ void GameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clientI
 
    // Make bots visible if showAllBots has been activated
    if(mShowAllBots && connection->isInCommanderMap())
-      for(S32 i = 0; i < mGame->getBotCount(); i++)
+      for(S32 i = 0; i < mGame->getBotCount(); ++i)
          connection->objectInScope(mGame->getBot(i));
 }
 
@@ -1806,7 +1808,7 @@ void GameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clientI
 void GameType::addItemOfInterest(MoveItem *item)
 {
 #ifdef TNL_DEBUG
-   for(S32 i = 0; i < mItemsOfInterest.size(); i++)
+   for(S32 i = 0; i < mItemsOfInterest.size(); ++i)
       TNLAssert(mItemsOfInterest[i].theItem.getPointer() != item, "Item already exists in ItemOfInterest!");
 #endif
 
@@ -1821,7 +1823,7 @@ void GameType::addItemOfInterest(MoveItem *item)
 // to those teams with ships close enough to see it, if any.  Called from idle()
 void GameType::queryItemsOfInterest()
 {
-   for(S32 i = 0; i < mItemsOfInterest.size(); i++)
+   for(S32 i = 0; i < mItemsOfInterest.size(); ++i)
    {
       ItemOfInterest &ioi = mItemsOfInterest[i];
       if(ioi.theItem.isNull())
@@ -1842,7 +1844,7 @@ void GameType::queryItemsOfInterest()
       fillVector.clear();
       mGame->getGameObjDatabase()->findObjects((TestFunc)isShipType, fillVector, queryRect);
 
-      for(S32 j = 0; j < fillVector.size(); j++)
+      for(S32 j = 0; j < fillVector.size(); ++j)
       {
          Ship *theShip = static_cast<Ship *>(fillVector[j]);     // Safe because we only looked for ships and robots
          Point delta = theShip->getActualPos() - pos;
@@ -1926,7 +1928,7 @@ void GameType::serverAddClient(ClientInfo *clientInfo)
                              clientInfo->getClientClass() == ClientInfo::ClassRobotAddedByLevelNoTeam;
    S32 minPlayers = S32_MAX;
 
-   for(S32 i = 0; i < mGame->getTeamCount(); i++)
+   for(S32 i = 0; i < mGame->getTeamCount(); ++i)
    {
       S32 playerCount  = counts[i][ClientInfo::ClassHuman] +
                          counts[i][ClientInfo::ClassRobotAddedByLevel] +
@@ -1942,7 +1944,7 @@ void GameType::serverAddClient(ClientInfo *clientInfo)
    S32 minTeamIndex = NONE;
    F32 minRating = F32_MAX;
 
-   for(S32 i = 0; i < mGame->getTeamCount(); i++)
+   for(S32 i = 0; i < mGame->getTeamCount(); ++i)
    {
       S32 playerCount  = counts[i][ClientInfo::ClassHuman] +
                          counts[i][ClientInfo::ClassRobotAddedByLevel] +
@@ -2132,7 +2134,7 @@ void GameType::updateScore(ClientInfo *player, S32 teamIndex, ScoringEvent scori
 
          // Broadcast player scores for rendering on the client
          if(!isTeamGame())
-            for(S32 i = 0; i < mGame->getClientCount(); i++)  // TODO: try to get rid of this for loop
+            for(S32 i = 0; i < mGame->getClientCount(); ++i)  // TODO: try to get rid of this for loop
                if(getGame()->getClientInfo(i) == player)      // and this pointer checks (we need to get the index, for variable "i")
                   s2cSetPlayerScore(i, player->getScore());
       }
@@ -2153,7 +2155,7 @@ void GameType::updateScore(ClientInfo *player, S32 teamIndex, ScoringEvent scori
       // Assumes that points < 0.
       if(scoringEvent == ScoreGoalOwnTeam)
       {
-         for(S32 i = 0; i < mGame->getTeamCount(); i++)
+         for(S32 i = 0; i < mGame->getTeamCount(); ++i)
          {
             if(i != teamIndex)  // Every team but scoring team
             {
@@ -2183,7 +2185,7 @@ void GameType::updateScore(ClientInfo *player, S32 teamIndex, ScoringEvent scori
    {
       if(scoringEvent == ScoreGoalOwnTeam)
       {
-         for(S32 i = 0; i < mGame->getTeamCount(); i++)
+         for(S32 i = 0; i < mGame->getTeamCount(); ++i)
          {
             // Fire Lua event, but not for scoring team
             if(i != teamIndex)
@@ -2210,7 +2212,7 @@ void GameType::updateLeadingTeamAndScore()
    mLeadingTeamScore = S32_MIN;
 
    // Find the leading team...
-   for(S32 i = 0; i < mGame->getTeamCount(); i++)
+   for(S32 i = 0; i < mGame->getTeamCount(); ++i)
    {
       TNLAssert(dynamic_cast<Team *>(mGame->getTeam(i)), "Bad team pointer or bad type");
       S32 score = static_cast<Team *>(mGame->getTeam(i))->getScore();
@@ -2233,7 +2235,7 @@ void GameType::updateLeadingPlayerAndScore()
    mSecondLeadingPlayer = -1;
 
    // Find the leading player
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       // Check to make sure client hasn't disappeared somehow
       if(!mGame->getClientInfo(i))
@@ -2281,7 +2283,7 @@ void GameType::updateScore(S32 teamIndex, ScoringEvent event, S32 data)
 // At game end, we need to update everyone's game-normalized ratings
 void GameType::updateRatings()
 {
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
       mGame->getClientInfo(i)->endOfGameScoringHandler();
 }
 
@@ -2563,7 +2565,7 @@ void GameType::changeClientTeam(ClientInfo *client, S32 team)
       fillVector.clear();
       mGame->getGameObjDatabase()->findObjects((TestFunc)isGrenadeType, fillVector);
 
-      for(S32 i = 0; i < fillVector.size(); i++)
+      for(S32 i = 0; i < fillVector.size(); ++i)
       {
          BfObject *obj = static_cast<BfObject *>(fillVector[i]);
 
@@ -2628,7 +2630,7 @@ GAMETYPE_RPC_S2C(GameType, s2cAddClient,
 
    const Vector<DatabaseObject*> &database = *(getGame()->getGameObjDatabase()->findObjects_fast());
 
-   for(S32 i = database.size() - 1; i >= 0; i--)
+   for(S32 i = database.size() - 1; i >= 0; --i)
    {
       if(database[i]->getObjectTypeNumber() == PlayerShipTypeNumber || database[i]->getObjectTypeNumber() == RobotShipTypeNumber)
          ((Ship *)database[i])->findClientInfoFromName();
@@ -2701,7 +2703,7 @@ void GameType::broadcastNewRemainingTime()
 GAMETYPE_RPC_S2C(GameType, s2cRenameClient, (StringTableEntry oldName, StringTableEntry newName), (oldName, newName))
 {
 #ifndef ZAP_DEDICATED
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mGame->getClientInfo(i);
       if(clientInfo->getName() == oldName)
@@ -2834,7 +2836,7 @@ GAMETYPE_RPC_S2C(GameType, s2cClientJoinedTeam,
       fillVector.clear();
       mGame->getGameObjDatabase()->findObjects((TestFunc)isGrenadeType, fillVector);
 
-      for(S32 i = 0; i < fillVector.size(); i++)
+      for(S32 i = 0; i < fillVector.size(); ++i)
          static_cast<Burst *>(fillVector[i])->mIsOwnedByLocalClient = false;
    }
 #endif
@@ -2883,7 +2885,7 @@ void GameType::onGhostAvailable(GhostConnection *theConnection)
                    mLevelHasLoadoutZone, mEngineerEnabled, mEngineerUnrestrictedEnabled, mGame->getLevelDatabaseId(),
                    isFogOfWarEnabled());
 
-   for(S32 i = 0; i < mGame->getTeamCount(); i++)
+   for(S32 i = 0; i < mGame->getTeamCount(); ++i)
    {
       Team *team = (Team *)mGame->getTeam(i);
       const Color *color = team->getColor();
@@ -2894,7 +2896,7 @@ void GameType::onGhostAvailable(GhostConnection *theConnection)
    notifyClientsWhoHasTheFlag();
 
    // Add all the client and team information
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mGame->getClientInfo(i);
       GameConnection *conn = clientInfo->getConnection();
@@ -2912,7 +2914,7 @@ void GameType::onGhostAvailable(GhostConnection *theConnection)
          s2cClientJoinedTeam(clientInfo->getName(), team, false);
    }
 
-   //for(S32 i = 0; i < Robot::getBotCount(); i++)  //Robot is part of mClientList
+   //for(S32 i = 0; i < Robot::getBotCount(); ++i)  //Robot is part of mClientList
    //{
    //   s2cAddClient(Robot::robots[i]->getName(), false, false, true, false);
    //   s2cClientJoinedTeam(Robot::robots[i]->getName(), Robot::robots[i]->getTeam());
@@ -2928,7 +2930,7 @@ void GameType::onGhostAvailable(GhostConnection *theConnection)
       if(!isFogOfWarEnabled())
       {
          // Non-FOW: enqueue all tiles immediately (drained per-tick at NORM rate)
-         for(S32 t = 0; t < mMapTiles.size(); t++)
+         for(S32 t = 0; t < mMapTiles.size(); ++t)
             gc->mWallDelivery.pending.push_back(mMapTiles[t].tileId);
       }
       // FOW mode: tiles are enqueued per-tick based on player position
@@ -2999,7 +3001,7 @@ TNL_IMPLEMENT_NETOBJECT_RPC(GameType, s2cSendWallTile, (U16 tileId, U16 polyCoun
       // Tile update — remove old polys belonging to this tileId.
       // Walk backwards so removals don't shift remaining indices.
       smReceivedTilePolys.reserve(smReceivedTilePolys.size());
-      for(S32 i = smReceivedTilePolys.size() - 1; i >= 0; i--)
+      for(S32 i = smReceivedTilePolys.size() - 1; i >= 0; --i)
       {
          if(i < smReceivedTileIds.size() && smReceivedTileIds[i] == tileId)
          {
@@ -3023,7 +3025,7 @@ TNL_IMPLEMENT_NETOBJECT_RPC(GameType, s2cSendWallTile, (U16 tileId, U16 polyCoun
    bool hasTileData = false;
 
    U32 vertOff = 0, outlineOff = 0;
-   for(U16 p = 0; p < polyCount; p++)
+   for(U16 p = 0; p < polyCount; ++p)
    {
       U32 n = polySizes[p];
       if(n < 3)
@@ -3036,12 +3038,12 @@ TNL_IMPLEMENT_NETOBJECT_RPC(GameType, s2cSendWallTile, (U16 tileId, U16 polyCoun
       WallPoly wp;
       wp.verts.reserve(n * 2);
       wp.edges.reserve(n);
-      for(U32 v = 0; v < n * 2; v++)
+      for(U32 v = 0; v < n * 2; ++v)
       {
          F32 val = allVerts[vertOff++];
          wp.verts.push_back(val);
       }
-      for(U32 b = 0; b < n; b++)
+      for(U32 b = 0; b < n; ++b)
          wp.edges.push_back(static_cast<EdgeStyle>(allStyles[outlineOff++]));
 
       // Expand tile bounds from this poly's vertices
@@ -3123,7 +3125,7 @@ static void buildTilePolyCache(WallPoly &wp)
    // Build contour from flat verts
    Vector<Point> contour;
    contour.reserve(n);
-   for(U32 v = 0; v < n; v++)
+   for(U32 v = 0; v < n; ++v)
       contour.push_back(Point(wp.verts[v * 2], wp.verts[v * 2 + 1]));
 
    // Strip colinear vertices (introduced by tile-boundary clipping)
@@ -3131,7 +3133,7 @@ static void buildTilePolyCache(WallPoly &wp)
    {
       Vector<Point> cleaned;
       S32 cn = contour.size();
-      for(S32 c = 0; c < cn; c++)
+      for(S32 c = 0; c < cn; ++c)
       {
          const Point &prev = contour[(c + cn - 1) % cn];
          const Point &curr = contour[c];
@@ -3150,7 +3152,7 @@ static void buildTilePolyCache(WallPoly &wp)
 
    // Classify edges into normal/destructible and set cachedDestructible flag
    wp.cachedDestructible = false;
-   for(U32 v = 0; v < n; v++)
+   for(U32 v = 0; v < n; ++v)
    {
       if(v >= wp.edges.size())
          continue;
@@ -3188,7 +3190,7 @@ bool GameType::findTileWallLOS(const Point &rayStart, const Point &rayEnd, bool 
    Point bestNormal;
    static Vector<Point> polyPoints;
 
-   for(S32 i = 0; i < smReceivedTilePolys.size(); i++)
+   for(S32 i = 0; i < smReceivedTilePolys.size(); ++i)
    {
       const WallPoly &wp = smReceivedTilePolys[i];
       if(wp.numVerts() < 3)
@@ -3226,7 +3228,7 @@ bool GameType::findTileWallSweptCircle(const Point &pos, const Point &delta, F32
    Point bestCp;
    static Vector<Point> polyPoints;
 
-   for(S32 i = 0; i < smReceivedTilePolys.size(); i++)
+   for(S32 i = 0; i < smReceivedTilePolys.size(); ++i)
    {
       const WallPoly &wp = smReceivedTilePolys[i];
       if(wp.numVerts() < 3)
@@ -3315,7 +3317,7 @@ void GameType::deliverWallTileTick()
    const bool fowEnabled = isFogOfWarEnabled();
    const U32 tilesPerTick = fowEnabled ? TILES_PER_TICK_FOW : TILES_PER_TICK_NORM;
 
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mGame->getClientInfo(i);
       if(!clientInfo || clientInfo->isRobot())
@@ -3342,7 +3344,7 @@ void GameType::deliverWallTileTick()
          F32 scopeRadSq = scopeRad * scopeRad;
 
          // Scan all tiles — find un-sent tiles within scope, compute distance
-         for(S32 t = 0; t < mMapTiles.size(); t++)
+         for(S32 t = 0; t < mMapTiles.size(); ++t)
          {
             const MapTile &tile = mMapTiles[t];
 
@@ -3374,7 +3376,7 @@ void GameType::deliverWallTileTick()
             {
                // Compute distance for the tile already in the list
                const MapTile *cmpTile = NULL;
-               for(S32 tt = 0; tt < mMapTiles.size(); tt++)
+               for(S32 tt = 0; tt < mMapTiles.size(); ++tt)
                {
                   if(mMapTiles[tt].tileId == deliveryState.pending[insertIdx])
                      cmpTile = &mMapTiles[tt]; break;
@@ -3382,7 +3384,8 @@ void GameType::deliverWallTileTick()
                F32 cmpDist = cmpTile ? distSqToTileCenter(shipPos, *cmpTile) : F32_MAX;
                if(tileDistSq <= cmpDist)
                   break;
-               insertIdx++;
+               ++insertIdx;
+
             }
             deliveryState.pending.insert(insertIdx, tile.tileId);
          }
@@ -3401,7 +3404,7 @@ void GameType::deliverWallTileTick()
          // in that case we send an empty tile (polyCount == 0) so the
          // client erases the old geometry.
          const MapTile *tile = NULL;
-         for(S32 t = 0; t < mMapTiles.size(); t++)
+         for(S32 t = 0; t < mMapTiles.size(); ++t)
          {
             if(mMapTiles[t].tileId == tileId)
             {
@@ -3417,13 +3420,13 @@ void GameType::deliverWallTileTick()
 
          if(tile)
          {
-            for(S32 p = 0; p < tile->polys.size(); p++)
+            for(S32 p = 0; p < tile->polys.size(); ++p)
             {
                const WallPoly &wp = tile->polys[p];
                polySizes.push_back(wp.numVerts());
-               for(S32 v = 0; v < wp.verts.size(); v++)
+               for(S32 v = 0; v < wp.verts.size(); ++v)
                   allVerts.push_back(wp.verts[v]);
-               for(S32 b = 0; b < wp.edges.size(); b++)
+               for(S32 b = 0; b < wp.edges.size(); ++b)
                   allStyles.push_back(static_cast<U8>(wp.edges[b]));
             }
          }
@@ -3434,7 +3437,8 @@ void GameType::deliverWallTileTick()
          s2cSendWallTile(tileId, static_cast<U16>(tile ? tile->polys.size() : 0), allVerts, allStyles, polySizes);
          NetObject::setRPCDestConnection(NULL);
 
-         sentThisTick++;
+         ++sentThisTick;
+
       }
    }
 }
@@ -3472,7 +3476,7 @@ void GameType::processServerCommand(ClientInfo *clientInfo, const char *cmd, Vec
          loadSettingsFromINI(&GameSettings::iniFile, serverGame->getSettings());    // Why??
 
          if(prev_enableServerVoiceChat != serverGame->getSettings()->getIniSettings()->enableServerVoiceChat)
-            for(S32 i = 0; i < mGame->getClientCount(); i++)
+            for(S32 i = 0; i < mGame->getClientCount(); ++i)
                if(!mGame->getClientInfo(i)->isRobot())
                {
                   GameConnection *gc = mGame->getClientInfo(i)->getConnection();
@@ -3533,7 +3537,7 @@ bool GameType::addBotFromClient(Vector<StringTableEntry> args)
       Vector<const char *> args_char(args.size());
 
       // The first arg = team number, the second arg = robot script filename, the rest of args get passed as script arguments
-      for(S32 i = 0; i < args.size(); i++)
+      for(S32 i = 0; i < args.size(); ++i)
          args_char.push_back(args[i].getString());
 
       string errorMessage = getGame()->addBot(args_char, ClientInfo::ClassRobotAddedByAddbots);
@@ -3575,11 +3579,12 @@ GAMETYPE_RPC_C2S(GameType, c2sAddBots,
 {
    S32 botsAdded = 0;
 
-   for(U32 i = 0; i < botCount; i++)
+   for(U32 i = 0; i < botCount; ++i)
    {
       // Exit the loop if there is a problem adding bots
       if(addBotFromClient(args))
-         botsAdded++;
+         ++botsAdded;
+
       else
          break;
    }
@@ -3650,7 +3655,7 @@ GAMETYPE_RPC_C2S(GameType, c2sResetScore, (), ())
       return;
 
    // Reset player scores
-   for(S32 i = 0; i < serverGame->getClientCount(); i++)
+   for(S32 i = 0; i < serverGame->getClientCount(); ++i)
    {
       if(mGame->getClientInfo(i)->getScore() != 0)
          s2cSetPlayerScore(i, 0);
@@ -3658,7 +3663,7 @@ GAMETYPE_RPC_C2S(GameType, c2sResetScore, (), ())
    }
 
    // Reset team scores
-   for(S32 i = 0; i < mGame->getTeamCount(); i++)
+   for(S32 i = 0; i < mGame->getTeamCount(); ++i)
    {
       // broadcast it to the clients
       if(((Team *)mGame->getTeam(i))->getScore() != 0)
@@ -3858,7 +3863,7 @@ GAMETYPE_RPC_C2S(GameType, c2sBanIp, (StringTableEntry ipAddressString, U32 dura
    // Now check to see if the client is connected and disconnect all of them if they are
    bool playerDisconnected = false;
 
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       GameConnection *baneeConn = mGame->getClientInfo(i)->getConnection();
 
@@ -4134,7 +4139,7 @@ void GameType::displayAnnouncement(const string &message) const
 {
    TNLAssert(dynamic_cast<ServerGame *>(mGame), "Server only!");
 
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       if(mGame->getClientInfo(i)->isRobot())
          continue;
@@ -4167,7 +4172,7 @@ void GameType::sendChat(const StringTableEntry &senderName, ClientInfo *senderCl
 {
    RefPtr<NetEvent> theEvent = TNL_RPC_CONSTRUCT_NETEVENT(this, s2cDisplayChatMessage, (global, senderName, message));
 
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mGame->getClientInfo(i);
 
@@ -4261,7 +4266,7 @@ GAMETYPE_RPC_C2S(GameType, c2sDropItem, (), ())
    Ship *ship = static_cast<Ship *>(controlObject);
 
    S32 count = ship->getMountedItemCount();
-   for(S32 i = count - 1; i >= 0; i--)
+   for(S32 i = count - 1; i >= 0; --i)
       ship->getMountedItem(i)->dismount(DISMOUNT_NORMAL);
 }
 
@@ -4284,7 +4289,7 @@ TNL_IMPLEMENT_NETOBJECT_RPC(GameType, c2sResendItemStatus, (U16 itemId), (itemId
    fillVector.clear();
    mGame->getGameObjDatabase()->findObjects(fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       MoveItem *item = dynamic_cast<MoveItem *>(fillVector[i]);
       if(item && item->getItemId() == itemId)
@@ -4371,7 +4376,7 @@ void GameType::updateClientScoreboard(GameConnection *gc)
    mDeaths.clear();
 
    // First, list the players
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *info = mGame->getClientInfo(i);
 
@@ -4398,7 +4403,7 @@ TNL_IMPLEMENT_NETOBJECT_RPC(GameType, s2cScoreboardUpdate,
                  (Vector<RangedU32<0, GameType::MaxPing> > pingTimes, Vector<Int<10> > kills, Vector<Int<10> > deaths),
                  (pingTimes, kills, deaths), NetClassGroupGameMask, RPCGuaranteedOrderedBigData, RPCToGhost, 0)
 {
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       if(i >= pingTimes.size())
          break;
@@ -4467,7 +4472,7 @@ TNL_IMPLEMENT_NETOBJECT_RPC(GameType, c2sVoiceChat, (bool echo, ByteBufferPtr vo
    {
       RefPtr<NetEvent> event = TNL_RPC_CONSTRUCT_NETEVENT(this, s2cVoiceChat, (sourceClientInfo->getName(), voiceBuffer));
 
-      for(S32 i = 0; i < mGame->getClientCount(); i++)
+      for(S32 i = 0; i < mGame->getClientCount(); ++i)
       {
          ClientInfo *clientInfo = mGame->getClientInfo(i);
          GameConnection *dest = clientInfo->getConnection();
@@ -4566,7 +4571,7 @@ void GameType::updateWhichTeamsHaveFlags()
 
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
       if(flag->isMounted() && flag->getMount())
@@ -4592,7 +4597,7 @@ void GameType::notifyClientsWhoHasTheFlag()
 {
    U16 packedBits = 0;
 
-   for(S32 i = 0; i < getGame()->getTeamCount(); i++)
+   for(S32 i = 0; i < getGame()->getTeamCount(); ++i)
       if(getGame()->getTeamHasFlag(i))
          packedBits += BIT(i);
 
@@ -4602,7 +4607,7 @@ void GameType::notifyClientsWhoHasTheFlag()
 
 GAMETYPE_RPC_S2C(GameType, s2cSendFlagPossessionStatus, (U16 packedBits), (packedBits))
 {
-   for(S32 i = 0; i < getGame()->getTeamCount(); i++)
+   for(S32 i = 0; i < getGame()->getTeamCount(); ++i)
       getGame()->setTeamHasFlag(i, packedBits & BIT(i));
 }
 
@@ -4770,7 +4775,7 @@ void GameType::broadcastMessage(GameConnection::MessageColors color, SFXProfiles
 {
    if(!isGameOver())  // Avoid flooding messages on game over.
    {
-      for(S32 i = 0; i < mGame->getClientCount(); i++)
+      for(S32 i = 0; i < mGame->getClientCount(); ++i)
          if(!mGame->getClientInfo(i)->isRobot())
             mGame->getClientInfo(i)->getConnection()->s2cDisplayMessage(color, sfx, message);
 
@@ -4788,7 +4793,7 @@ void GameType::broadcastMessage(GameConnection::MessageColors color, SFXProfiles
 {
    if(!isGameOver())  // Avoid flooding messages on game over
    {
-      for(S32 i = 0; i < mGame->getClientCount(); i++)
+      for(S32 i = 0; i < mGame->getClientCount(); ++i)
          if(!mGame->getClientInfo(i)->isRobot())
             mGame->getClientInfo(i)->getConnection()->s2cDisplayMessageE(color, sfx, formatString, e);
 
@@ -4836,7 +4841,7 @@ const char *GameType::getGameTypeClassName(GameTypeId gameType)
 // static
 const char *GameType::getGameTypeClassName(const string &gameTypeName)
 {
-   for(U32 i = 0; i < ARRAYSIZE(GameTypeNames); i++)
+   for(U32 i = 0; i < ARRAYSIZE(GameTypeNames); ++i)
    {
       if(strcmp(GameTypeNames[i], gameTypeName.c_str()) == 0)
          return gameTypeClassNames[i];
@@ -4852,7 +4857,7 @@ Vector<string> GameType::getGameTypeNames()
 {
    Vector<string> gameTypes;
 
-   for(U32 i = 0; i < ARRAYSIZE(GameTypeNames); i++)
+   for(U32 i = 0; i < ARRAYSIZE(GameTypeNames); ++i)
       gameTypes.push_back(GameTypeNames[i]);
 
    return gameTypes;

--- a/zap/gameType.cpp
+++ b/zap/gameType.cpp
@@ -367,7 +367,8 @@ void GameType::setScript(const Vector<string> &args)
    mScriptName = args.size() > 0 ? args[0] : "";
 
    mScriptArgs.clear();       // Clear out any args from a previous Script line
-   for(S32 i = 1; i < args.size(); ++i)
+   S32 args_sz = args.size();
+   for (S32 i = 1; i < args_sz; ++i)
       mScriptArgs.push_back(args[i]);
 }
 
@@ -885,7 +886,8 @@ VersionedGameStats GameType::getGameStats()
          Vector<U32> shots = statistics->getShotsVector();
          Vector<U32> hits = statistics->getHitsVector();
 
-         for(S32 k = 0; k < shots.size(); ++k)
+         S32 shots_sz = shots.size();
+         for (S32 k = 0; k < shots_sz; ++k)
          {
             WeaponStats weaponStats;
             weaponStats.weaponType = WeaponType(k);
@@ -909,7 +911,8 @@ VersionedGameStats GameType::getGameStats()
 
          Vector<U32> loadouts = statistics->getLoadouts();
 
-         for(S32 i = 0; i < loadouts.size(); ++i)
+         S32 loadouts_sz = loadouts.size();
+         for (S32 i = 0; i < loadouts_sz; ++i)
          {
             LoadoutStats loadoutStats;
             loadoutStats.loadoutHash = loadouts[i];
@@ -1219,7 +1222,8 @@ void GameType::buildMapTiles(const Rect *fixedLevelBounds)
    // per-edge style classification.
    Vector<const Vector<Point> *> inputPolygons;
    Vector<bool> inputDestructible;       // Parallel: which input polygons are destructible
-   for(S32 i = 0; i < barriers.size(); ++i)
+   S32 barriers_sz = barriers.size();
+   for (S32 i = 0; i < barriers_sz; ++i)
    {
       Barrier *barrier = dynamic_cast<Barrier *>(barriers[i]);
       if(barrier)
@@ -1235,7 +1239,8 @@ void GameType::buildMapTiles(const Rect *fixedLevelBounds)
 
    MapTileBuilder builder(levelBounds, 200);
 
-   for(S32 i = 0; i < inputPolygons.size(); ++i)
+   S32 inputPolygons_sz = inputPolygons.size();
+   for (S32 i = 0; i < inputPolygons_sz; ++i)
       builder.addWallPolygon(*inputPolygons[i], inputDestructible[i]);
 
    builder.build(mMapTiles);
@@ -1321,13 +1326,15 @@ void GameType::rebuildWallTilesAndBotZones()
    // the same.  Therefore tileId maps to the same world position in both
    // oldTiles and mMapTiles, and we can use a simple O(n²) lookup.
    Vector<U16> changedTileIds;
-   for(S32 t = 0; t < mMapTiles.size(); ++t)
+   S32 mMapTiles_sz = mMapTiles.size();
+   for (S32 t = 0; t < mMapTiles_sz; ++t)
    {
       const MapTile &newTile = mMapTiles[t];
 
       // Find matching old tile by tileId
       const MapTile *oldTile = NULL;
-      for(S32 i = 0; i < oldTiles.size(); ++i)
+      S32 oldTiles_sz = oldTiles.size();
+      for (S32 i = 0; i < oldTiles_sz; ++i)
          if(oldTiles[i].tileId == newTile.tileId)
          {
             oldTile = &oldTiles[i];
@@ -1341,10 +1348,12 @@ void GameType::rebuildWallTilesAndBotZones()
    // Find tiles that existed in the old set but no longer exist in the new
    // set — these need to be sent as empty tiles so the client erases them.
    Vector<U16> removedTileIds;
-   for(S32 i = 0; i < oldTiles.size(); ++i)
+   S32 oldTiles_sz = oldTiles.size();
+   for (S32 i = 0; i < oldTiles_sz; ++i)
    {
       bool found = false;
-      for(S32 j = 0; j < mMapTiles.size(); ++j)
+      S32 mMapTiles_sz = mMapTiles.size();
+      for (S32 j = 0; j < mMapTiles_sz; ++j)
          if(mMapTiles[j].tileId == oldTiles[i].tileId)
          {
             found = true;
@@ -1377,7 +1386,8 @@ void GameType::rebuildWallTilesAndBotZones()
       conn->mWallDelivery.init(tileCount);
 
       // Enqueue changed tiles
-      for(S32 i = 0; i < changedTileIds.size(); ++i)
+      S32 changedTileIds_sz = changedTileIds.size();
+      for (S32 i = 0; i < changedTileIds_sz; ++i)
       {
          // In FOW mode, let the per-tick scope enqueue handle changed tiles;
          // sentTiles is reset so they'll be picked up when in range.
@@ -1388,7 +1398,8 @@ void GameType::rebuildWallTilesAndBotZones()
       // Enqueue removed tiles that the client may have already seen.
       // In FOW mode, these tiles are no longer in mMapTiles so the scope
       // enqueue won't find them — we must explicitly send empty tiles.
-      for(S32 i = 0; i < removedTileIds.size(); ++i)
+      S32 removedTileIds_sz = removedTileIds.size();
+      for (S32 i = 0; i < removedTileIds_sz; ++i)
       {
          if(!isFogOfWarEnabled() || (removedTileIds[i] < wasSent.size() && wasSent[removedTileIds[i]]))
             conn->mWallDelivery.pending.push_back(removedTileIds[i]);
@@ -1412,7 +1423,8 @@ void GameType::rebuildWallTilesAndBotZones()
             {
                U16 tid = conn->mWallDelivery.pending[p];
                bool found = false;
-               for(S32 t = 0; t < mMapTiles.size(); ++t)
+               S32 mMapTiles_sz = mMapTiles.size();
+               for (S32 t = 0; t < mMapTiles_sz; ++t)
                {
                   if(mMapTiles[t].tileId == tid)
                   {
@@ -1430,7 +1442,8 @@ void GameType::rebuildWallTilesAndBotZones()
 
             // Insertion sort: reorder pending and dists together by ascending distance
             Vector<U16> &pending = conn->mWallDelivery.pending;
-            for(S32 i = 1; i < pending.size(); ++i)
+            S32 pending_sz = pending.size();
+            for (S32 i = 1; i < pending_sz; ++i)
             {
                U16 keyTid = pending[i];
                F32 keyDist = dists[i];
@@ -1528,7 +1541,8 @@ bool GameType::spawnShip(ClientInfo *clientInfo)
          Vector<DatabaseObject *> loadoutZones;
          getGame()->getGameObjDatabase()->findObjects(LoadoutZoneTypeNumber, loadoutZones);
          LoadoutZone *zone;
-         for(S32 i = 0; i < loadoutZones.size(); ++i)
+         S32 loadoutZones_sz = loadoutZones.size();
+         for (S32 i = 0; i < loadoutZones_sz; ++i)
          {
             zone = static_cast<LoadoutZone*>(loadoutZones.get(i));
             if(newShip->isOnObject(zone))
@@ -1571,7 +1585,8 @@ Vector<AbstractSpawn *> GameType::getSpawnPoints(TypeNumber typeNumber, S32 team
 
    const Vector<DatabaseObject *> *objects = getGame()->getGameObjDatabase()->findObjects_fast();
 
-   for(S32 i = 0; i < objects->size(); ++i)
+   S32 objects_sz = objects->size();
+   for (S32 i = 0; i < objects_sz; ++i)
    {
       if(objects->get(i)->getObjectTypeNumber() == typeNumber)
       {
@@ -1661,7 +1676,8 @@ void GameType::performScopeQuery(GhostConnection *connection)
    const Vector<SafePtr<BfObject> > &scopeAlwaysList = mGame->getScopeAlwaysList();
 
    // Make sure the "always-in-scope" objects are actually in scope
-   for(S32 i = 0; i < scopeAlwaysList.size(); ++i)
+   S32 scopeAlwaysList_sz = scopeAlwaysList.size();
+   for (S32 i = 0; i < scopeAlwaysList_sz; ++i)
       if(!scopeAlwaysList[i].isNull())
          if(scopeAlwaysList[i]->getObjectTypeNumber() != FlagTypeNumber || !((MountableItem*)(((SafePtr<BfObject> *)&scopeAlwaysList[i])->getPointer()))->isMounted())
             conn->objectInScope(scopeAlwaysList[i]);
@@ -1696,7 +1712,8 @@ void GameType::performScopeQuery(GhostConnection *connection)
          mGame->getGameObjDatabase()->findObjects((TestFunc)isAnyObjectType, fillVector, queryRect, sameQuery);
          sameQuery = true;
 
-         for(S32 j = 0; j < fillVector.size(); ++j)
+         S32 fillVector_sz = fillVector.size();
+         for (S32 j = 0; j < fillVector_sz; ++j)
          {
             // Some objects don't have geometry (ForceFields).  Is this a bug?
             if(!fillVector[j]->hasGeometry())
@@ -1790,7 +1807,8 @@ void GameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clientI
    }
 
    // Set object-in-scope for all objects found above
-   for(S32 i = 0; i < fillVector.size(); ++i)
+   S32 fillVector_sz = fillVector.size();
+   for (S32 i = 0; i < fillVector_sz; ++i)
    {
       connection->objectInScope(static_cast<BfObject *>(fillVector[i]));
       if(isShipType(fillVector[i]->getObjectTypeNumber()))
@@ -1808,7 +1826,8 @@ void GameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo *clientI
 void GameType::addItemOfInterest(MoveItem *item)
 {
 #ifdef TNL_DEBUG
-   for(S32 i = 0; i < mItemsOfInterest.size(); ++i)
+   S32 mItemsOfInterest_sz = mItemsOfInterest.size();
+   for (S32 i = 0; i < mItemsOfInterest_sz; ++i)
       TNLAssert(mItemsOfInterest[i].theItem.getPointer() != item, "Item already exists in ItemOfInterest!");
 #endif
 
@@ -1823,7 +1842,8 @@ void GameType::addItemOfInterest(MoveItem *item)
 // to those teams with ships close enough to see it, if any.  Called from idle()
 void GameType::queryItemsOfInterest()
 {
-   for(S32 i = 0; i < mItemsOfInterest.size(); ++i)
+   S32 mItemsOfInterest_sz = mItemsOfInterest.size();
+   for (S32 i = 0; i < mItemsOfInterest_sz; ++i)
    {
       ItemOfInterest &ioi = mItemsOfInterest[i];
       if(ioi.theItem.isNull())
@@ -1844,7 +1864,8 @@ void GameType::queryItemsOfInterest()
       fillVector.clear();
       mGame->getGameObjDatabase()->findObjects((TestFunc)isShipType, fillVector, queryRect);
 
-      for(S32 j = 0; j < fillVector.size(); ++j)
+      S32 fillVector_sz = fillVector.size();
+      for (S32 j = 0; j < fillVector_sz; ++j)
       {
          Ship *theShip = static_cast<Ship *>(fillVector[j]);     // Safe because we only looked for ships and robots
          Point delta = theShip->getActualPos() - pos;
@@ -2565,7 +2586,8 @@ void GameType::changeClientTeam(ClientInfo *client, S32 team)
       fillVector.clear();
       mGame->getGameObjDatabase()->findObjects((TestFunc)isGrenadeType, fillVector);
 
-      for(S32 i = 0; i < fillVector.size(); ++i)
+      S32 fillVector_sz = fillVector.size();
+      for (S32 i = 0; i < fillVector_sz; ++i)
       {
          BfObject *obj = static_cast<BfObject *>(fillVector[i]);
 
@@ -2836,7 +2858,8 @@ GAMETYPE_RPC_S2C(GameType, s2cClientJoinedTeam,
       fillVector.clear();
       mGame->getGameObjDatabase()->findObjects((TestFunc)isGrenadeType, fillVector);
 
-      for(S32 i = 0; i < fillVector.size(); ++i)
+      S32 fillVector_sz = fillVector.size();
+      for (S32 i = 0; i < fillVector_sz; ++i)
          static_cast<Burst *>(fillVector[i])->mIsOwnedByLocalClient = false;
    }
 #endif
@@ -2930,7 +2953,8 @@ void GameType::onGhostAvailable(GhostConnection *theConnection)
       if(!isFogOfWarEnabled())
       {
          // Non-FOW: enqueue all tiles immediately (drained per-tick at NORM rate)
-         for(S32 t = 0; t < mMapTiles.size(); ++t)
+         S32 mMapTiles_sz = mMapTiles.size();
+         for (S32 t = 0; t < mMapTiles_sz; ++t)
             gc->mWallDelivery.pending.push_back(mMapTiles[t].tileId);
       }
       // FOW mode: tiles are enqueued per-tick based on player position
@@ -3190,7 +3214,8 @@ bool GameType::findTileWallLOS(const Point &rayStart, const Point &rayEnd, bool 
    Point bestNormal;
    static Vector<Point> polyPoints;
 
-   for(S32 i = 0; i < smReceivedTilePolys.size(); ++i)
+   S32 smReceivedTilePolys_sz = smReceivedTilePolys.size();
+   for (S32 i = 0; i < smReceivedTilePolys_sz; ++i)
    {
       const WallPoly &wp = smReceivedTilePolys[i];
       if(wp.numVerts() < 3)
@@ -3228,7 +3253,8 @@ bool GameType::findTileWallSweptCircle(const Point &pos, const Point &delta, F32
    Point bestCp;
    static Vector<Point> polyPoints;
 
-   for(S32 i = 0; i < smReceivedTilePolys.size(); ++i)
+   S32 smReceivedTilePolys_sz = smReceivedTilePolys.size();
+   for (S32 i = 0; i < smReceivedTilePolys_sz; ++i)
    {
       const WallPoly &wp = smReceivedTilePolys[i];
       if(wp.numVerts() < 3)
@@ -3344,7 +3370,8 @@ void GameType::deliverWallTileTick()
          F32 scopeRadSq = scopeRad * scopeRad;
 
          // Scan all tiles — find un-sent tiles within scope, compute distance
-         for(S32 t = 0; t < mMapTiles.size(); ++t)
+         S32 mMapTiles_sz = mMapTiles.size();
+         for (S32 t = 0; t < mMapTiles_sz; ++t)
          {
             const MapTile &tile = mMapTiles[t];
 
@@ -3376,7 +3403,8 @@ void GameType::deliverWallTileTick()
             {
                // Compute distance for the tile already in the list
                const MapTile *cmpTile = NULL;
-               for(S32 tt = 0; tt < mMapTiles.size(); ++tt)
+               S32 mMapTiles_sz = mMapTiles.size();
+               for (S32 tt = 0; tt < mMapTiles_sz; ++tt)
                {
                   if(mMapTiles[tt].tileId == deliveryState.pending[insertIdx])
                      cmpTile = &mMapTiles[tt]; break;
@@ -3404,7 +3432,8 @@ void GameType::deliverWallTileTick()
          // in that case we send an empty tile (polyCount == 0) so the
          // client erases the old geometry.
          const MapTile *tile = NULL;
-         for(S32 t = 0; t < mMapTiles.size(); ++t)
+         S32 mMapTiles_sz = mMapTiles.size();
+         for (S32 t = 0; t < mMapTiles_sz; ++t)
          {
             if(mMapTiles[t].tileId == tileId)
             {
@@ -3537,7 +3566,8 @@ bool GameType::addBotFromClient(Vector<StringTableEntry> args)
       Vector<const char *> args_char(args.size());
 
       // The first arg = team number, the second arg = robot script filename, the rest of args get passed as script arguments
-      for(S32 i = 0; i < args.size(); ++i)
+      S32 args_sz = args.size();
+      for (S32 i = 0; i < args_sz; ++i)
          args_char.push_back(args[i].getString());
 
       string errorMessage = getGame()->addBot(args_char, ClientInfo::ClassRobotAddedByAddbots);
@@ -4289,7 +4319,8 @@ TNL_IMPLEMENT_NETOBJECT_RPC(GameType, c2sResendItemStatus, (U16 itemId), (itemId
    fillVector.clear();
    mGame->getGameObjDatabase()->findObjects(fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); ++i)
+   S32 fillVector_sz = fillVector.size();
+   for (S32 i = 0; i < fillVector_sz; ++i)
    {
       MoveItem *item = dynamic_cast<MoveItem *>(fillVector[i]);
       if(item && item->getItemId() == itemId)
@@ -4571,7 +4602,8 @@ void GameType::updateWhichTeamsHaveFlags()
 
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); ++i)
+   S32 flags_sz = flags->size();
+   for (S32 i = 0; i < flags_sz; ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
       if(flag->isMounted() && flag->getMount())

--- a/zap/goalZone.cpp
+++ b/zap/goalZone.cpp
@@ -97,7 +97,7 @@ bool GoalZone::processArguments(S32 argc2, const char **argv2, Game *game)
    // so a possible future version can add parameters without compatibility problem.
    S32 argc = 0;
    const char *argv[Geometry::MAX_POLY_POINTS * 2 + 1];
-   for(S32 i = 0; i < argc2; i++)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char c = argv2[i][0];
 
@@ -105,7 +105,8 @@ bool GoalZone::processArguments(S32 argc2, const char **argv2, Game *game)
       {
          if(argc < Geometry::MAX_POLY_POINTS * 2 + 1)
          {  argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }
@@ -254,7 +255,8 @@ void GoalZone::idle(BfObject::IdleCallPath path)
    if(mFlashTimer.update(mCurrentMove.time))
    {
       mFlashTimer.reset(FlashDelay);
-      mFlashCount--;
+      --mFlashCount;
+
    }
 }
 

--- a/zap/gridDB.cpp
+++ b/zap/gridDB.cpp
@@ -29,10 +29,11 @@ GridDatabase::GridDatabase(bool createWallSegmentManager)
    if(mChunker == NULL)
       mChunker = new ClassChunker<DatabaseBucketEntry>();        // Static shared by all databases, reference counted and deleted in destructor
 
-   mCountGridDatabase++;
+   ++mCountGridDatabase;
 
-   for(U32 i = 0; i < BucketRowCount; i++)
-      for(U32 j = 0; j < BucketRowCount; j++)
+
+   for(U32 i = 0; i < BucketRowCount; ++i)
+      for(U32 j = 0; j < BucketRowCount; ++j)
          mBuckets[i][j].nextInBucket = NULL;
 
    if(createWallSegmentManager)
@@ -49,7 +50,7 @@ GridDatabase::GridDatabase(bool createWallSegmentManager)
 // {
 //    mAllObjects.reserve(source.mAllObjects.size());
 //
-//    for(S32 i = 0; i < source.mAllObjects.size(); i++)
+//    for(S32 i = 0; i < source.mAllObjects.size(); ++i)
 //       addToDatabase(source.mAllObjects[i]->clone(), source.mAllObjects[i]->getExtent());
 // }
 
@@ -64,7 +65,8 @@ GridDatabase::~GridDatabase()
    if(mWallSegmentManager)
       delete mWallSegmentManager;
 
-   mCountGridDatabase--;
+   --mCountGridDatabase;
+
 
    if(mCountGridDatabase == 0)
    {
@@ -107,7 +109,7 @@ void GridDatabase::copyObjects(const GridDatabase *source)
    mSpyBugs   .reserve(source->mSpyBugs.size());
 
 
-   for(S32 i = 0; i < source->mAllObjects.size(); i++)
+   for(S32 i = 0; i < source->mAllObjects.size(); ++i)
       addToDatabase(source->mAllObjects[i]->clone());
 
    sortObjects(mAllObjects);
@@ -130,8 +132,8 @@ void GridDatabase::addToDatabase(DatabaseObject *theObject)
    static IntRect bins;
    fillBins(theObject->getExtent(), bins);
 
-   for(S32 x = bins.minx; bins.maxx - x >= 0; x++)
-      for(S32 y = bins.miny; bins.maxy - y >= 0; y++)
+   for(S32 x = bins.minx; bins.maxx - x >= 0; ++x)
+      for(S32 y = bins.miny; bins.maxy - y >= 0; ++y)
       {
          DatabaseBucketEntry *be = mChunker->alloc();
          DatabaseBucketEntryBase *base = &mBuckets[x & BucketMask][y & BucketMask];
@@ -163,16 +165,16 @@ void GridDatabase::addToDatabase(DatabaseObject *theObject)
 // Bulk add items to database
 void GridDatabase::addToDatabase(const Vector<DatabaseObject *> &objects)
 {
-   for(S32 i = 0; i < objects.size(); i++)
+   for(S32 i = 0; i < objects.size(); ++i)
       addToDatabase(objects[i]);
 }
 
 
 void GridDatabase::removeEverythingFromDatabase()
 {
-   for(S32 x = 0; x < BucketRowCount; x++)
+   for(S32 x = 0; x < BucketRowCount; ++x)
    {
-      for(S32 y = 0; y < BucketRowCount; y++)
+      for(S32 y = 0; y < BucketRowCount; ++y)
       {
          for(DatabaseBucketEntry *walk = mBuckets[x & BucketMask][y & BucketMask].nextInBucket; walk; )
          {
@@ -201,7 +203,7 @@ void GridDatabase::removeEverythingFromDatabase()
 // Don't use this with a sorted list!
 static void eraseObject_fast(Vector<DatabaseObject *> *objects, DatabaseObject *objectToDelete)
 {
-   for(S32 i = 0; i < objects->size(); i++)
+   for(S32 i = 0; i < objects->size(); ++i)
       if(objects->get(i) == objectToDelete)
       {
          objects->erase_fast(i);
@@ -235,7 +237,7 @@ void GridDatabase::removeFromDatabase(DatabaseObject *object, bool deleteObject)
    }
 
    // Find and delete object from our non-spatial databases
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
       if(mAllObjects[i] == object)
       {
          mAllObjects.erase(i);            // mAllObjects is sorted, so we can't use erase_fast
@@ -261,7 +263,7 @@ void GridDatabase::findObjects(Vector<DatabaseObject *> &fillVector) const
 {
    fillVector.resize(mAllObjects.size());
 
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
       fillVector[i] = mAllObjects[i];
 }
 
@@ -303,10 +305,10 @@ void GridDatabase::findObjects(U8 typeNumber, Vector<DatabaseObject *> &fillVect
 
 void GridDatabase::findObjects(Vector<U8> typeNumbers, Vector<DatabaseObject *> &fillVector, const Rect *extents, const IntRect *bins) const
 {
-   mQueryId++;    // Used to prevent the same item from being found in multiple buckets
+   ++mQueryId;    // Used to prevent the same item from being found in multiple buckets
 
-   for(S32 x = bins->minx; bins->maxx - x >= 0; x++)
-      for(S32 y = bins->miny; bins->maxy - y >= 0; y++)
+   for(S32 x = bins->minx; bins->maxx - x >= 0; ++x)
+      for(S32 y = bins->miny; bins->maxy - y >= 0; ++y)
          for(DatabaseBucketEntry *walk = mBuckets[x & BucketMask][y & BucketMask].nextInBucket; walk; walk = walk->nextInBucket)
          {
             DatabaseObject *theObject = walk->theObject;
@@ -331,26 +333,26 @@ void GridDatabase::findObjects(U8 typeNumber, Vector<DatabaseObject *> &fillVect
 
    if(typeNumber == GoalZoneTypeNumber)
    {
-      for(S32 i = 0; i < mGoalZones.size(); i++)
+      for(S32 i = 0; i < mGoalZones.size(); ++i)
          fillVector.push_back(mGoalZones[i]);
       return;
    }
 
    //if(typeNumber == FlagTypeNumber)
    //{
-   //   for(S32 i = 0; i < mFlags.size(); i++)
+   //   for(S32 i = 0; i < mFlags.size(); ++i)
    //      fillVector.push_back(mFlags[i]);
    //   return;
    //}
 
    //if(typeNumber == SpyBugTypeNumber)
    //{
-   //   for(S32 i = 0; i < mSpyBugs.size(); i++)
+   //   for(S32 i = 0; i < mSpyBugs.size(); ++i)
    //      fillVector.push_back(mSpyBugs[i]);
    //   return;
    //}
 
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
       if(mAllObjects[i]->getObjectTypeNumber() == typeNumber)
          fillVector.push_back(mAllObjects[i]);
 }
@@ -386,10 +388,10 @@ void GridDatabase::findObjects(TestFunc testFunc, Vector<DatabaseObject *> &fill
 {
    TNLAssert(this, "findObjects 'this' is NULL");
    if(!sameQuery)
-      mQueryId++;    // Used to prevent the same item from being found in multiple buckets
+      ++mQueryId;    // Used to prevent the same item from being found in multiple buckets
 
-   for(S32 x = bins->minx; bins->maxx - x >= 0; x++)
-      for(S32 y = bins->miny; bins->maxy - y >= 0; y++)
+   for(S32 x = bins->minx; bins->maxx - x >= 0; ++x)
+      for(S32 y = bins->miny; bins->maxy - y >= 0; ++y)
          for(DatabaseBucketEntry *walk = mBuckets[x & BucketMask][y & BucketMask].nextInBucket; walk; walk = walk->nextInBucket)
          {
             DatabaseObject *theObject = walk->theObject;
@@ -408,7 +410,7 @@ void GridDatabase::findObjects(TestFunc testFunc, Vector<DatabaseObject *> &fill
 // Find all objects in database using derived type test function
 void GridDatabase::findObjects(TestFunc testFunc, Vector<DatabaseObject *> &fillVector) const
 {
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
       if(testFunc(mAllObjects[i]->getObjectTypeNumber()))
          fillVector.push_back(mAllObjects[i]);
 }
@@ -427,7 +429,7 @@ void GridDatabase::findObjects(const Vector<U8> &types, Vector<DatabaseObject *>
 // Find all objects in database using derived type test function
 void GridDatabase::findObjects(const Vector<U8> &types, Vector<DatabaseObject *> &fillVector) const
 {
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
       if(testTypes(types, mAllObjects[i]->getObjectTypeNumber()))
          fillVector.push_back(mAllObjects[i]);
 }
@@ -436,7 +438,7 @@ void GridDatabase::findObjects(const Vector<U8> &types, Vector<DatabaseObject *>
 // Find first object in database with specified id; currently only used in tests
 BfObject *GridDatabase::findObjectById(S32 id) const
 {
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
    {
       BfObject *bfobj = dynamic_cast<BfObject*>(mAllObjects[i]);
 
@@ -450,7 +452,7 @@ BfObject *GridDatabase::findObjectById(S32 id) const
 
 bool GridDatabase::testTypes(const Vector<U8> &types, U8 objectType) const
 {
-   for(S32 i = 0; i < types.size(); i++)
+   for(S32 i = 0; i < types.size(); ++i)
       if(types[i] == objectType)
          return true;
 
@@ -470,8 +472,8 @@ void GridDatabase::findObjects(TestFunc testFunc, Vector<DatabaseObject *> &fill
 
 void GridDatabase::dumpObjects()
 {
-   for(S32 x = 0; x < BucketRowCount; x++)
-      for(S32 y = 0; y < BucketRowCount; y++)
+   for(S32 x = 0; x < BucketRowCount; ++x)
+      for(S32 y = 0; y < BucketRowCount; ++y)
          for(DatabaseBucketEntry *walk = mBuckets[x & BucketMask][y & BucketMask].nextInBucket; walk; walk = walk->nextInBucket)
          {
             DatabaseObject *theObject = walk->theObject;
@@ -502,7 +504,7 @@ Rect GridDatabase::getExtents()
    S32 first = -1;
 
    // Look for first non-UnknownType object
-   for(S32 i = 0; i < mAllObjects.size() && first == -1; i++)
+   for(S32 i = 0; i < mAllObjects.size() && first == -1; ++i)
       if(mAllObjects[i]->getObjectTypeNumber() != UnknownTypeNumber)
       {
          rect = mAllObjects[i]->getExtent();
@@ -520,7 +522,7 @@ Rect GridDatabase::getExtents()
    rect = mAllObjects[0]->getExtent();
 
    // Now start unioning the extents of remaining objects.  Should be all of them.
-   for(S32 i = /*first + */1; i < mAllObjects.size(); i++)
+   for(S32 i = /*first + */1; i < mAllObjects.size(); ++i)
       rect.unionRect(mAllObjects[i]->getExtent());
 
    return rect;
@@ -603,7 +605,7 @@ DatabaseObject *GridDatabase::findObjectLOS(U8 typeNumber, U32 stateIndex, bool 
    Point center;
    Rect rect;
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       if(!fillVector[i]->isCollisionEnabled())     // Skip collision-disabled objects
          continue;
@@ -665,7 +667,7 @@ DatabaseObject *GridDatabase::findObjectLOS(TestFunc testFunc, U32 stateIndex, b
    Point center;
    Rect rect;
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       if(!fillVector[i]->isCollisionEnabled())     // Skip collision-disabled objects
          continue;
@@ -735,13 +737,13 @@ void GridDatabase::computeSelectionMinMax(Point &min, Point &max)
    min.set( F32_MAX,  F32_MAX);
    max.set(-F32_MAX, -F32_MAX);
 
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
    {
       BfObject *obj = static_cast<BfObject *>(mAllObjects[i]);
 
       if(obj->isSelected())
       {
-         for(S32 j = 0; j < obj->getVertCount(); j++)
+         for(S32 j = 0; j < obj->getVertCount(); ++j)
          {
             Point v = obj->getVert(j);
 
@@ -789,7 +791,7 @@ bool GridDatabase::hasObjectOfType(U8 typeNumber) const
    if(typeNumber == SpyBugTypeNumber)
       return mSpyBugs.size() > 0;
 
-   for(S32 i = 0; i < mAllObjects.size(); i++)
+   for(S32 i = 0; i < mAllObjects.size(); ++i)
       if(mAllObjects[i]->getObjectTypeNumber() == typeNumber)
          return true;
 
@@ -948,8 +950,8 @@ void DatabaseObject::setExtent(const Rect &extents)
          }
 
          // ...and re-add for the new extent
-         for(S32 x = minx; maxx - x >= 0; x++)
-            for(S32 y = miny; maxy - y >= 0; y++)
+         for(S32 x = minx; maxx - x >= 0; ++x)
+            for(S32 y = miny; maxy - y >= 0; ++y)
             {
                DatabaseBucketEntry *be = gridDB->mChunker->alloc();
                DatabaseBucketEntryBase *base = &gridDB->mBuckets[x & gridDB->BucketMask][y & gridDB->BucketMask];

--- a/zap/helperMenu.cpp
+++ b/zap/helperMenu.cpp
@@ -54,7 +54,7 @@ void HelperMenu::initialize(ClientGame *game, HelperManager *manager)
 // Static method, for testing
 InputCode HelperMenu::getInputCodeForOption(const OverlayMenuItem *items, S32 itemCount, U32 index, bool keyBut)
 {
-   for(S32 i = 0; i < itemCount; i++)
+   for(S32 i = 0; i < itemCount; ++i)
       if(items[i].itemIndex == index)
          return keyBut ? items[i].key : items[i].button;
 
@@ -128,9 +128,10 @@ void HelperMenu::drawItemMenu(const char *title, const OverlayMenuItem *items, S
    S32 displayItems = 0;
 
    // Count how many items we will be displaying -- some may be hidden
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
       if(items[i].showOnMenu)
-         displayItems++;
+         ++displayItems;
+
 
    bool hasLegend = legendCount > 0;
 
@@ -217,7 +218,7 @@ S32 HelperMenu::getButtonWidth(const OverlayMenuItem *items, S32 itemCount) cons
    InputMode inputMode = getGame()->getInputMode();
 
    S32 buttonWidth = 0;
-   for(S32 i = 0; i < itemCount; i++)
+   for(S32 i = 0; i < itemCount; ++i)
    {
       if(!items[i].showOnMenu)
          continue;
@@ -250,7 +251,7 @@ void HelperMenu::drawMenuItems(const OverlayMenuItem *items, S32 count, S32 top,
    S32 height = 0;
 
    // Calculate height of all our items, ignoring those that are hidden
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
       if(items[i].showOnMenu)
          height += MENU_FONT_SIZE + MENU_FONT_SPACING;
 
@@ -280,7 +281,7 @@ void HelperMenu::drawMenuItems(const OverlayMenuItem *items, S32 count, S32 top,
 
    yPos += 2;        // Aesthetics
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       // Skip hidden options!
       if(!items[i].showOnMenu)
@@ -345,12 +346,12 @@ void HelperMenu::renderLegend(S32 x, S32 y, const char **legendText, const Color
    const S32 SPACE_BETWEEN_LEGEND_ITEMS = 7;
 
    // First, get the total width so we can center properly
-   for(S32 i = 0; i < legendCount; i++)
+   for(S32 i = 0; i < legendCount; ++i)
       width += getStringWidth(MENU_LEGEND_FONT_SIZE, legendText[i]) + SPACE_BETWEEN_LEGEND_ITEMS;
 
    x -= width / 2;
 
-   for(S32 i = 0; i < legendCount; i++)
+   for(S32 i = 0; i < legendCount; ++i)
    {
       Renderer::get().setColor(*legendColors[i]);
       x += drawStringAndGetWidth(x, y, MENU_LEGEND_FONT_SIZE, legendText[i]) + SPACE_BETWEEN_LEGEND_ITEMS;
@@ -363,7 +364,7 @@ S32 HelperMenu::getMaxItemWidth(const OverlayMenuItem *items, S32 count) const
 {
    S32 maxWidth = 0;
 
-   for(S32 i = 0; i < count; i++)
+   for(S32 i = 0; i < count; ++i)
    {
       S32 width = getStringWidth(HelperMenuContext, MENU_FONT_SIZE, items[i].name) + getStringWidth(MENU_FONT_SIZE, items[i].help);
       if(width > maxWidth)

--- a/zap/lineEditor.cpp
+++ b/zap/lineEditor.cpp
@@ -48,7 +48,8 @@ void LineEditor::backspacePressed()
    }
 
    mLine = mLine.substr(0, mCursorOffset - 1) + mLine.substr(mCursorOffset, mLine.length() - mCursorOffset);
-   mCursorOffset -= 1;
+   --mCursorOffset;
+
    mMatchIndex = -1;
 }
 
@@ -180,7 +181,7 @@ void LineEditor::buildMatchList(const Vector<string> *candidates, const string &
 
       string::size_type len = partial.size();
 
-      for(S32 i = 0; i < candidates->size(); i++)
+      for(S32 i = 0; i < candidates->size(); ++i)
       {
          // If partial is empty, then everything matches -- we want all candidates in our list
          if(partial == "" || stricmp(partial.c_str(), (*candidates)[i].substr(0, len).c_str()) == 0)
@@ -202,7 +203,7 @@ void LineEditor::completePartial(const Vector<string> *candidates, const string 
       if(mMatchList.size() == 0)             // Found no matches... no expansion possible
          return;
 
-      mMatchIndex++;                         // Advance to next potential match
+      ++mMatchIndex;                         // Advance to next potential match
 
       if(mMatchIndex >= mMatchList.size())   // Handle wrap-around
          mMatchIndex = 0;
@@ -297,7 +298,8 @@ bool LineEditor::addChar(const char c)
    if(length() < mMaxLen)
    {
       mLine = mLine.substr(0, mCursorOffset) + c + mLine.substr(mCursorOffset, mLine.length() - mCursorOffset);
-      mCursorOffset += 1;
+      ++mCursorOffset;
+
    }
    mMatchIndex = -1;
    return true;
@@ -322,7 +324,8 @@ bool LineEditor::handleKey(InputCode inputCode)
       }
       else
       {
-         spacePos += 1;
+         ++spacePos;
+
       }
 
       string left = mLine.substr(0, spacePos);

--- a/zap/loadoutHelper.cpp
+++ b/zap/loadoutHelper.cpp
@@ -197,7 +197,7 @@ bool LoadoutHelper::processInputCode(InputCode inputCode)
 
    S32 index;
 
-   for(index = 0; index < menuItems.size(); index++)
+   for(index = 0; index < menuItems.size(); ++index)
       if(inputCode == menuItems[index].key || inputCode == menuItems[index].button)
          break;
 
@@ -238,12 +238,12 @@ bool LoadoutHelper::processInputCode(InputCode inputCode)
 
    if(mCurrentIndex < ShipModuleCount)    // We're working with modules
    {                                      // (note... braces required here!)
-      for(S32 i = 0; i < mCurrentIndex && !alreadyUsed; i++)
+      for(S32 i = 0; i < mCurrentIndex && !alreadyUsed; ++i)
          if(mModule[i] == index)
             alreadyUsed = true;
    }
    else                                   // We're working with weapons
-      for(S32 i = ShipModuleCount; i < mCurrentIndex && !alreadyUsed; i++)
+      for(S32 i = ShipModuleCount; i < mCurrentIndex && !alreadyUsed; ++i)
          if(mWeapon[i - ShipModuleCount] == index)
             alreadyUsed = true;
 
@@ -254,7 +254,8 @@ bool LoadoutHelper::processInputCode(InputCode inputCode)
       menuItems[index].buttonOverrideColor = &Colors::overlayMenuSelectedItemColor;
 
       mModule[mCurrentIndex] = ShipModule(index);
-      mCurrentIndex++;
+      ++mCurrentIndex;
+
 
       // Check if we need to switch over to weapons
       if(mCurrentIndex == ShipModuleCount)
@@ -265,10 +266,10 @@ bool LoadoutHelper::processInputCode(InputCode inputCode)
    {
       LoadoutTracker loadout;
 
-      for(S32 i = 0; i < ShipModuleCount; i++)
+      for(S32 i = 0; i < ShipModuleCount; ++i)
          loadout.setModule(i, ShipModule(loadoutModuleMenuItems[mModule[i]].itemIndex));
 
-      for(S32 i = 0; i < ShipWeaponCount; i++)
+      for(S32 i = 0; i < ShipWeaponCount; ++i)
          loadout.setWeapon(i, WeaponType(loadoutWeaponMenuItems[mWeapon[i]].itemIndex));
 
       Ship *ship = getGame()->getLocalPlayerShip();         // Can be NULL if game has ended while we're here

--- a/zap/loadoutZone.cpp
+++ b/zap/loadoutZone.cpp
@@ -82,7 +82,7 @@ bool LoadoutZone::processArguments(S32 argc2, const char **argv2, Game *game)
    // so a possible future version can add parameters without compatibility problem.
    S32 argc = 0;
    const char *argv[Geometry::MAX_POLY_POINTS * 2 + 1];
-   for(S32 i = 0; i < argc2; i++)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)  // the idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char c = argv2[i][0];
       //switch(c)
@@ -93,7 +93,8 @@ bool LoadoutZone::processArguments(S32 argc2, const char **argv2, Game *game)
       {
          if(argc < Geometry::MAX_POLY_POINTS * 2 + 1)
          {  argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }

--- a/zap/luaGameInfo.cpp
+++ b/zap/luaGameInfo.cpp
@@ -255,7 +255,7 @@ S32 LuaGameInfo::lua_getPlayers(lua_State *L)
 
    lua_newtable(L);    // Create a table, with no slots pre-allocated for our data
 
-   for(S32 i = 0; i < game->getClientCount(); i++)
+   for(S32 i = 0; i < game->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = game->getClientInfo(i);
 
@@ -263,14 +263,14 @@ S32 LuaGameInfo::lua_getPlayers(lua_State *L)
          continue;
 
       clientInfo->getPlayerInfo()->push(L);
-      pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 
    for(S32 i = 0; i < game->getRobotCount(); i ++)
    {
       game->getBot(i)->getPlayerInfo()->push(L);
-      pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 

--- a/zap/main.cpp
+++ b/zap/main.cpp
@@ -208,7 +208,7 @@ void hostGame(ServerGame *serverGame)
 #ifndef ZAP_DEDICATED
    const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
 
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       clientGames->get(i)->getUIManager()->disableLevelLoadDisplay(true);
       clientGames->get(i)->joinLocalGame(serverGame->getNetInterface());  // ...then we'll play, too!
@@ -246,7 +246,7 @@ void display()
 
    const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
 
-   for(S32 i = 0; i < clientGames->size(); i++)
+   for(S32 i = 0; i < clientGames->size(); ++i)
    {
       // Do any la-ti-da that we might need to get the viewport setup for the game we're about to run.  For example, if
       // we have two games, we might want to divide the screen into two viewports, configuring each before running the
@@ -282,7 +282,7 @@ void checkIfServerGameIsShuttingDown(U32 timeDelta)
    {
 #ifndef ZAP_DEDICATED
       // Disconnect any local clients, passing whatever reason string we have
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
          clientGames->get(i)->closeConnectionToGameServer(shutdownReason.c_str());
 
       if(clientGames->size() > 0)       // If there are any clients running...
@@ -309,7 +309,7 @@ void loadAnotherLevelOrStartHosting()
 #ifndef ZAP_DEDICATED
       const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
       // Notify any client UIs on the hosting machine that the server has loaded a level
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
          clientGames->get(i)->getUIManager()->serverLoadedLevel(levelName);
 #endif
    }
@@ -385,7 +385,7 @@ void idle()
          shutdownBitfighter();
 
       // Pass the event to all clientGames
-      for(S32 i = 0; i < clientGames->size(); i++)
+      for(S32 i = 0; i < clientGames->size(); ++i)
          Event::onEvent(clientGames->get(i), &event);
    }
    // END SDL event polling
@@ -568,7 +568,7 @@ void createClientGame(GameSettingsPtr settings)
       if(settings->shouldShowNameEntryScreenOnStartup())
       {
          const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
-         for(S32 i = 0; i < clientGames->size(); i++)
+         for(S32 i = 0; i < clientGames->size(); ++i)
             clientGames->get(i)->getUIManager()->activate<NameEntryUserInterface>();
 
          //if(gClientGame)
@@ -586,7 +586,7 @@ void createClientGame(GameSettingsPtr settings)
       else  // Skipping startup screen
       {
          const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
-         for(S32 i = 0; i < clientGames->size(); i++)
+         for(S32 i = 0; i < clientGames->size(); ++i)
          {
             clientGames->get(i)->getUIManager()->activate<MainMenuUserInterface>();
             clientGames->get(i)->setReadyToConnectToMaster(true);
@@ -843,7 +843,7 @@ void copyResourcesToUserData()
    string installDataDir = getInstalledDataDir();
    string fileSeparator = getFileSeparator();
 
-   for(S32 i = 0; i < dirArray.size(); i++)
+   for(S32 i = 0; i < dirArray.size(); ++i)
    {
       // Make sure each resource folder exists
       string userResourceDir = userDataDir + fileSeparator + dirArray[i];
@@ -862,7 +862,7 @@ void copyResourcesToUserData()
       Vector<string> fillFiles;
       getFilesFromFolder(installedResourceDir, fillFiles);
 
-      for(S32 i = 0; i < fillFiles.size(); i++)
+      for(S32 i = 0; i < fillFiles.size(); ++i)
       {
          string sourceFile = installedResourceDir + fileSeparator + fillFiles[i];
          if(!copyFileToDir(sourceFile, userResourceDir))
@@ -1097,7 +1097,7 @@ void exceptionHandler(int sig) {
    logprintf(LogConsumer::LogError, "Error: signal %d:", sig);
    functions = backtrace_symbols(stack, size);
 
-   for(S32 i=0; i < size; i++)
+   for(S32 i=0; i < size; ++i)
       logprintf(LogConsumer::LogError, "%d: %s", i, functions[i]);
 
    free(functions);
@@ -1166,7 +1166,7 @@ int main(int argc, char **argv)
    // Put all cmd args into a Vector for easier processing
    Vector<string> argVector(argc - 1);
 
-   for(S32 i = 1; i < argc; i++)
+   for(S32 i = 1; i < argc; ++i)
       argVector.push_back(argv[i]);
 
    // We change our current directory to be useful, usually to the location the executable resides
@@ -1295,7 +1295,7 @@ int main(int argc, char **argv)
       if(configurationErrors.size() > 0)
       {
          const Vector<ClientGame *> *clientGames = GameManager::getClientGames();
-         for(S32 i = 0; i < clientGames->size(); i++)
+         for(S32 i = 0; i < clientGames->size(); ++i)
          {
             UIManager *uiManager = clientGames->get(i)->getUIManager();
             ErrorMessageUserInterface *ui = uiManager->getUI<ErrorMessageUserInterface>();
@@ -1304,7 +1304,7 @@ int main(int argc, char **argv)
             ui->setTitle("CONFIGURATION ERROR");
 
             string msg = "";
-            for(S32 i = 0; i < configurationErrors.size(); i++)
+            for(S32 i = 0; i < configurationErrors.size(); ++i)
                msg += itos(i + 1) + ".  " + configurationErrors[i] + "\n";
 
             ui->setMessage(msg);

--- a/zap/masterConnection.cpp
+++ b/zap/masterConnection.cpp
@@ -73,7 +73,8 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2cHostOnServerAvailable, (bo
 void MasterServerConnection::startServerQuery(bool hostOnServer)
 {
    // Invalidate old queries
-   mCurrentQueryId++;
+   ++mCurrentQueryId;
+
 
    // And automatically do a server query as well - you may not want to do things
    // in this order in your own clients.
@@ -104,7 +105,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2cQueryServersResponse, (U32
    if(ipList.size() > 0)
    {
       // Store these intermediate results
-      for(S32 i = 0; i < ipList.size(); i++)
+      for(S32 i = 0; i < ipList.size(); ++i)
          mServerList.push_back(ServerAddr(ipList[i]));
    }
    else  // Empty list received, transmission complete, send whole list on to the UI
@@ -139,7 +140,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2cQueryServersResponse_019a,
    if(ipList.size() > 0)
    {
       // Store these intermediate results
-      for(S32 i = 0; i < ipList.size(); i++)
+      for(S32 i = 0; i < ipList.size(); ++i)
          mServerList.push_back(ServerAddr(ipList[i], serverIdList[i]));
    }
    else  // Empty list received, transmission complete, send whole list on to the UI
@@ -174,7 +175,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2cQueryServersResponse_023,
 	if(ipList.size() > 0)
 	{
 		// Store these intermediate results
-		for(S32 i = 0; i < ipList.size(); i++)
+		for(S32 i = 0; i < ipList.size(); ++i)
 			mServerList.push_back(ServerAddr(ipList[i], serverIdList[i], serverNames[i]));
 	}
 	else  // Empty list received, transmission complete, send whole list on to the UI
@@ -189,13 +190,15 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2cQueryServersResponse_023,
 
 void MasterServerConnection::cancelArrangedConnectionAttempt()
 {
-   mCurrentQueryId++;
+   ++mCurrentQueryId;
+
 }
 
 
 void MasterServerConnection::requestArrangedConnection(const Address &remoteAddress)
 {
-   mCurrentQueryId++;
+   ++mCurrentQueryId;
+
 
    c2mRequestArrangedConnection(mCurrentQueryId, remoteAddress.toIPAddress(),
       getInterface()->getFirstBoundInterfaceAddress().toIPAddress(),
@@ -233,7 +236,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2sClientRequestedArrangedCon
    // From here on, we're running on a game server that the master is trying to arrange a connection with
 
    Vector<Address> fullPossibleAddresses;
-   for(S32 i = 0; i < possibleAddresses.size(); i++)
+   for(S32 i = 0; i < possibleAddresses.size(); ++i)
       fullPossibleAddresses.push_back(Address(possibleAddresses[i]));
 
    // Ok, let's do the arranged connection!
@@ -274,7 +277,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2cArrangedConnectionAccepted
       logprintf(LogConsumer::LogConnection, "Remote host accepted arranged connection.");
 
       Vector<Address> fullPossibleAddresses;
-      for(S32 i = 0; i < possibleAddresses.size(); i++)
+      for(S32 i = 0; i < possibleAddresses.size(); ++i)
          fullPossibleAddresses.push_back(Address(possibleAddresses[i]));
 
       ByteBufferPtr theSharedData =
@@ -361,7 +364,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2sSetAuthenticated_019, (Vec
 
    Nonce clientId(id);     // Reconstitute our id into a nonce
 
-   for(S32 i = 0; i < mGame->getClientCount(); i++)
+   for(S32 i = 0; i < mGame->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = mGame->getClientInfo(i);
 
@@ -373,7 +376,7 @@ TNL_IMPLEMENT_RPC_OVERRIDE(MasterServerConnection, m2sSetAuthenticated_019, (Vec
             clientInfo->setAuthenticated(true, badges, gamesPlayed);       // Broadcasts status to other clients
 
             // Auto-rename other non-authenticated clients to avoid stealing the authenticated name
-            for(S32 j = 0; j < mGame->getClientCount(); j++)
+            for(S32 j = 0; j < mGame->getClientCount(); ++j)
             {
                ClientInfo *c = mGame->getClientInfo(j);
 

--- a/zap/md5wrapper.cpp
+++ b/zap/md5wrapper.cpp
@@ -60,7 +60,7 @@ std::string md5wrapper::convToString(unsigned char *bytes)
 	char asciihash[33];
 
 	int p = 0;
-	for(int i=0; i<16; i++)
+	for(int i=0; i<16; ++i)
 	{
 		::sprintf(&asciihash[p],"%02x",bytes[i]);
 		p += 2;
@@ -73,7 +73,7 @@ std::string md5wrapper::convToString(unsigned char *bytes)
 // Convert string to lower case
 std::string lcase(std::string strToConvert)
 {
-   for(std::string::size_type i = 0; i < strToConvert.length(); i++)
+   for(std::string::size_type i = 0; i < strToConvert.length(); ++i)
       strToConvert[i] = TNL::toLower(strToConvert[i]);
    return strToConvert;
 }

--- a/zap/move.cpp
+++ b/zap/move.cpp
@@ -47,7 +47,7 @@ void Move::initialize()
    y = 0;
    angle = 0;
 
-   for(U32 i = 0; i < ARRAYSIZE(modulePrimary); i++)
+   for(U32 i = 0; i < ARRAYSIZE(modulePrimary); ++i)
    {
       modulePrimary[i]   = false;
       moduleSecondary[i] = false;
@@ -69,7 +69,7 @@ void Move::set(F32 x, F32 y, F32 angle)
 
 bool Move::isAnyModActive() const
 {
-   for(U32 i = 0; i < ARRAYSIZE(modulePrimary); i++)
+   for(U32 i = 0; i < ARRAYSIZE(modulePrimary); ++i)
       if(modulePrimary[i] || moduleSecondary[i])
          return true;
 
@@ -79,7 +79,7 @@ bool Move::isAnyModActive() const
 
 bool Move::isEqualMove(const Move *move) const
 {
-   for(U32 i = 0; i < ARRAYSIZE(modulePrimary); i++)
+   for(U32 i = 0; i < ARRAYSIZE(modulePrimary); ++i)
       if(move->modulePrimary[i] != modulePrimary[i] || move->moduleSecondary[i] != moduleSecondary[i])
          return false;
 
@@ -111,7 +111,7 @@ void Move::pack(BitStream *stream, Move *prev, bool packTime)
       stream->writeSignedInt(writeAngle, AngleBits);
       stream->writeFlag(fire);
 
-      for(S32 i = 0; i < ShipModuleCount; i++)
+      for(S32 i = 0; i < ShipModuleCount; ++i)
       {
          stream->writeFlag(modulePrimary[i]);
          stream->writeFlag(moduleSecondary[i]);
@@ -146,7 +146,7 @@ void Move::unpack(BitStream *stream, bool unpackTime)
       angle = unitToRadians(stream->readSignedInt(AngleBits) / F32(1 << AngleBits));
       fire = stream->readFlag();
 
-      for(S32 i = 0; i < ShipModuleCount; i++)
+      for(S32 i = 0; i < ShipModuleCount; ++i)
       {
          modulePrimary[i] = stream->readFlag();
          moduleSecondary[i] = stream->readFlag();
@@ -181,7 +181,7 @@ string Move::toString()
 
    Point p(x,y);
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
    {
       modpstr += modulePrimary[i]   ? "1" : "0";
       modsstr += moduleSecondary[i] ? "1" : "0";

--- a/zap/moveObject.cpp
+++ b/zap/moveObject.cpp
@@ -227,7 +227,7 @@ void MoveObject::setInitialPosVelAng(const Point &pos, const Point &vel, F32 ang
 
 void MoveObject::setPosVelAng(const Point &pos, const Point &vel, F32 ang)
 {
-   for(U32 i = 0; i < MoveStateCount; i++)
+   for(U32 i = 0; i < MoveStateCount; ++i)
    {
       setPos(i, pos);
       setVel(i, vel);
@@ -343,7 +343,8 @@ F32 MoveObject::move(F32 moveTime, U32 stateIndex, bool isBeingDisplaced, Vector
 
    while(moveTime > moveTimeEpsilon && tryCount < TRY_COUNT_MAX)     // moveTimeEpsilon is a very short, but non-zero, bit of time
    {
-      tryCount++;
+      ++tryCount;
+
 
       // Ignore tiny movements unless we're processing a collision
       if(!isBeingDisplaced && getVel(stateIndex).len() < velocityEpsilon)
@@ -379,7 +380,7 @@ F32 MoveObject::move(F32 moveTime, U32 stateIndex, bool isBeingDisplaced, Vector
       {
          disabledList.push_back(objectHit);
          objectHit->disableCollision();
-         tryCount--;   // Don't count as tryCount
+         --tryCount;   // Don't count as tryCount
       }
       else if(objectHit->isMoveObject())     // Collided with a MoveObject (including a ship)
       {
@@ -394,7 +395,7 @@ F32 MoveObject::move(F32 moveTime, U32 stateIndex, bool isBeingDisplaced, Vector
          if(isBeingDisplaced)
          {
             bool hit = false;
-            for(S32 i = 0; i < displacerList.size(); i++)
+            for(S32 i = 0; i < displacerList.size(); ++i)
                if(moveObjectThatWasHit == displacerList[i])
                  hit = true;
             if(hit) break;
@@ -425,7 +426,8 @@ F32 MoveObject::move(F32 moveTime, U32 stateIndex, bool isBeingDisplaced, Vector
             {
                // Move the displaced object a tiny bit, true -> isBeingDisplaced
                moveObjectThatWasHit->move(t + displaceEpsilon, stateIndex, true, displacerList);
-               mHitLimit--;
+               --mHitLimit;
+
             }
          }
       }
@@ -435,7 +437,7 @@ F32 MoveObject::move(F32 moveTime, U32 stateIndex, bool isBeingDisplaced, Vector
       moveTime -= collisionTime;
    }
 
-   for(S32 i = 0; i < disabledList.size(); i++)   // enable any disabled collision
+   for(S32 i = 0; i < disabledList.size(); ++i)   // enable any disabled collision
       if(disabledList[i].isValid())
          disabledList[i]->enableCollision();
 
@@ -496,7 +498,7 @@ BfObject *MoveObject::findFirstCollision(U32 stateIndex, F32 &collisionTime, Poi
 
    BfObject *collisionObject = NULL;
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *foundObject = static_cast<BfObject *>(fillVector[i]);
 
@@ -602,11 +604,11 @@ void MoveObject::checkForZones()
    getZonesObjectIsIn(currZoneList);     // Fill currZoneList with a list of all zones ship is currently in
 
    // Now compare currZoneList with prevZoneList to figure out if ship entered or exited any zones
-   for(S32 i = 0; i < currZoneList.size(); i++)
+   for(S32 i = 0; i < currZoneList.size(); ++i)
       if(!prevZoneList.contains(currZoneList[i]))
          onEnteredZone(currZoneList[i].getPointer());
 
-   for(S32 i = 0; i < prevZoneList.size(); i++)
+   for(S32 i = 0; i < prevZoneList.size(); ++i)
       // Zone can sometimes disappear if removed from the game via Lua, check if valid first
       if(prevZoneList[i].isValid() && !currZoneList.contains(prevZoneList[i]))
          onLeftZone(prevZoneList[i].getPointer());
@@ -641,7 +643,7 @@ void MoveObject::getZonesObjectIsIn(Vector<SafePtr<Zone> > &zoneList)
    findObjects((TestFunc)isZoneType, fillVector, rect);  // Find all zones the object might be in
 
    // Extents overlap...  now check for actual overlap
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       // Get points that define the zone boundaries
       const Vector<Point> *polyPoints = fillVector[i]->getCollisionPoly();
@@ -689,7 +691,7 @@ void MoveObject::computeCollisionResponseBarrier(U32 stateIndex, Point &collisio
 
          Color bumpC(scale/3, scale/3, scale);
 
-         for(S32 i = 0; i < 4 * pow((F32)scale, 0.5f); i++)
+         for(S32 i = 0; i < 4 * pow((F32)scale, 0.5f); ++i)
          {
             Point chaos(TNL::Random::readF(), TNL::Random::readF());
             chaos *= scale + 1;
@@ -1614,7 +1616,7 @@ F32 Asteroid::getEditorRadius(F32 currentScale)
 
 const Vector<Point> *Asteroid::getCollisionPoly() const
 {
-   //for(S32 i = 0; i < ASTEROID_POINTS; i++)
+   //for(S32 i = 0; i < ASTEROID_POINTS; ++i)
    //{
    //   Point p = Point(mMoveState[MoveObject::ActualState].pos.x + (F32) AsteroidCoords[mDesign][i][0] * asteroidRenderSize[mSizeIndex],
    //                   mMoveState[MoveObject::ActualState].pos.y + (F32) AsteroidCoords[mDesign][i][1] * asteroidRenderSize[mSizeIndex] );
@@ -1636,7 +1638,8 @@ void Asteroid::damageObject(DamageInfo *damageInfo)
       shooter->getStatistics()->mAsteroidsKilled++;
 
    // Compute impulse direction
-   mSizeLeft--;
+   --mSizeLeft;
+
 
    if(mSizeLeft <= 0)    // Kill small items
    {
@@ -1761,7 +1764,7 @@ bool Asteroid::processArguments(S32 argc2, const char **argv2, Game *game)
    S32 argc = 0;
    const char *argv[8];                // 8 is ok for now..
 
-   for(S32 i = 0; i < argc2; i++)      // The idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)      // The idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char firstChar = argv2[i][0];    // First character of arg
 
@@ -1777,7 +1780,8 @@ bool Asteroid::processArguments(S32 argc2, const char **argv2, Game *game)
          if(argc < 8)
          {
             argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }
@@ -2009,7 +2013,7 @@ void TestItem::damageObject(DamageInfo *damageInfo)
 
 const Vector<Point> *TestItem::getCollisionPoly() const
 {
-   //for(S32 i = 0; i < 8; i++)    // 8 so that first point gets repeated!  Needed?  Maybe not
+   //for(S32 i = 0; i < 8; ++i)    // 8 so that first point gets repeated!  Needed?  Maybe not
    //{
    //   Point p = Point(60 * cos(i * Float2Pi / TEST_ITEM_SIDES + FloatHalfPi) + getActualPos().x, 60 * sin(i * Float2Pi / TEST_ITEM_SIDES + FloatHalfPi) + getActualPos().y);
    //   polyPoints.push_back(p);

--- a/zap/oglconsole.cpp
+++ b/zap/oglconsole.cpp
@@ -185,7 +185,8 @@ int OGLCONSOLE_CreateFont()
 						*dst++ = 0;
 					}
 				}
-				src++;
+				++src;
+
 			}
 		}
 
@@ -373,7 +374,7 @@ void OGLCONSOLE_Resize(_OGLCONSOLE_Console *console)
       if(oldLines)
       {
          int gLine;
-         for (gLine = 0; gLine < DEFAULT_MAX_LINES; gLine++)
+         for (gLine = 0; gLine < DEFAULT_MAX_LINES; ++gLine)
          {
             char * s = oldLines + (gLine * oldTextWidth);
             if(s != NULL && s[0] != 0)
@@ -598,12 +599,14 @@ void OGLCONSOLE_Render(OGLCONSOLE_Console C)
         if(v < 0)
         {
             v ^= -1;
-            C->visibility++;
+            ++C->visibility;
+
         }
         else
         {
             v = SLIDE_STEPS - v;
-            C->visibility--;
+            --C->visibility;
+
         }
 
         d = C->textHeight * C->characterHeight * (1.0f - v * (1.0f / SLIDE_STEPS));
@@ -642,7 +645,7 @@ void OGLCONSOLE_Render(OGLCONSOLE_Console C)
         int gLine, tLine = C->lineScrollIndex;
 
         /* Iterate through each line being displayed */
-        for (gLine = 0; gLine < C->textHeight; gLine++)
+        for (gLine = 0; gLine < C->textHeight; ++gLine)
         {
             /* Draw this line of text adjusting for user scrolling up/down */
             OGLCONSOLE_DrawString(
@@ -709,7 +712,8 @@ void OGLCONSOLE_DrawString(char *s, F32 x, F32 y, F32 w, F32 h, F32 z)
     while (*s)
     {
         OGLCONSOLE_DrawCharacter(*s-FIRST_CHARACTER, x, y, w, h, z);
-        s++;
+        ++s;
+
         x += w;
     }
 }
@@ -724,7 +728,8 @@ void OGLCONSOLE_DrawWrapString(char *s, F32 x, F32 y, F32 w, F32 h,
     while (*s)
     {
         OGLCONSOLE_DrawCharacter(*s-FIRST_CHARACTER, X, y, w, h, z);
-        s++;
+        ++s;
+
         X += w;
 
         if(++pos >= wrap)
@@ -859,7 +864,8 @@ void OGLCONSOLE_Output(OGLCONSOLE_Console C, const char *s, ...)
          if(*outputCursor == '\n')
          {
              C->outputNewline = 1;
-             outputCursor++;
+             ++outputCursor;
+
              continue;
          }
 
@@ -877,7 +883,8 @@ void OGLCONSOLE_Output(OGLCONSOLE_Console C, const char *s, ...)
                  /* Switch on the console's newline bit, and advance through the
                   * string output we've been given */
                  C->outputNewline = 1;
-                 outputCursor++;
+                 ++outputCursor;
+
                  continue;
              }
 
@@ -886,7 +893,8 @@ void OGLCONSOLE_Output(OGLCONSOLE_Console C, const char *s, ...)
              {
                  n = TAB_WIDTH - n % TAB_WIDTH;
                  while (n--) *(consoleCursor++) = ' ';
-                 outputCursor++;
+                 ++outputCursor;
+
                  continue;
              }
          }
@@ -929,7 +937,8 @@ void OGLCONSOLE_AddHistory(OGLCONSOLE_Console C, char *s)
           blank = 0;
           break;
        }
-       i++;
+       ++i;
+
     }
 
     if(blank)
@@ -937,13 +946,15 @@ void OGLCONSOLE_AddHistory(OGLCONSOLE_Console C, char *s)
 
    strcpy(C->history[C->historyQueueIndex], s);      // strcpy(dest, src)
 
-    C->maxHistoryIndex++;
+    ++C->maxHistoryIndex;
+
 
     if(C->maxHistoryIndex >= MAX_HISTORY_COUNT)
         C->maxHistoryIndex = MAX_HISTORY_COUNT;
 
 
-    C->historyQueueIndex++;
+    ++C->historyQueueIndex;
+
 
     if(C->historyQueueIndex >= MAX_HISTORY_COUNT)
         C->historyQueueIndex = 0;
@@ -1063,7 +1074,8 @@ int OGLCONSOLE_KeyEvent(int sym, int mod)
 
                 /* This is all that differentiates the backspace from the delete
                  * key */
-                userConsole->inputCursorPos--;
+                --userConsole->inputCursorPos;
+
             }
 
             /* Delete key operations bail if the cursor is at the end of the
@@ -1079,7 +1091,8 @@ int OGLCONSOLE_KeyEvent(int sym, int mod)
             while (c <= end)
             {
                 *c = *(c+1);
-                c++;
+                ++c;
+
             }
         }
 
@@ -1225,7 +1238,8 @@ int OGLCONSOLE_KeyEvent(int sym, int mod)
         OGLCONSOLE_YankHistory(userConsole);
 
         if(userConsole->inputCursorPos > 0)
-            userConsole->inputCursorPos--;
+            --userConsole->inputCursorPos;
+
 
         return 1;
     }
@@ -1238,7 +1252,8 @@ int OGLCONSOLE_KeyEvent(int sym, int mod)
 
         if(userConsole->inputCursorPos <
             userConsole->inputLineLength)
-            userConsole->inputCursorPos++;
+            ++userConsole->inputCursorPos;
+
 
         return 1;
     }
@@ -1272,17 +1287,19 @@ int OGLCONSOLE_CharEvent(int unicode)
       d = userConsole->inputLine + userConsole->inputLineLength + 1;
 
       /* Slide some of the string to the right */
-      for (; d != c; d--)
+      for (; d != c; --d)
          *d = *(d-1);
 
       /* Insert new character */
       *c = (char)unicode;
 
       /* Increment input line length counter */
-      userConsole->inputLineLength++;
+      ++userConsole->inputLineLength;
+
 
       /* Advance input cursor position */
-      userConsole->inputCursorPos++;
+      ++userConsole->inputCursorPos;
+
    }
 
    return 1;

--- a/zap/pictureloader.cpp
+++ b/zap/pictureloader.cpp
@@ -72,14 +72,14 @@ bool LoadWAVFile(const char *filename, char &format, char **data, int &size, int
    readint(file); // data rate
    readshort(file); // data block size
    bool bits16 = readshort(file) == 16; // bits per sample
-   for(int i=16; i<size1; i++)
+   for(int i=16; i<size1; ++i)
       readbyte(file);
 
    a=readint(file);
    while(a != 0x61746164 && a != 0) // loop until found "data"
    {
       a=readint(file);
-      for(int i=0; i < (a & 0xFFF); i++)
+      for(int i=0; i < (a & 0xFFF); ++i)
          readbyte(file);
       a=readint(file);
    }
@@ -145,7 +145,7 @@ PictureLoader *LoadPicture(const char* path){
    if(bpp<=8){
       a=1 << bpp;
       if(!p) {closefile(r);return 0;}
-      for(b=0;b<a;b++){
+      for(b=0;b<a;++b){
          p[b]=readint(r) ^ 0xFF000000; //most palette are 32 bit with zero alpha.
       }
    }
@@ -153,7 +153,7 @@ PictureLoader *LoadPicture(const char* path){
    c=0;
    d=0;
    y2=y;while(y2>0){
-      y2--;e=0;
+      --y2;e=0;
       x2=0;while(x2<x){
          switch(bpp){
          case 32:j=readint(r);
@@ -172,9 +172,10 @@ PictureLoader *LoadPicture(const char* path){
 
          j = (j & 255) << 16 | ((j >> 16) & 255) | (j & 0xFF00FF00);  // BGRA to RGBA, as used for GL Texture loader
          mem[x2+y2*x]=j;
-         x2++;
+         ++x2;
+
       }
-      for(e=1;e<vx;e++){a=readbyte(r);}
+      for(e=1;e<vx;++e){a=readbyte(r);}
       //If Eof(r) Then y2=0
    }
    closefile(r);
@@ -202,7 +203,7 @@ GLuint loadGLTex(PictureLoader *picture)
 
    //if(num == 0)  // move color into alpha
    //{
-   //   for(S32 i = pict->x * pict->y - 1; i>=0; i--)
+   //   for(S32 i = pict->x * pict->y - 1; i>=0; --i)
    //      pict->data[i] = (pict->data[i] << 24) | 0x00FFFFFF;
    //}
 

--- a/zap/projectile.cpp
+++ b/zap/projectile.cpp
@@ -257,7 +257,8 @@ void Projectile::idle(BfObject::IdleCallPath path)
 
       while(timeLeft > 0.01f && loopcount != 0)    // This loop is to prevent slow bounce on low frame rate / high time left
       {
-         loopcount--;
+         --loopcount;
+
 
          startPos = getPos();
 
@@ -319,7 +320,7 @@ void Projectile::idle(BfObject::IdleCallPath path)
          // Note that if we hit an object that does want to be collided with, it won't be in disabledList
          // and thus collisions will not have been disabled, and thus don't need to be re-enabled.
          // Our collision detection is done, and hitObject contains the first thing that the projectile hit.
-         for(S32 i = 0; i < disabledList.size(); i++)
+         for(S32 i = 0; i < disabledList.size(); ++i)
             disabledList[i]->enableCollision();
 
          // This logic lets the Railgun go through ships. It assumes that the
@@ -361,7 +362,8 @@ void Projectile::idle(BfObject::IdleCallPath path)
                      (S32)mTimeRemaining < WeaponInfo::getWeaponInfo(mWeaponType).projLiveTime)
                {
                   mTimeRemaining += LIVETIME_INCREASE;
-                  mLiveTimeIncreases++;
+                  ++mLiveTimeIncreases;
+
                }
 
                // We hit something that we should bounce from, so bounce!
@@ -502,7 +504,7 @@ void Projectile::explode(BfObject *hitObject, Point pos)
          if(safeZone && safeZone->protectsShip(ship))
          {
             useDesaturatedSparks = true;
-            for(S32 i = 0; i < NumSparkColors; i++)
+            for(S32 i = 0; i < NumSparkColors; ++i)
                desaturatedSparkColors[i].interp(0.75f, sparkColors[i], Colors::gray50);
          }
       }
@@ -861,7 +863,7 @@ void Burst::explode(const Point &pos)
    S32 hits = radiusDamage(pos, InnerBlastRadius, OuterBlastRadius, (TestFunc)isRadiusDamageAffectableType, damageInfo);
 
    if(getOwner())
-      for(S32 i = 0; i < hits; i++)
+      for(S32 i = 0; i < hits; ++i)
          getOwner()->getStatistics()->countHit(mWeaponType);
 
    disableCollision();
@@ -1023,7 +1025,7 @@ void Mine::idle(IdleCallPath path)
 
    // Found something!
    bool foundItem = false;
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       BfObject *foundObject = static_cast<BfObject *>(fillVector[i]);
 
@@ -1715,7 +1717,7 @@ void Seeker::acquireTarget()
 
    F32 closest = F32_MAX;
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       TNLAssert(dynamic_cast<BfObject *>(fillVector[i]), "Not a BfObject");
       BfObject *foundObject = static_cast<BfObject *>(fillVector[i]);
@@ -1752,7 +1754,7 @@ void Seeker::acquireTarget()
       F32 dummy;
       bool wallInTheWay = false;
 
-      for(S32 i = 0; i < localFillVector.size(); i++)
+      for(S32 i = 0; i < localFillVector.size(); ++i)
       {
          BfObject *collideObject = static_cast<BfObject *>(localFillVector[i]);
 
@@ -1893,7 +1895,7 @@ void Seeker::handleCollision(BfObject *hitObject, Point collisionPoint)
       S32 hits = radiusDamage(collisionPoint, InnerBlastRadius, OuterBlastRadius, (TestFunc)isRadiusDamageAffectableType, damageInfo, 200);
 
       if(getOwner())
-         for(S32 i = 0; i < hits; i++)
+         for(S32 i = 0; i < hits; ++i)
             getOwner()->getStatistics()->countHit(mWeaponType);
    }
 

--- a/zap/quickChatHelper.cpp
+++ b/zap/quickChatHelper.cpp
@@ -127,7 +127,7 @@ S32 QuickChatHelper::getWidthOfItems() const
 {
    S32 maxWidth = 0;
 
-   for(S32 i = 0; i < nodeTree.size(); i++)
+   for(S32 i = 0; i < nodeTree.size(); ++i)
    {
       S32 width = getStringWidth(MENU_FONT_SIZE, nodeTree[i].caption.c_str());
 
@@ -146,7 +146,7 @@ S32 QuickChatHelper::getWidthOfButtons() const
 
    S32 maxWidth = 0;
 
-   for(S32 i = 0; i < nodeTree.size(); i++)
+   for(S32 i = 0; i < nodeTree.size(); ++i)
    {
       InputCode code = (inputMode == InputModeJoystick) ? nodeTree[i].buttonCode : nodeTree[i].inputCode;
       S32 width = JoystickRender::getControllerButtonRenderedSize(code);
@@ -171,7 +171,8 @@ void QuickChatHelper::updateChatMenuItems(S32 curNode)
 
    S32 walk = mCurNode;
    U32 matchLevel = nodeTree[walk].depth + 1;
-   walk++;
+   ++walk;
+
 
    mMenuItems1IsCurrent = !mMenuItems1IsCurrent;
 
@@ -184,7 +185,8 @@ void QuickChatHelper::updateChatMenuItems(S32 curNode)
 
    // First get to the end...
    while(nodeTree[walk].depth >= matchLevel)
-      walk++;
+      ++walk;
+
 
    // Then draw bottom up...
    while(walk != mCurNode)
@@ -203,7 +205,8 @@ void QuickChatHelper::updateChatMenuItems(S32 curNode)
 
          menuItems->push_back(item);
       }
-      walk--;
+      --walk;
+
    }
 }
 
@@ -224,7 +227,8 @@ bool QuickChatHelper::processInputCode(InputCode inputCode)
    // Set up walk...
    S32 walk = mCurNode;
    U32 matchLevel = nodeTree[walk].depth + 1;
-   walk++;
+   ++walk;
+
 
    // Iterate over anything at our desired depth or lower
    while(nodeTree[walk].depth >= matchLevel)
@@ -241,7 +245,8 @@ bool QuickChatHelper::processInputCode(InputCode inputCode)
          UserInterface::playBoop();
 
          // If we're at a leaf (ie, next child down is higher or equal to us), then issue the chat and call it good
-         walk++;
+         ++walk;
+
          if(nodeTree[mCurNode].depth >= nodeTree[walk].depth)
          {
             exitHelper();
@@ -261,7 +266,8 @@ bool QuickChatHelper::processInputCode(InputCode inputCode)
          }
          return true;
       }
-      walk++;
+      ++walk;
+
    }
 
    return false;

--- a/zap/rabbitGame.cpp
+++ b/zap/rabbitGame.cpp
@@ -118,7 +118,7 @@ Vector<string> RabbitGameType::getGameParameterMenuKeys()
    Vector<string> items = Parent::getGameParameterMenuKeys();
 
    // Use "Win Score" as an indicator of where to insert our Rabbit specific menu items
-   for(S32 i = 0; i < items.size(); i++)
+   for(S32 i = 0; i < items.size(); ++i)
       if(items[i] == "Win Score")
       {
          items.insert(i - 1, "Flag Return Time");
@@ -248,7 +248,7 @@ void RabbitGameType::idle(BfObject::IdleCallPath path, U32 deltaT)
    // Server only from here on
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *mRabbitFlag = static_cast<FlagItem *>(flags->get(i));
 

--- a/zap/retrieveGame.cpp
+++ b/zap/retrieveGame.cpp
@@ -125,7 +125,7 @@ void RetrieveGameType::shipTouchZone(Ship *s, GoalZone *z)
    // See if this zone already has a flag in it.  If so, do nothing.
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
       if(static_cast<FlagItem *>(flags->get(i))->getZone() == z)
          return;
 
@@ -170,18 +170,19 @@ void RetrieveGameType::shipTouchZone(Ship *s, GoalZone *z)
       const Vector<DatabaseObject *> *goalZones = getGame()->getGameObjDatabase()->findObjects_fast(GoalZoneTypeNumber);
 
       U32 teamZoneCount = 0;
-      for(S32 i = 0; i < goalZones->size(); i++)
+      for(S32 i = 0; i < goalZones->size(); ++i)
       {
          GoalZone *thisZone = static_cast<GoalZone *>(goalZones->get(i));
 
          // If zone is same team as the ship, count it
          if(thisZone->getTeam() == s->getTeam())
-            teamZoneCount++;
+            ++teamZoneCount;
+
       }
 
       U32 teamZoneFlagCount = 0;
       U32 teamPossibleFlagCount = 0;
-      for(S32 i = 0; i < flags->size(); i++)
+      for(S32 i = 0; i < flags->size(); ++i)
       {
          FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 
@@ -192,11 +193,13 @@ void RetrieveGameType::shipTouchZone(Ship *s, GoalZone *z)
          if(canBeOurFlag)
          {
             // Keep track of possibles for later
-            teamPossibleFlagCount++;
+            ++teamPossibleFlagCount;
+
 
             // If it's in a zone and the zone is our team's, count it
             if(flag->getZone() && (flag->getZone()->getTeam() == s->getTeam()))
-               teamZoneFlagCount++;
+               ++teamZoneFlagCount;
+
          }
       }
 
@@ -213,7 +216,7 @@ void RetrieveGameType::shipTouchZone(Ship *s, GoalZone *z)
          static StringTableEntry capAllString("Team %e0 retrieved all the flags!");
          e[0] = getGame()->getTeamName(s->getTeam());
 
-         for(S32 i = 0; i < getGame()->getClientCount(); i++)
+         for(S32 i = 0; i < getGame()->getClientCount(); ++i)
             if(!getGame()->getClientInfo(i)->isRobot())
             {
                if(isGameOver())  // Avoid flooding messages on game over. (empty formatString)
@@ -224,7 +227,7 @@ void RetrieveGameType::shipTouchZone(Ship *s, GoalZone *z)
       }
 
       // Return all the flags to their starting locations if need be
-      for(S32 i = 0; i < flags->size(); i++)
+      for(S32 i = 0; i < flags->size(); ++i)
       {
          FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 
@@ -263,7 +266,7 @@ void RetrieveGameType::performProxyScopeQuery(BfObject *scopeObject, ClientInfo 
    S32 uTeam = scopeObject->getTeam();
 
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 
@@ -300,11 +303,11 @@ void RetrieveGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight)
    const Vector<DatabaseObject *> *goalZones = getGame()->getGameObjDatabase()->findObjects_fast(GoalZoneTypeNumber);
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       if(static_cast<FlagItem *>(flags->get(i))->getMount() == ship)
       {
-         for(S32 j = 0; j < goalZones->size(); j++)
+         for(S32 j = 0; j < goalZones->size(); ++j)
          {
             GoalZone *goalZone = static_cast<GoalZone *>(goalZones->get(j));
 
@@ -313,7 +316,7 @@ void RetrieveGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight)
                continue;
 
             bool found = false;
-            for(S32 k = 0; k < flags->size(); k++)
+            for(S32 k = 0; k < flags->size(); ++k)
                if(static_cast<FlagItem *>(flags->get(k))->getZone() == goalZone)
                {
                   found = true;
@@ -328,7 +331,7 @@ void RetrieveGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight)
       }
    }
 
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
       if(!flag->isMounted() && !uFlag)

--- a/zap/robot.cpp
+++ b/zap/robot.cpp
@@ -418,7 +418,7 @@ bool Robot::processArguments(S32 argc, const char **argv, Game *game)
    {
       string line;
 
-      for(S32 i = 0; i < argc; i++)
+      for(S32 i = 0; i < argc; ++i)
       {
          if(i > 0)
             line += " ";
@@ -478,7 +478,7 @@ bool Robot::processArguments(S32 argc, const char **argv, Game *game, string &er
    // Collect our arguments to be passed into the args table in the robot (starting with the robot name)
    // Need to make a copy or containerize argv[i] somehow, because otherwise new data will get written
    // to the string location subsequently, and our vals will change from under us.  That's bad!
-   for(S32 i = 2; i < argc; i++)        // Does nothing if we have no args
+   for(S32 i = 2; i < argc; ++i)        // Does nothing if we have no args
       mScriptArgs.push_back(string(argv[i]));
 
    // I'm not sure this goes here, but it needs to be set early in setting up the Robot, but after
@@ -543,7 +543,7 @@ bool Robot::canSeePoint(Point point, bool wallOnly)
    fillVector.clear();
    mGame->getGameObjDatabase()->findObjects(wallOnly ? (TestFunc)isWallType : (TestFunc)isCollideableType, fillVector, queryRect);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       const Vector<Point> *otherPoints = fillVector[i]->getCollisionPoly();
       if(otherPoints && polygonsIntersect(thisPoints, *otherPoints))
@@ -601,7 +601,7 @@ void Robot::clearMove()
    mCurrentMove.x = 0;
    mCurrentMove.y = 0;
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
    {
       mCurrentMove.modulePrimary[i] = false;
       mCurrentMove.moduleSecondary[i] = false;
@@ -648,7 +648,7 @@ U16 Robot::findClosestZone(const Point &point)
 
    getGame()->getBotZoneDatabase()->findObjects(BotNavMeshZoneTypeNumber, objects, rect);
 
-   for(S32 i = 0; i < objects.size(); i++)
+   for(S32 i = 0; i < objects.size(); ++i)
    {
       BotNavMeshZone *zone = static_cast<BotNavMeshZone *>(objects[i]);
       Point center = zone->getCenter();
@@ -991,7 +991,7 @@ S32 Robot::lua_findClosestEnemy(lua_State *L)
    else
       getGame()->getGameObjDatabase()->findObjects((TestFunc)isShipType, fillVector);
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       // Ignore self
       if(fillVector[i] == this)
@@ -1116,7 +1116,7 @@ S32 Robot::lua_fireWeapon(lua_State *L)
    bool hasWeapon = false;
 
    // Check the weapons we have on board -- if any match the requested weapon, select it
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       if(mLoadout.getWeapon(i) == weapon)
       {
          hasWeapon = true;
@@ -1152,7 +1152,7 @@ S32 Robot::lua_hasWeapon(lua_State *L)
    checkArgList(L, functionArgs, "Robot", "hasWeapon");
    WeaponType weap = getWeaponType(L, 1);
 
-   for(S32 i = 0; i < ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipWeaponCount; ++i)
       if(mLoadout.getWeapon(i) == weap)
          return returnBool(L, true);      // We have it!
 
@@ -1176,7 +1176,7 @@ S32 Robot::lua_fireModule(lua_State *L)
    bool hasModule = false;
 
    // Check if module is equipped and fire it
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       if(getModule(i) == module)
       {
          hasModule = true;
@@ -1205,7 +1205,7 @@ S32 Robot::lua_hasModule(lua_State *L)
    checkArgList(L, functionArgs, "Robot", "hasModule");
    ShipModule module = getShipModule(L, 1);
 
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
       if(mLoadout.getModule(i) == module)
          return returnBool(L, true);      // We have it!
 
@@ -1435,7 +1435,7 @@ S32 Robot::lua_findVisibleObjects(lua_State *L)
 
    S32 pushed = 0;      // Count of items we put into our table
 
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
    {
       if(isShipType(fillVector[i]->getObjectTypeNumber()))
       {
@@ -1450,7 +1450,7 @@ S32 Robot::lua_findVisibleObjects(lua_State *L)
       }
 
       static_cast<BfObject *>(fillVector[i])->push(L);
-      pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 
@@ -1607,7 +1607,7 @@ S32 Robot::lua_dropItem(lua_State *L)
    checkArgList(L, functionArgs, "Robot", "dropItem");
 
    S32 count = mMountedItems.size();
-   for(S32 i = count - 1; i >= 0; i--)
+   for(S32 i = count - 1; i >= 0; --i)
       mMountedItems[i]->dismount(DISMOUNT_NORMAL);
 
    return 0;

--- a/zap/robot.cpp
+++ b/zap/robot.cpp
@@ -110,17 +110,17 @@ Robot::Robot(lua_State *L) : Ship(NULL, TEAM_NEUTRAL, Point(0,0), true),
       S32 i = 1;
 
       if(profile >= 1) {
-         setPos(L, ++i);
-         setTeam(L, ++i);
+         setPos(L, i++);
+         setTeam(L, i++);
       }
 
       if(profile == 2)
       {
-         mScriptName = GameSettings::getFolderManager()->findBotFile(getString(L, ++i));
+         mScriptName = GameSettings::getFolderManager()->findBotFile(getString(L, i++));
 
          while(i <= lua_gettop(L))
          {
-            mScriptArgs.push_back(getString(L, ++i));
+            mScriptArgs.push_back(getString(L, i++));
          }
       }
 

--- a/zap/robot.cpp
+++ b/zap/robot.cpp
@@ -110,17 +110,17 @@ Robot::Robot(lua_State *L) : Ship(NULL, TEAM_NEUTRAL, Point(0,0), true),
       S32 i = 1;
 
       if(profile >= 1) {
-         setPos(L, i++);
-         setTeam(L, i++);
+         setPos(L, ++i);
+         setTeam(L, ++i);
       }
 
       if(profile == 2)
       {
-         mScriptName = GameSettings::getFolderManager()->findBotFile(getString(L, i++));
+         mScriptName = GameSettings::getFolderManager()->findBotFile(getString(L, ++i));
 
          while(i <= lua_gettop(L))
          {
-            mScriptArgs.push_back(getString(L, i++));
+            mScriptArgs.push_back(getString(L, ++i));
          }
       }
 

--- a/zap/safeZone.cpp
+++ b/zap/safeZone.cpp
@@ -65,7 +65,7 @@ bool SafeZone::processArguments(S32 rawArgc, const char **rawArgv, Game *game)
    const S32 MAX_ARGV_SIZE = Geometry::MAX_POLY_POINTS * 2 + 1;
    S32 argc = 0;
    const char *argv[MAX_ARGV_SIZE];
-   for(S32 i = 0; i < rawArgc; i++)
+   for(S32 i = 0; i < rawArgc; ++i)
    {
       char c = rawArgv[i][0];
       // Ignore optional alphabetic tokens so newer level params remain backward-compatible.
@@ -74,7 +74,8 @@ bool SafeZone::processArguments(S32 rawArgc, const char **rawArgv, Game *game)
          if(argc < MAX_ARGV_SIZE)
          {
             argv[argc] = rawArgv[i];
-            argc++;
+            ++argc;
+
          }
       }
    }

--- a/zap/ship.cpp
+++ b/zap/ship.cpp
@@ -94,7 +94,7 @@ void Ship::initialize(ClientInfo *clientInfo, S32 team, const Point &pos, bool i
    mEngineeredTeleporter = NULL;
 
    // Set up module secondary delay timer
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
       mModuleSecondaryTimer[i].setPeriod(ModuleSecondaryTimerDelay);
 
    mSpyBugPlacementTimer.setPeriod(SpyBugPlacementTimerDelay);
@@ -105,7 +105,7 @@ void Ship::initialize(ClientInfo *clientInfo, S32 team, const Point &pos, bool i
    mNetFlags.set(Ghostable);
 
 #ifndef ZAP_DEDICATED
-   for(U32 i = 0; i < TrailCount; i++)
+   for(U32 i = 0; i < TrailCount; ++i)
       mLastTrailPoint[i] = -1;   // Or something... doesn't really matter what
 #endif
 
@@ -166,7 +166,7 @@ bool Ship::isServerCopyOf(const Ship &clientShip) const
     if(mMountedItems.size() != clientShip.mMountedItems.size())
        return false;
 
-    for(S32 i = 0; i < mMountedItems.size(); i++)
+    for(S32 i = 0; i < mMountedItems.size(); ++i)
        if(mMountedItems[i]->getObjectTypeNumber() != clientShip.mMountedItems[i]->getObjectTypeNumber())
           return false;
 
@@ -190,7 +190,7 @@ void Ship::initialize(const Point &pos)
    mHasExploded = false; // Haven't exploded yet!
 
 #ifndef ZAP_DEDICATED
-   for(S32 i = 0; i < TrailCount; i++)          // Clear any vehicle trails
+   for(S32 i = 0; i < TrailCount; ++i)          // Clear any vehicle trails
       mTrail[i].reset();
 #endif
 
@@ -211,7 +211,7 @@ bool Ship::processArguments(S32 argc, const char **argv, Game *game)
    Point pos;
    pos.read(argv + 1);
    pos *= game->getLegacyGridSize();
-   for(U32 i = 0; i < MoveStateCount; i++)
+   for(U32 i = 0; i < MoveStateCount; ++i)
    {
       setPos(i, pos);
       setAngle(i, 0);
@@ -370,7 +370,7 @@ BfObject *Ship::doIsInZone(const Vector<DatabaseObject *> &objects) const
 
    // Extents overlap...  now check for actual overlap
 
-   for(S32 i = 0; i < objects.size(); i++)
+   for(S32 i = 0; i < objects.size(); ++i)
    {
       BfObject *zone = static_cast<BfObject *>(objects[i]);
 
@@ -393,7 +393,7 @@ DatabaseObject *Ship::isOnObject(U8 objectType, U32 stateIndex)
       return NULL;
 
    // Return first actually overlapping object on our candidate list
-   for(S32 i = 0; i < fillVector.size(); i++)
+   for(S32 i = 0; i < fillVector.size(); ++i)
       if(isOnObject(static_cast<BfObject *>(fillVector[i]), ActualState))
          return fillVector[i];
 
@@ -531,7 +531,7 @@ void Ship::controlMoveReplayComplete()
 #ifndef ZAP_DEDICATED
       // If it's a large delta, get rid of the movement trails
       if(deltaLenSq > sq(MaxControlObjectInterpDistance))
-         for(S32 i = 0; i < TrailCount; i++)
+         for(S32 i = 0; i < TrailCount; ++i)
             mTrail[i].reset();
 #endif
 
@@ -729,7 +729,7 @@ void Ship::findRepairTargets()
    foundObjects.clear();
    findObjects((TestFunc)isWithHealthType, foundObjects, r);   // All isWithHealthType objects are items
 
-   for(S32 i = 0; i < foundObjects.size(); i++)
+   for(S32 i = 0; i < foundObjects.size(); ++i)
    {
       BfObject *item = static_cast<BfObject*>(foundObjects[i]);
 
@@ -783,7 +783,7 @@ void Ship::repairTargets()
    di.damagingObject = this;
    di.damageType = DamageTypePoint;
 
-   for(S32 i = 0; i < mRepairTargets.size(); i++)
+   for(S32 i = 0; i < mRepairTargets.size(); ++i)
       mRepairTargets[i]->damageObject(&di);
 }
 
@@ -791,7 +791,7 @@ void Ship::repairTargets()
 void Ship::processModules()
 {
    // Update some timers
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
       mModuleSecondaryTimer[i].update(mCurrentMove.time);
 
    mSpyBugPlacementTimer.update(mCurrentMove.time);
@@ -800,7 +800,7 @@ void Ship::processModules()
    bool wasModulePrimaryActive[ModuleCount];
    bool wasModuleSecondaryActive[ModuleCount];
 
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
    {
       wasModulePrimaryActive[i]   = mLoadout.isModulePrimaryActive(ShipModule(i));
       wasModuleSecondaryActive[i] = mLoadout.isModuleSecondaryActive(ShipModule(i));
@@ -810,7 +810,7 @@ void Ship::processModules()
 
    // Go through our loaded modules and see if they are currently turned on
    // Are these checked on the server side?
-   for(S32 i = 0; i < ShipModuleCount; i++)
+   for(S32 i = 0; i < ShipModuleCount; ++i)
    {
       // If you have passive module, it's always active, no restrictions, but is off for energy consumption purposes
       if(ModuleInfo::getModuleInfo(mLoadout.getModule(i))->getPrimaryUseType() == ModulePrimaryUsePassive)
@@ -857,7 +857,7 @@ void Ship::processModules()
 
       //   if(fillVector.size() > 0)
       //   {
-      //      for(S32 i=0; i<fillVector.size(); i++)
+      //      for(S32 i=0; i<fillVector.size(); ++i)
       //      {
       //         Ship *s = dynamic_cast<Ship *>(fillVector[i]);
 
@@ -879,7 +879,7 @@ void Ship::processModules()
    S32 primaryActivationCount = 0;
 
    // Update things based on available energy...
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
    {
       if(mLoadout.isModulePrimaryActive(ShipModule(i)))
       {
@@ -889,7 +889,8 @@ void Ship::processModules()
 
          // Exclude passive modules
          if(energyUsed != 0)
-            primaryActivationCount += 1;
+            ++primaryActivationCount;
+
 
          if(getClientInfo())
             getClientInfo()->getStatistics()->addModuleUsed(ShipModule(i), mCurrentMove.time);
@@ -956,7 +957,7 @@ void Ship::processModules()
       mEnergy += EnergyRechargeRate * timeInMilliSeconds;
 
    // Do logic triggered when module primary component state changes
-   for(S32 i = 0; i < ModuleCount;i++)
+   for(S32 i = 0; i < ModuleCount;++i)
    {
       if(mLoadout.isModulePrimaryActive(ShipModule(i)) != wasModulePrimaryActive[i])
       {
@@ -968,7 +969,7 @@ void Ship::processModules()
    }
 
    // Do logic triggered when module secondary component state changes
-   for(U32 i = 0; i < ModuleCount;i++)
+   for(U32 i = 0; i < ModuleCount;++i)
    {
       if(mLoadout.isModuleSecondaryActive(ShipModule(i)) != wasModuleSecondaryActive[i])
       {
@@ -1234,7 +1235,7 @@ void Ship::updateModuleSounds()
       SFXNone,       // Armor... tough, but he don't say much
    };
 
-   for(U32 i = 0; i < ModuleCount; i++)
+   for(U32 i = 0; i < ModuleCount; ++i)
    {
       if(mLoadout.isModulePrimaryActive(ShipModule(i)) && moduleSFXs[i] != SFXNone)
       {
@@ -1261,7 +1262,7 @@ static U32 MaxFireDelay = 0;
 // static method, only run during init on both client and server
 void Ship::computeMaxFireDelay()
 {
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
       if(WeaponInfo::getWeaponInfo(WeaponType(i)).fireDelay > MaxFireDelay)
          MaxFireDelay = WeaponInfo::getWeaponInfo(WeaponType(i)).fireDelay;
 }
@@ -1360,7 +1361,7 @@ U32 Ship::packUpdate(GhostConnection *connection, U32 updateMask, BitStream *str
       stream->writeStringTableEntry(getClientInfo() ? getClientInfo()->getName() : StringTableEntry());
 
       // Now write all the mounts:
-      for(S32 i = 0; i < mMountedItems.size(); i++)
+      for(S32 i = 0; i < mMountedItems.size(); ++i)
       {
          if(mMountedItems[i].isValid())
          {
@@ -1380,10 +1381,10 @@ U32 Ship::packUpdate(GhostConnection *connection, U32 updateMask, BitStream *str
 
    if(stream->writeFlag(updateMask & LoadoutMask))       // Loadout configuration
    {
-      for(S32 i = 0; i < ShipModuleCount; i++)
+      for(S32 i = 0; i < ShipModuleCount; ++i)
          stream->writeEnum(mLoadout.getModule(i), ModuleCount);
 
-      for(S32 i = 0; i < ShipWeaponCount; i++)
+      for(S32 i = 0; i < ShipWeaponCount; ++i)
          stream->writeEnum(mLoadout.getWeapon(i), WeaponCount);
    }
 
@@ -1433,12 +1434,12 @@ U32 Ship::packUpdate(GhostConnection *connection, U32 updateMask, BitStream *str
 
       // If a module primary component is detected as on, pack it
       if(stream->writeFlag(updateMask & ModulePrimaryMask))    // <=== THREE
-         for(S32 i = 0; i < ModuleCount; i++)                  // Send info about which modules are active (primary)
+         for(S32 i = 0; i < ModuleCount; ++i)                  // Send info about which modules are active (primary)
             stream->writeFlag(mLoadout.isModulePrimaryActive(ShipModule(i)));
 
       // If a module secondary component is detected as on, pack it
       if(stream->writeFlag(updateMask & ModuleSecondaryMask))  // <=== FOUR
-         for(S32 i = 0; i < ModuleCount; i++)                  // Send info about which modules are active (secondary)
+         for(S32 i = 0; i < ModuleCount; ++i)                  // Send info about which modules are active (secondary)
             stream->writeFlag(mLoadout.isModuleSecondaryActive(ShipModule(i)));
    }
 
@@ -1513,7 +1514,7 @@ void Ship::unpackUpdate(GhostConnection *connection, BitStream *stream)
       bool hasSensorNow = false;
       bool hasEngineerModule = false;
 
-      for(S32 i = 0; i < ShipModuleCount; i++)
+      for(S32 i = 0; i < ShipModuleCount; ++i)
       {
          // Check old loadout for sensor
          if(mLoadout.getModule(i) == ModuleSensor)
@@ -1534,7 +1535,7 @@ void Ship::unpackUpdate(GhostConnection *connection, BitStream *stream)
       if(hadSensorThen != hasSensorNow && !isInitialUpdate())  // ! isInitialUpdate(), don't do zoom out effect of ship spawn
          mSensorEquipZoomTimer.reset();
 
-      for(S32 i = 0; i < ShipWeaponCount; i++)
+      for(S32 i = 0; i < ShipWeaponCount; ++i)
          mLoadout.setWeapon(i, (WeaponType) stream->readEnum(WeaponCount));
 
       // Notify the user interface (via the ClientGame object) about some things that may have changed.
@@ -1623,7 +1624,7 @@ void Ship::unpackUpdate(GhostConnection *connection, BitStream *stream)
    if(stream->readFlag())     // ModulePrimaryMask
    {
       bool wasPrimaryActive[ModuleCount];
-      for(S32 i = 0; i < ModuleCount; i++)
+      for(S32 i = 0; i < ModuleCount; ++i)
       {
          wasPrimaryActive[i] = mLoadout.isModulePrimaryActive(ShipModule(i));
          mLoadout.setModulePrimary(ShipModule(i), stream->readFlag());
@@ -1638,7 +1639,7 @@ void Ship::unpackUpdate(GhostConnection *connection, BitStream *stream)
    }
 
    if(stream->readFlag())     // ModuleSecondaryMask
-      for(S32 i = 0; i < ModuleCount; i++)
+      for(S32 i = 0; i < ModuleCount; ++i)
          mLoadout.setModuleSecondary(ShipModule(i), stream->readFlag());
 
    setActualAngle(mCurrentMove.angle);
@@ -1655,7 +1656,7 @@ void Ship::unpackUpdate(GhostConnection *connection, BitStream *stream)
       mInterpolating = false;
       copyMoveState(ActualState, RenderState);
 
-      for(S32 i = 0; i < TrailCount; i++)
+      for(S32 i = 0; i < TrailCount; ++i)
          mTrail[i].reset();
    }
    else
@@ -1708,7 +1709,7 @@ void Ship::updateInterpolation()
    Parent::updateInterpolation();
 
    // Update position of any mounted items
-   for(S32 i = 0; i < mMountedItems.size(); i++)
+   for(S32 i = 0; i < mMountedItems.size(); ++i)
       if(mMountedItems[i].isValid())
          mMountedItems[i]->setRenderPos(getRenderPos());
 }
@@ -1732,7 +1733,7 @@ bool Ship::isVisible(bool viewerHasSensor)
    if(viewerHasSensor || !mLoadout.isModulePrimaryActive(ModuleCloak))
       return true;
 
-   for(S32 i = 0; i < mMountedItems.size(); i++)
+   for(S32 i = 0; i < mMountedItems.size(); ++i)
       if(mMountedItems[i].isValid() && mMountedItems[i]->isItemThatMakesYouVisibleWhileCloaked())
          return true;
 
@@ -1743,7 +1744,7 @@ bool Ship::isVisible(bool viewerHasSensor)
 // Returns index of first flag mounted on ship, or NO_FLAG if there aren't any
 S32 Ship::getFlagIndex()
 {
-   for(S32 i = 0; i < mMountedItems.size(); i++)
+   for(S32 i = 0; i < mMountedItems.size(); ++i)
       if(mMountedItems[i].isValid() && (mMountedItems[i]->getObjectTypeNumber() == FlagTypeNumber))
          return i;
    return GameType::NO_FLAG;
@@ -1753,7 +1754,7 @@ S32 Ship::getFlagIndex()
 S32 Ship::getFlagCount()
 {
    S32 count = 0;
-   for(S32 i = 0; i < mMountedItems.size(); i++)
+   for(S32 i = 0; i < mMountedItems.size(); ++i)
       if(mMountedItems[i].isValid() && (mMountedItems[i]->getObjectTypeNumber() == FlagTypeNumber))
       {
          FlagItem *flag = static_cast<FlagItem *>(mMountedItems[i].getPointer());
@@ -1765,7 +1766,7 @@ S32 Ship::getFlagCount()
 
 bool Ship::isCarryingItem(U8 objectType) const
 {
-   for(S32 i = mMountedItems.size() - 1; i >= 0; i--)
+   for(S32 i = mMountedItems.size() - 1; i >= 0; --i)
       if(mMountedItems[i].isValid() && mMountedItems[i]->getObjectTypeNumber() == objectType)
          return true;
 
@@ -1776,7 +1777,7 @@ bool Ship::isCarryingItem(U8 objectType) const
 // Dismounts first object found of specified type, and returns the object.  If no objects of specified type found, will return NULL.
 MountableItem *Ship::dismountFirst(U8 objectType)
 {
-   for(S32 i = mMountedItems.size() - 1; i >= 0; i--)
+   for(S32 i = mMountedItems.size() - 1; i >= 0; --i)
       if(mMountedItems[i]->getObjectTypeNumber() == objectType)
       {
          MountableItem *item = mMountedItems[i];
@@ -1792,7 +1793,7 @@ MountableItem *Ship::dismountFirst(U8 objectType)
 void Ship::dismountAll()
 {
    // Count down here because as items are dismounted, they will be removed from the mMountedItems vector
-   for(S32 i = mMountedItems.size() - 1; i >= 0; i--)
+   for(S32 i = mMountedItems.size() - 1; i >= 0; --i)
       if(mMountedItems[i].isValid())               // Can be NULL when quitting the server
          mMountedItems[i]->dismount(DISMOUNT_MOUNT_WAS_KILLED);
 }
@@ -1801,7 +1802,7 @@ void Ship::dismountAll()
 // Dismount all objects of specified type.  Currently only used when loadout no longer includes engineer and ship drops all ResourceItems.
 void Ship::dismountAll(U8 objectType)
 {
-   for(S32 i = mMountedItems.size() - 1; i >= 0; i--)
+   for(S32 i = mMountedItems.size() - 1; i >= 0; --i)
       if(mMountedItems[i]->getObjectTypeNumber() == objectType)
          mMountedItems[i]->dismount(DISMOUNT_NORMAL);
 }
@@ -1950,7 +1951,7 @@ void Ship::kill()
 
       getZonesObjectIsIn(zoneList);
 
-      for(S32 i = 0; i < zoneList.size(); i++)
+      for(S32 i = 0; i < zoneList.size(); ++i)
          EventManager::get()->fireEvent(EventManager::ShipLeftZoneEvent, this, static_cast<Zone *>(zoneList[i].getPointer()));
    }
 
@@ -2020,7 +2021,7 @@ void Ship::emitMovementSparks()
    Vector<Point> shipDirs;
    shipDirs.resize(cornerCount);
 
-   for(S32 i = 0; i < cornerCount; i++)
+   for(S32 i = 0; i < cornerCount; ++i)
       corners[i].set(shipShapeInfo->cornerPoints[i*2], shipShapeInfo->cornerPoints[i*2 + 1]);
 
    F32 th = FloatHalfPi - getRenderAngle();
@@ -2029,7 +2030,7 @@ void Ship::emitMovementSparks()
    F32 cosTh = cos(th);
    F32 warpInScale = (WarpFadeInTime - mWarpInTimer.getCurrent()) / F32(WarpFadeInTime);
 
-   for(S32 i = 0; i < cornerCount; i++)
+   for(S32 i = 0; i < cornerCount; ++i)
    {
       shipDirs[i].x = corners[i].x * cosTh + corners[i].y * sinTh;
       shipDirs[i].y = corners[i].y * cosTh - corners[i].x * sinTh;
@@ -2046,7 +2047,7 @@ void Ship::emitMovementSparks()
    F32 bestDot = leftVec.dot(shipDirs[0]);
 
    // Find the left-wards match
-   for(S32 i = 1; i < cornerCount; i++)
+   for(S32 i = 1; i < cornerCount; ++i)
    {
       F32 d = leftVec.dot(shipDirs[i]);
       if(d >= bestDot)
@@ -2063,7 +2064,7 @@ void Ship::emitMovementSparks()
    bestId = 0;
    bestDot = rightVec.dot(shipDirs[0]);
 
-   for(S32 i = 1; i < cornerCount; i++)
+   for(S32 i = 1; i < cornerCount; ++i)
    {
       F32 d = rightVec.dot(shipDirs[i]);
       if(d >= bestDot)
@@ -2130,7 +2131,7 @@ void Ship::emitMovementSparks()
       shipDirs[2].set( shipDirs[0].y, -shipDirs[0].x);
       shipDirs[3].set(-shipDirs[0].y,  shipDirs[0].x);
 
-      for(U32 i = 0; i < 4; i++)
+      for(U32 i = 0; i < 4; ++i)
       {
          F32 th = shipDirs[i].dot(velDir);
 
@@ -2166,7 +2167,7 @@ void Ship::emitMovementSparks()
 void Ship::updateTrails()
 {
 #ifndef ZAP_DEDICATED
-   for(U32 i = 0; i < TrailCount; i++)
+   for(U32 i = 0; i < TrailCount; ++i)
       mTrail[i].idle(mCurrentMove.time);
 #endif
 }
@@ -2236,7 +2237,7 @@ void Ship::renderLayer(S32 layerIndex)
       renderShipRepairRays(getRenderPos(), this, mRepairTargets, alpha);
 
    // Render mounted items
-   for(S32 i = 0; i < mMountedItems.size(); i++)
+   for(S32 i = 0; i < mMountedItems.size(); ++i)
       if(mMountedItems[i].isValid())
          mMountedItems[i]->renderItemAlpha(getRenderPos(), alpha);
 #endif
@@ -2346,7 +2347,7 @@ void Ship::addMountedItem(MountableItem *item)
 // Supposes mountedItems are not repeated, and list is unordered
 void Ship::removeMountedItem(MountableItem *item)
 {
-   for(S32 i = 0; i < mMountedItems.size(); i++)
+   for(S32 i = 0; i < mMountedItems.size(); ++i)
       if(mMountedItems[i] == item)
       {
          mMountedItems.erase_fast(i);
@@ -2608,7 +2609,7 @@ S32 Ship::lua_getMountedItems(lua_State *L)
    Vector<BfObject *> tempVector;
 
    // Loop through all the mounted items
-   for(S32 i = 0; i < mMountedItems.size(); i++)
+   for(S32 i = 0; i < mMountedItems.size(); ++i)
    {
       // Add every item to the list if no arguments were specified
       if(!hasArgs)
@@ -2628,7 +2629,8 @@ S32 Ship::lua_getMountedItems(lua_State *L)
                break;
             }
 
-            index++;
+            ++index;
+
          }
       }
    }
@@ -2640,10 +2642,10 @@ S32 Ship::lua_getMountedItems(lua_State *L)
    // Now push all found items back to LUA
    S32 pushed = 0;      // Count of items actually pushed onto the stack
 
-   for(S32 i = 0; i < tempVector.size(); i++)
+   for(S32 i = 0; i < tempVector.size(); ++i)
    {
       tempVector[i]->push(L);
-      pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+      ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
       lua_rawseti(L, 1, pushed);
    }
 
@@ -2669,7 +2671,7 @@ S32 Ship::lua_getLoadout(lua_State *L)
    lua_createtable(L, ShipModuleCount + ShipWeaponCount, 0);
 
    // Add current modules and weapons to the table
-   for(S32 i = 0; i < ShipModuleCount + ShipWeaponCount; i++)
+   for(S32 i = 0; i < ShipModuleCount + ShipWeaponCount; ++i)
    {
       // Modules
       if(i < ShipModuleCount)
@@ -2708,7 +2710,7 @@ LoadoutTracker Ship::checkAndBuildLoadout(lua_State *L, S32 profile)
    // 5 parameters all integers, the argument list check guarantees 5 params here
    else
    {
-      for(S32 i = 0; i < expectedSize; i++)
+      for(S32 i = 0; i < expectedSize; ++i)
          loadoutValues.push_back(getInt2<S32>(L, i + 1));
    }
 
@@ -2720,7 +2722,7 @@ LoadoutTracker Ship::checkAndBuildLoadout(lua_State *L, S32 profile)
    // Now we verify and build up our loadout
    S32 moduleCount = 0;
    S32 weaponCount = 0;
-   for(S32 i = 0; i < expectedSize; i++)
+   for(S32 i = 0; i < expectedSize; ++i)
    {
       S32 value = loadoutValues[i];
 
@@ -2731,7 +2733,8 @@ LoadoutTracker Ship::checkAndBuildLoadout(lua_State *L, S32 profile)
             THROW_LUA_EXCEPTION(L, string("Too many weapons!  You must provide exactly " + itos(ShipWeaponCount) + " weapons.").c_str());
 
          loadout.setWeapon(weaponCount, WeaponType(value - ModuleCount));
-         weaponCount++;
+         ++weaponCount;
+
       }
       else
       {
@@ -2739,7 +2742,8 @@ LoadoutTracker Ship::checkAndBuildLoadout(lua_State *L, S32 profile)
             THROW_LUA_EXCEPTION(L, string("Too many modules!  You must provide exactly " + itos(ShipModuleCount) + " modules.").c_str());
 
          loadout.setModule(moduleCount, ShipModule(value));
-         moduleCount++;
+         ++moduleCount;
+
       }
    }
 

--- a/zap/soccerGame.cpp
+++ b/zap/soccerGame.cpp
@@ -165,7 +165,8 @@ void SoccerGameType::scoreGoal(Ship *ship, const StringTableEntry &scorerName, S
       // If our current scorer was the last scorer and is wasn't an own-goal
       if(clientInfo == mPossibleHatTrickPlayer && !isOwnGoal)
       {
-         mHatTrickCounter++;
+         ++mHatTrickCounter;
+
 
          // Now test if we got the badge!
          if(mHatTrickCounter == 3 &&                              // Must have scored 3 in a row !
@@ -208,7 +209,7 @@ void SoccerGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeight) c
 
    const Vector<DatabaseObject *> *zones = getGame()->getGameObjDatabase()->findObjects_fast(GoalZoneTypeNumber);
 
-   for(S32 i = 0; i < zones->size(); i++)
+   for(S32 i = 0; i < zones->size(); ++i)
    {
       GoalZone *zone = static_cast<GoalZone *>(zones->get(i));
 

--- a/zap/sparkManager.cpp
+++ b/zap/sparkManager.cpp
@@ -31,7 +31,7 @@ struct FxManager::TeleporterEffect
 
 FxManager::FxManager()
 {
-   for(U32 i = 0; i < SparkTypeCount; i++)
+   for(U32 i = 0; i < SparkTypeCount; ++i)
    {
       firstFreeIndex[i] = 0;
       lastOverwrittenIndex[i] = MAX_SPARKS / 4;   // Use a value proportional to MAX_SPARKS
@@ -224,7 +224,7 @@ void FxManager::idle(U32 timeDelta)
    F32 dTsecs = timeDelta * .001f;
 
    // We have two spark arrays -- one for points, one for lines.  Loop through both.
-   for (U32 j = 0; j < SparkTypeCount; j++)
+   for (U32 j = 0; j < SparkTypeCount; ++j)
    {
       U32 slotsPerSpark = (j == SparkTypeLine) ? 2 : 1;
 
@@ -277,12 +277,13 @@ void FxManager::idle(U32 timeDelta)
 
 
    // Kill off any old debris chunks, advance the others
-   for(S32 i = 0; i < mDebrisChunks.size(); i++)
+   for(S32 i = 0; i < mDebrisChunks.size(); ++i)
    {
       if(mDebrisChunks[i].ttl < (S32)timeDelta)
       {
          mDebrisChunks.erase_fast(i);
-         i--;
+         --i;
+
       }
       else
          mDebrisChunks[i].idle(timeDelta);
@@ -290,12 +291,13 @@ void FxManager::idle(U32 timeDelta)
 
 
    // Same for our TextEffects
-   for(S32 i = 0; i < mTextEffects.size(); i++)
+   for(S32 i = 0; i < mTextEffects.size(); ++i)
    {
       if(mTextEffects[i].ttl < (S32)timeDelta)
       {
          mTextEffects.erase_fast(i);
-         i--;
+         --i;
+
       }
       else
          mTextEffects[i].idle(timeDelta);
@@ -361,10 +363,10 @@ void FxManager::render(S32 renderPass, F32 commanderZoomFraction) const
             sizeof(Spark));         // Stride
       }
 
-      for(S32 i = 0; i < mDebrisChunks.size(); i++)
+      for(S32 i = 0; i < mDebrisChunks.size(); ++i)
          mDebrisChunks[i].render();
 
-      for(S32 i = 0; i < mTextEffects.size(); i++)
+      for(S32 i = 0; i < mTextEffects.size(); ++i)
          mTextEffects[i].render();
    }
 }
@@ -375,7 +377,7 @@ void FxManager::emitBlast(const Point &pos, U32 size)
 {
    const F32 speed = 800.0f;
 
-   for(F32 i = 0.0f; i < 360.0f; i += 1)
+   for(F32 i = 0.0f; i < 360.0f; ++i)
    {
       Point dir = Point(cos(dr(i)), sin(dr(i)));
       // Emit a ring of bright orange sparks, as well as a whole host of yellow ones
@@ -387,7 +389,7 @@ void FxManager::emitBlast(const Point &pos, U32 size)
 
 void FxManager::emitExplosion(const Point &pos, F32 size, const Color *colorArray, U32 numColors)
 {
-   for(U32 i = 0; i < (250.0 * size); i++)
+   for(U32 i = 0; i < (250.0 * size); ++i)
    {
       F32 th = TNL::Random::readF() * 2 * 3.14f;
       F32 f = (TNL::Random::readF() * 2 - 1) * 400 * size;
@@ -410,7 +412,7 @@ void FxManager::emitBurst(const Point &pos, const Point &scale, const Color &col
 {
    F32 size = 1;
 
-   for(U32 i = 0; i < sparkCount; i++)
+   for(U32 i = 0; i < sparkCount; ++i)
    {
 
       F32 th = TNL::Random::readF() * 2 * FloatPi;                // angle
@@ -432,7 +434,7 @@ void FxManager::emitBurst(const Point &pos, const Point &scale, const Color &col
 void FxManager::clearSparks()
 {
    // Remove all sparks
-   for(U32 j = 0; j < SparkTypeCount; j++)
+   for(U32 j = 0; j < SparkTypeCount; ++j)
    {
       U32 slotsPerSpark = (j == SparkTypeLine) ? 2 : 1;
 
@@ -505,7 +507,7 @@ void FxTrail::render() const
    static F32 FxTrailVertexArray[64];     // 2 coordinates per node
    static F32 FxTrailColorArray[128];     // 4 colors components per node
 
-   for(S32 i = 0; i < mNodes.size(); i++)
+   for(S32 i = 0; i < mNodes.size(); ++i)
    {
       F32 t = ((F32)i / (F32)mNodes.size());
 

--- a/zap/speedZone.cpp
+++ b/zap/speedZone.cpp
@@ -165,12 +165,18 @@ void SpeedZone::generatePoints(const Point &start, const Point &end, Vector<Poin
       F32 offset = halfWidth * 2 * i - (i * 4);
 
       // Red chevron -- iterate twice to generate pair
-      points[index++] = start + parallel *  (chevronThickness + offset);  // 0
-      points[index++] = start + perpendic * (halfWidth-2*inset) + parallel * (inset + offset);   // 1                      //  1   2
-      points[index++] = start + perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 2    //    0    3
-      points[index++] = start + parallel *  (chevronDepth + chevronThickness + inset + offset);  // 3                      //  5    4
-      points[index++] = start - perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 4
-      points[index++] = start - perpendic * (halfWidth-2*inset) + parallel * (inset + offset);  // 5
+      points[index] = start + parallel *  (chevronThickness + offset);  // 0
+      ++index;
+      points[index] = start + perpendic * (halfWidth-2*inset) + parallel * (inset + offset);   // 1                      //  1   2
+      ++index;
+      points[index] = start + perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 2    //    0    3
+      ++index;
+      points[index] = start + parallel *  (chevronDepth + chevronThickness + inset + offset);  // 3                      //  5    4
+      ++index;
+      points[index] = start - perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 4
+      ++index;
+      points[index] = start - perpendic * (halfWidth-2*inset) + parallel * (inset + offset);  // 5
+      ++index;
    }
 
    // Pick a few selected points from those generated above to create an outline shape -- note that we need to reverse the winding

--- a/zap/speedZone.cpp
+++ b/zap/speedZone.cpp
@@ -165,18 +165,12 @@ void SpeedZone::generatePoints(const Point &start, const Point &end, Vector<Poin
       F32 offset = halfWidth * 2 * i - (i * 4);
 
       // Red chevron -- iterate twice to generate pair
-      points[index] = start + parallel *  (chevronThickness + offset);  // 0
-      ++index;
-      points[index] = start + perpendic * (halfWidth-2*inset) + parallel * (inset + offset);   // 1                      //  1   2
-      ++index;
-      points[index] = start + perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 2    //    0    3
-      ++index;
-      points[index] = start + parallel *  (chevronDepth + chevronThickness + inset + offset);  // 3                      //  5    4
-      ++index;
-      points[index] = start - perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 4
-      ++index;
-      points[index] = start - perpendic * (halfWidth-2*inset) + parallel * (inset + offset);  // 5
-      ++index;
+      points[index++] = start + parallel *  (chevronThickness + offset);  // 0
+      points[index++] = start + perpendic * (halfWidth-2*inset) + parallel * (inset + offset);   // 1                      //  1   2
+      points[index++] = start + perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 2    //    0    3
+      points[index++] = start + parallel *  (chevronDepth + chevronThickness + inset + offset);  // 3                      //  5    4
+      points[index++] = start - perpendic * (halfWidth-2*inset) + parallel * (chevronThickness + inset + offset);  // 4
+      points[index++] = start - perpendic * (halfWidth-2*inset) + parallel * (inset + offset);  // 5
    }
 
    // Pick a few selected points from those generated above to create an outline shape -- note that we need to reverse the winding

--- a/zap/speedZone.cpp
+++ b/zap/speedZone.cpp
@@ -160,7 +160,7 @@ void SpeedZone::generatePoints(const Point &start, const Point &end, Vector<Poin
 
    S32 index = 0;
 
-   for(S32 i = 0; i < 2; i++)
+   for(S32 i = 0; i < 2; ++i)
    {
       F32 offset = halfWidth * 2 * i - (i * 4);
 
@@ -278,7 +278,7 @@ bool SpeedZone::processArguments(S32 argc2, const char **argv2, Game *game)
    S32 argc = 0;
    const char *argv[8];                // 8 is ok, SpeedZone only supports 4 numbered args
 
-   for(S32 i = 0; i < argc2; i++)      // The idea here is to allow optional R3.5 for rotate at speed of 3.5
+   for(S32 i = 0; i < argc2; ++i)      // The idea here is to allow optional R3.5 for rotate at speed of 3.5
    {
       char firstChar = argv2[i][0];    // First character of arg
 
@@ -296,7 +296,8 @@ bool SpeedZone::processArguments(S32 argc2, const char **argv2, Game *game)
          if(argc < 8)
          {
             argv[argc] = argv2[i];
-            argc++;
+            ++argc;
+
          }
       }
    }
@@ -541,7 +542,8 @@ void SpeedZone::unpackUpdate(GhostConnection *connection, BitStream *stream)
    {
       Point pos, dir;
 
-      mUnpackInit++;
+      ++mUnpackInit;
+
 
       pos.read(stream);
       dir.read(stream);

--- a/zap/statistics.cpp
+++ b/zap/statistics.cpp
@@ -35,21 +35,24 @@ Statistics::~Statistics()
 void Statistics::countShot(WeaponType weaponType)
 {
    TNLAssert(weaponType < WeaponCount, "Out of range");
-   mShots[(S32) weaponType]++;
+   ++mShots[(S32) weaponType];
+
 }
 
 
 void Statistics::countHit(WeaponType weaponType)
 {
    TNLAssert(weaponType < WeaponCount, "Out of range");
-   mHits[(S32) weaponType]++;
+   ++mHits[(S32) weaponType];
+
 }
 
 
 void Statistics::countHitBy(WeaponType weaponType)
 {
    TNLAssert(weaponType < WeaponCount, "Out of range");
-   mHitBy[(S32) weaponType]++;
+   ++mHitBy[(S32) weaponType];
+
 }
 
 
@@ -57,7 +60,7 @@ S32 Statistics::getShots()
 {
    S32 totalShots = 0;
 
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
       totalShots += mShots[i];
 
    return totalShots;
@@ -74,7 +77,7 @@ Vector<U32> Statistics::getShotsVector()
 {
    Vector<U32>(shots);
    shots.resize(WeaponCount);
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
       shots[i] = mShots[i];
    return shots;
 }
@@ -84,7 +87,7 @@ Vector<U32> Statistics::getHitsVector()
 {
    Vector<U32>(hits);
    hits.resize(WeaponCount);
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
       hits[i] = mHits[i];
    return hits;
 }
@@ -94,7 +97,7 @@ S32 Statistics::getHits()
 {
    S32 totalHits = 0;
 
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
       totalHits += mHits[i];
 
    return totalHits;
@@ -148,15 +151,18 @@ U32 Statistics::getModuleUsed(ShipModule module)
 
 void Statistics::addGamePlayed()
 {
-   mGamesPlayed++;
+   ++mGamesPlayed;
+
 }
 
 
 // Player killed another player
 void Statistics::addKill(U32 killStreak)
 {
-   mKills++;
-   mTotalKills++;
+   ++mKills;
+
+   ++mTotalKills;
+
    mLongestKillStreak = MAX(killStreak, mLongestKillStreak);
 }
 
@@ -171,8 +177,10 @@ U32 Statistics::getKills()
 // Player got killed
 void Statistics::addDeath()
 {
-   mDeaths++;
-   mTotalDeaths++;
+   ++mDeaths;
+
+   ++mTotalDeaths;
+
 }
 
 
@@ -192,8 +200,10 @@ U32 Statistics::getLongestKillStreak() const
 // Player killed self
 void Statistics::addSuicide()
 {
-   mSuicides++;
-   mTotalSuicides++;
+   ++mSuicides;
+
+   ++mTotalSuicides;
+
 }
 
 
@@ -207,8 +217,10 @@ U32 Statistics::getSuicides()
 // Player killed teammate
 void Statistics::addFratricide()
 {
-   mFratricides++;
-   mTotalFratricides++;
+   ++mFratricides;
+
+   ++mTotalFratricides;
+
 }
 
 
@@ -282,14 +294,14 @@ void Statistics::resetStatistics()
    mFratricides = 0;
    mDist = 0;
 
-   for(S32 i = 0; i < WeaponCount; i++)
+   for(S32 i = 0; i < WeaponCount; ++i)
    {
       mShots[i] = 0;
       mHits[i] = 0;
       mHitBy[i] = 0;
    }
 
-   for(S32 i = 0; i < ModuleCount; i++)
+   for(S32 i = 0; i < ModuleCount; ++i)
       mModuleUsedTime[i] = 0;
 
    mLoadouts.clear();

--- a/zap/stringUtils.cpp
+++ b/zap/stringUtils.cpp
@@ -222,7 +222,7 @@ bool caseInsensitiveStringCompare(const string &str1, const string &str2) {
 // Convert string to lower case
 string lcase(string strToConvert)      // Note that strToConvert is a copy of whatever was passed
 {
-   for(U32 i = 0; i < strToConvert.length(); i++)
+   for(U32 i = 0; i < strToConvert.length(); ++i)
       strToConvert[i] = toLower(strToConvert[i]);
    return strToConvert;
 }
@@ -231,7 +231,7 @@ string lcase(string strToConvert)      // Note that strToConvert is a copy of wh
 // Convert string to upper case
 string ucase(string strToConvert)
 {
-   for(U32 i = 0; i < strToConvert.length(); i++)
+   for(U32 i = 0; i < strToConvert.length(); ++i)
       strToConvert[i] = toUpper(strToConvert[i]);
    return strToConvert;
 }
@@ -255,7 +255,8 @@ bool isPositiveInteger(const char *str)
    {
       if(s[i] < '0' || s[i] > '9')
          return false;
-      i++;
+      ++i;
+
    }
 
    return true;
@@ -354,7 +355,8 @@ string formatMessage(const char *format, const Vector<StringTableEntry> &e, cons
             while(isDigit(*src))
             {
                index = index * 10 + (*src - '0');
-               src++;
+               ++src;
+
             }
 
             switch(*type)
@@ -425,7 +427,8 @@ Vector<string> parseString(const string &line)
             if(i + 1 < line.length() && line[i + 1] == '"')
             {
                current += '"';
-               i++;
+               ++i;
+
             }
             else
             {
@@ -496,7 +499,8 @@ void parseString(const char *inputString, Vector<string> &words, char separator)
       {
          word += inputString[isn];
       }
-      isn++;
+      ++isn;
+
    }
 
    words.push_back(trim(word));
@@ -530,20 +534,23 @@ const char *findPointerOfArg(const char *message, S32 count)
 
    // Skip leading whitespace
    while(message[cur] != '\0' && isspace((unsigned char)message[cur]))
-      cur++;
+      ++cur;
 
-   for(S32 i = 0; i < count; i++)
+
+   for(S32 i = 0; i < count; ++i)
    {
       if(message[cur] == '\0')    // End of string
          return &message[cur];
 
       // Skip current argument (non-whitespace)
       while(message[cur] != '\0' && !isspace((unsigned char)message[cur]))
-         cur++;
+         ++cur;
+
 
       // Skip whitespace separating this arg from the next
       while(message[cur] != '\0' && isspace((unsigned char)message[cur]))
-         cur++;
+         ++cur;
+
    }
 
    return &message[cur];
@@ -558,7 +565,7 @@ string concatenate(const Vector<string> &words, S32 startingWith)
       startingWith = 0;
 
    string concatenated = "";
-   for(S32 i = startingWith; i < words.size(); i++)
+   for(S32 i = startingWith; i < words.size(); ++i)
       concatenated += (i == startingWith ? "" : " ") + words[i];
 
    return concatenated;
@@ -570,7 +577,7 @@ string listToString(const Vector<string> &words, const string &separator)
 {
    string str = "";
 
-   for(S32 i = 0; i < words.size(); i++)
+   for(S32 i = 0; i < words.size(); ++i)
       str += words[i] + ((i < words.size() - 1) ? separator : "");
 
    return str;
@@ -653,7 +660,7 @@ bool getFilesFromFolder(const string &dir, Vector<string> &files, const string e
       {
          string extension = lcase(extractExtension(name));
 
-         for(S32 i = 0; i < extensionCount; i++)
+         for(S32 i = 0; i < extensionCount; ++i)
          {
             if(name.length() > extensions[i].length() + 1)  // +1 -> include the dot '.'
             {
@@ -685,7 +692,8 @@ bool safeFilename(const char *str)
    {
       if(chr == '\\' || chr == '/')
          return false;
-      i++;
+      ++i;
+
       chr = str[i];
    }
    return true;
@@ -832,10 +840,11 @@ S32 countCharInString(const string &source, char search)
 {
     S32 count = 0;
 
-    for(size_t i = 0; i < source.length(); i++)
+    for(size_t i = 0; i < source.length(); ++i)
     {
       if (source[i] == search)
-         count++;
+         ++count;
+
     }
     return count;
 }
@@ -860,7 +869,8 @@ string makeFilenameFromString(const char *levelname, bool allowLastDot)
             lastDotIndex = i;
          filename[i]='_';
       }
-      i++;
+      ++i;
+
    }
 
    filename[i] = 0;    // Null terminate
@@ -905,7 +915,8 @@ string replaceString(const char *in, const char *find, const char *replace)
       else
       {
          out += in[n];
-         n++;
+         ++n;
+
       }
    }
    return out;
@@ -929,7 +940,8 @@ string chopComment(const string &line)
          {
             // Check for escaped quote ""
             if(i + 1 < line.length() && line[i + 1] == '"')
-               i++;
+               ++i;
+
             else
                inQuotes = false;
          }
@@ -954,7 +966,8 @@ string writeLevelString(const char *in)
 
    int c = 0;
    while(in[c] != 0 && in[c] != '\"' && in[c] != '#' && !isSpace(in[c]))
-      c++;
+      ++c;
+
 
    if(in[c] == 0 && c != 0)
       return string(in);  // string does not need to be changed if not zero length and there is no space or any of: # "
@@ -1048,7 +1061,7 @@ bool stringContainsAllTheSameCharacter(const string &str)
    if(str.size() <= 1)
       return true;
 
-   for(string::size_type i = 1; i < str.size(); i++)
+   for(string::size_type i = 1; i < str.size(); ++i)
       if(str[i] != str[0])
          return false;
 
@@ -1096,7 +1109,7 @@ bool isHex(const string &str)
    if(str.empty())
       return false;
 
-   for(string::size_type i = 0; i < str.length(); i++)
+   for(string::size_type i = 0; i < str.length(); ++i)
       if(!TNL::isHex(str[i]))
          return false;
 
@@ -1125,17 +1138,21 @@ bool alphaNumberSort(const string &a, const string &b)
          // Compare numeric segments
          size_t start_a = ia;
          while(ia < size_a && a[ia] == '0')
-            ia++;
+            ++ia;
+
          size_t end_a = ia;
          while(end_a < size_a && isDigit(a[end_a]))
-            end_a++;
+            ++end_a;
+
 
          size_t start_b = ib;
          while(ib < size_b && b[ib] == '0')
-            ib++;
+            ++ib;
+
          size_t end_b = ib;
          while(end_b < size_b && isDigit(b[end_b]))
-            end_b++;
+            ++end_b;
+
 
          size_t len_a = end_a - ia;
          size_t len_b = end_b - ib;
@@ -1145,7 +1162,7 @@ bool alphaNumberSort(const string &a, const string &b)
             return len_a < len_b;
 
          // Same number of digits, compare them one by one
-         for(size_t i = 0; i < len_a; i++)
+         for(size_t i = 0; i < len_a; ++i)
          {
             if(a[ia + i] != b[ib + i])
                return a[ia + i] < b[ib + i];
@@ -1170,8 +1187,10 @@ bool alphaNumberSort(const string &a, const string &b)
          if(ca != cb)
             return (unsigned char)ca < (unsigned char)cb;
 
-         ia++;
-         ib++;
+         ++ia;
+
+         ++ib;
+
       }
    }
 

--- a/zap/teamInfo.cpp
+++ b/zap/teamInfo.cpp
@@ -238,14 +238,16 @@ S32 Team::getPlayerBotCount() const
 
 void Team::incrementPlayerCount()
 {
-   mPlayerCount++;
+   ++mPlayerCount;
+
 }
 
 
 // This should definitely NOT be a public method...
 void Team::incrementBotCount()
 {
-   mBotCount++;
+   ++mBotCount;
+
 }
 
 
@@ -362,14 +364,14 @@ S32 Team::lua_getPlayers(lua_State *L)
 
    lua_newtable(L);    // Create a table, with no slots pre-allocated for our data
 
-   for(S32 i = 0; i < game->getClientCount(); i++)
+   for(S32 i = 0; i < game->getClientCount(); ++i)
    {
       ClientInfo *clientInfo = game->getClientInfo(i);
 
       if(clientInfo->getTeamIndex() == mTeamIndex)
       {
          clientInfo->getPlayerInfo()->push(L);
-         pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+         ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
          lua_rawseti(L, 1, pushed);
       }
    }
@@ -379,7 +381,7 @@ S32 Team::lua_getPlayers(lua_State *L)
       if(game->getBot(i)->getTeam() == mTeamIndex)
       {
          game->getBot(i)->getPlayerInfo()->push(L);
-         pushed++;      // Increment pushed before using it because Lua uses 1-based arrays
+         ++pushed;      // Increment pushed before using it because Lua uses 1-based arrays
          lua_rawseti(L, 1, pushed);
       }
    }
@@ -514,7 +516,7 @@ void TeamManager::setTeamHasFlag(S32 teamIndex, bool hasFlag)
 
 void TeamManager::clearTeamHasFlagList()
 {
-   for(S32 i = 0; i < mTeamHasFlagList.size(); i++)
+   for(S32 i = 0; i < mTeamHasFlagList.size(); ++i)
       mTeamHasFlagList[i] = 0;
 }
 
@@ -539,7 +541,7 @@ S32 TeamManager::getBotCount() const
 {
    S32 bots = 0;
 
-   for(S32 i = 0; i < mTeams.size(); i++)
+   for(S32 i = 0; i < mTeams.size(); ++i)
       bots += mTeams[i]->getBotCount();
 
    return bots;

--- a/zap/voiceCodec.cpp
+++ b/zap/voiceCodec.cpp
@@ -112,7 +112,8 @@ ByteBufferPtr VoiceDecoder::decompressBuffer(const ByteBufferPtr &compressedBuff
       // Decode a frame and advance our buffer offset
       bufferOffset = decompressFrame(decodedBufferPtr + frameCount * samplesPerFrame, compressedBufferPtr + i, compressedSize - i);
 
-      frameCount++;
+      ++frameCount;
+
    }
 
    // Finally resize the buffer to correspond to how many frames we've decompressed

--- a/zap/zoneControlGame.cpp
+++ b/zap/zoneControlGame.cpp
@@ -141,7 +141,7 @@ void ZoneControlGameType::shipTouchZone(Ship *s, GoalZone *z)
    updateScore(s, CaptureZone);
 
    // Does team control all zones? ...
-   for(S32 i = 0; i < zoneCount; i++)
+   for(S32 i = 0; i < zoneCount; ++i)
       if(static_cast<GoalZone *>(zones->get(i))->getTeam() != s->getTeam())   // ...no?...
          return;                                                              // ...then bail
 
@@ -151,7 +151,7 @@ void ZoneControlGameType::shipTouchZone(Ship *s, GoalZone *z)
    e.push_back(getGame()->getTeamName(s->getTeam()));
 
 
-   for(S32 i = 0; i < getGame()->getClientCount(); i++)
+   for(S32 i = 0; i < getGame()->getClientCount(); ++i)
    {
       GameConnection *gc = getGame()->getClientInfo(i)->getConnection();
       if(gc)
@@ -173,7 +173,7 @@ void ZoneControlGameType::shipTouchZone(Ship *s, GoalZone *z)
       if(mPossibleZcBadgeAchiever == NULL)
          mPossibleZcBadgeAchiever = static_cast<GoalZone *>(zones->first())->getCapturer();
 
-      for(S32 i = 0; i < zoneCount; i++)
+      for(S32 i = 0; i < zoneCount; ++i)
       {
          if(static_cast<GoalZone *>(zones->get(i))->getCapturer() != mPossibleZcBadgeAchiever)
          {
@@ -184,7 +184,7 @@ void ZoneControlGameType::shipTouchZone(Ship *s, GoalZone *z)
    }
 
    // Reset zones to neutral
-   for(S32 i = 0; i < zoneCount; i++)
+   for(S32 i = 0; i < zoneCount; ++i)
    {
       GoalZone *zone = static_cast<GoalZone *>(zones->get(i));
 
@@ -193,7 +193,7 @@ void ZoneControlGameType::shipTouchZone(Ship *s, GoalZone *z)
    }
 
    // Return the flag to spawn point
-   for(S32 i = 0; i < s->getMountedItemCount(); i++)
+   for(S32 i = 0; i < s->getMountedItemCount(); ++i)
    {
       MountableItem *item = s->getMountedItem(i);
       if(item->getObjectTypeNumber() != FlagTypeNumber)
@@ -217,7 +217,7 @@ void ZoneControlGameType::performProxyScopeQuery(BfObject *scopeObject, ClientIn
    S32 uTeam = scopeObject->getTeam();
 
    const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
-   for(S32 i = 0; i < flags->size(); i++)
+   for(S32 i = 0; i < flags->size(); ++i)
    {
       FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
 
@@ -255,7 +255,7 @@ void ZoneControlGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeig
    if(localClientHasFlag)
    {
       // Show all the GoalZones to go to
-      for(S32 i = 0; i < zoneCount; i++)
+      for(S32 i = 0; i < zoneCount; ++i)
       {
          GoalZone *zone = static_cast<GoalZone *>(zones->get(i));
 
@@ -270,7 +270,7 @@ void ZoneControlGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeig
       const Vector<DatabaseObject *> *flags = getGame()->getGameObjDatabase()->findObjects_fast(FlagTypeNumber);
 
       // Show all flags that can be picked up or is on the ship
-      for(S32 i = 0; i < flags->size(); i++)
+      for(S32 i = 0; i < flags->size(); ++i)
       {
          FlagItem *flag = static_cast<FlagItem *>(flags->get(i));
          if(flag->getTeam() == TEAM_NEUTRAL || flag->getTeam() == ship->getTeam() || flag->isMounted())
@@ -284,7 +284,7 @@ void ZoneControlGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeig
       }
 
       S32 whichTeamHasFlag = -1;
-      for(S32 i = getGame()->getTeamCount() - 1; i >= 0; i--)
+      for(S32 i = getGame()->getTeamCount() - 1; i >= 0; --i)
          if(getGame()->getTeamHasFlag(i))
          {
             if(whichTeamHasFlag != -1)
@@ -297,7 +297,7 @@ void ZoneControlGameType::renderInterfaceOverlay(S32 canvasWidth, S32 canvasHeig
 
       // Show all zones the ship holding flag can go to
       if(whichTeamHasFlag != -1)
-         for(S32 i = 0; i < zoneCount; i++)
+         for(S32 i = 0; i < zoneCount; ++i)
          {
             GoalZone *zone = static_cast<GoalZone *>(zones->get(i));
 
@@ -345,7 +345,7 @@ void ZoneControlGameType::majorScoringEventOccurred(S32 team)
    const Vector<DatabaseObject *> *goalZones = getGame()->getGameObjDatabase()->findObjects_fast(GoalZoneTypeNumber);
 
    // ...and make sure they're not flashing...
-   for(S32 i = 0; i < goalZones->size(); i++)
+   for(S32 i = 0; i < goalZones->size(); ++i)
    {
       GoalZone *goalZone = static_cast<GoalZone *>(goalZones->get(i));
       if(goalZone)


### PR DESCRIPTION
Replaces post-increment and post-decrement operations with pre-increment and pre-decrement where applicable to avoid the performance overhead of temporary copies, depending on compiler optimizations and user-defined types.

Caches loop invariants outside the condition statement so that the same value return isn't recomputed on every iteration, potentially reducing condition check time complexity  $T_M \in \Theta (n)$ to $\Theta (1)$.