### PR TITLE
Change iterator post-increments to pre-increments

### DIFF
--- a/bitfighter_test/TestGeomUtils.cpp
+++ b/bitfighter_test/TestGeomUtils.cpp
@@ -37,7 +37,7 @@ void parsePoly(const char* lines[], S32 size, Vector<Point> &result)
 	}
 
 	// maps are sorted by key on insertion
-	for(map<char, Point>::iterator it = points.begin(); it != points.end(); it++)
+	for(map<char, Point>::iterator it = points.begin(); it != points.end(); ++it) // ++it more efficient
 	{
 		result.push_back((*it).second);
 	}

--- a/zap/EditorPlugin.cpp
+++ b/zap/EditorPlugin.cpp
@@ -338,7 +338,7 @@ S32 EditorPlugin::lua_getSelectedObjects(lua_State *L)
    S32 pushed = 0;
 
    map<U32, BfObject*>::iterator it;
-   for(it = orderedSelectedItems.begin(); it != orderedSelectedItems.end(); it++)
+   for(it = orderedSelectedItems.begin(); it != orderedSelectedItems.end(); ++it) // ++it more efficient
    {
       BfObject *obj = (*it).second;
       obj->push(L);

--- a/zap/HttpRequest.cpp
+++ b/zap/HttpRequest.cpp
@@ -185,7 +185,7 @@ string HttpRequest::urlEncode(const string& str)
    string result;
    string::const_iterator it;
 
-   for(it = str.begin(); it < str.end(); it++)
+   for(it = str.begin(); it < str.end(); ++it) // ++it more efficient
    {
       result += urlEncodeChar(*it);
    }
@@ -219,14 +219,14 @@ string HttpRequest::buildRequest()
    if(mMethod == PostMethod)
    {
       stringstream encodedData("");
-      for(map<string, string>::iterator it = mData.begin(); it != mData.end(); it++)
+      for(map<string, string>::iterator it = mData.begin(); it != mData.end(); ++it) // ++it more efficient
       {
          encodedData << "--" + HttpRequestBoundary + "\r\n";
          encodedData << "Content-Disposition: form-data; name=\"" + (*it).first + "\"\r\n\r\n";
          encodedData << (*it).second + "\r\n";
       }
 
-      for(list<HttpRequestFileInfo>::iterator it = mFiles.begin(); it != mFiles.end(); it++)
+      for(list<HttpRequestFileInfo>::iterator it = mFiles.begin(); it != mFiles.end(); ++it) // ++it more efficient
       {
          stringstream fileData;
          fileData.write((const char*) (*it).data, (*it).length);

--- a/zap/LuaScriptRunner.cpp
+++ b/zap/LuaScriptRunner.cpp
@@ -1116,7 +1116,7 @@ void LuaScriptRunner::registerLooseFunctions(lua_State *L)
    ProfileMap moduleProfiles = LuaModuleRegistrarBase::getModuleProfiles();
 
    ProfileMap::iterator it;
-   for(it = moduleProfiles.begin(); it != moduleProfiles.end(); it++)
+   for(it = moduleProfiles.begin(); it != moduleProfiles.end(); ++it) // ++it more efficient
    {
       if((*it).first == "global")
       {

--- a/zap/UIMenus.cpp
+++ b/zap/UIMenus.cpp
@@ -1275,7 +1275,7 @@ static void addControllerOptions(Vector<string> *opts)
 
    map<S32,string>::iterator it;
    for(it = GameSettings::DetectedControllerList.begin();
-         it != GameSettings::DetectedControllerList.end(); it++)
+         it != GameSettings::DetectedControllerList.end(); ++it) // ++it more efficient
    {
       // Not too long of a string or we'll overflow the menu option
       string name = it->second;


### PR DESCRIPTION
Updated iterator loops in bitfighter_test/TestGeomUtils.cpp, zap/EditorPlugin.cpp, zap/HttpRequest.cpp, zap/LuaScriptRunner.cpp, and zap/UIMenus.cpp to use pre-increment ++it along with an inline comment explaining that ++it is more efficient.

---
*PR created automatically by Jules for task [5505310730935638588](https://jules.google.com/task/5505310730935638588) started by @eykamp*