### PR TITLE
Document Gatekeeper Open Anyway for unsigned macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ The fast-paced team-based outer-space multi-player arcade game. Blast your frien
 
 ## [Download](http://bitfighter.org/downloads/) | [Discord](https://discord.gg/3sdzjkz) | [Wiki](http://bitfighter.org/wiki/index.php?title=Main_Page) | [Forum](http://bitfighter.org/forums/viewforum.php?f=4)
 
-macOS CI builds are not notarized. If Gatekeeper blocks Bitfighter, see [INSTALLATION AND PACKAGING &rarr; macOS](#macos).
-
 ## DEPENDENCIES
 
 Bitfighter has several common, open source dependencies:
@@ -113,8 +111,7 @@ and re-points the load commands.  Homebrew currently ships SDL2 as **sdl2-compat
 which `dlopen`s `libSDL3` at runtime; that library is also copied into
 `Frameworks` (dylibbundler cannot see dlopen deps).  The bundle is **ad-hoc
 signed**, so Gatekeeper will block it on first launch.  See [macOS](#macos)
-below for how to open it; Developer ID signing and notarization are a
-separate step.
+below for how to open it.
 
 To build the Intel client under Rosetta instead (using the bundled `lib/`
 frameworks), configure with `cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The fast-paced team-based outer-space multi-player arcade game. Blast your frien
 
 ## [Download](http://bitfighter.org/downloads/) | [Discord](https://discord.gg/3sdzjkz) | [Wiki](http://bitfighter.org/wiki/index.php?title=Main_Page) | [Forum](http://bitfighter.org/forums/viewforum.php?f=4)
 
+macOS CI builds are not notarized. If Gatekeeper blocks Bitfighter, see [INSTALLATION AND PACKAGING &rarr; macOS](#macos).
+
 ## DEPENDENCIES
 
 Bitfighter has several common, open source dependencies:
@@ -110,8 +112,9 @@ This copies the dependent dylibs into `Contents/Frameworks` (via `dylibbundler`)
 and re-points the load commands.  Homebrew currently ships SDL2 as **sdl2-compat**,
 which `dlopen`s `libSDL3` at runtime; that library is also copied into
 `Frameworks` (dylibbundler cannot see dlopen deps).  The bundle is **ad-hoc
-signed**, so other users must right-click &rarr; Open it the first time
-(Gatekeeper); Developer ID signing and notarization are a separate step.
+signed**, so Gatekeeper will block it on first launch.  See [macOS](#macos)
+below for how to open it; Developer ID signing and notarization are a
+separate step.
 
 To build the Intel client under Rosetta instead (using the bundled `lib/`
 frameworks), configure with `cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64`.
@@ -135,6 +138,21 @@ This will build a self-extracting installer for Bitfighter. You will need to bui
 
 ### macOS
 Run `make package` to build a distributable DMG.
+
+The packaged `.dmg` (from `make package` or CI) is ad-hoc signed, not
+notarized. On first launch macOS will refuse to open it (Gatekeeper):
+
+1. Double-click Bitfighter.app. When the warning appears, click **Done**
+   (do not Move to Trash).
+2. Open **System Settings &rarr; Privacy & Security** and scroll to
+   **Security**.
+3. Click **Open Anyway** next to the Bitfighter blocked message, then
+   authenticate.
+
+You only need to do this once. On macOS 15 (Sequoia) and later, the old
+right-click &rarr; Open bypass no longer works.
+
+[Open a Mac app from an unknown developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac)
 
 ## CRASHES & PROBLEMS
 If you are building from the `master` branch, then expect crashes and problems. Feel free to report them via the Issues tab, but consider joining the Discord and checking in the dev_irc channel to ask a developer about it -- we probably are already aware.


### PR DESCRIPTION
## Summary

macOS CI/package DMGs are ad-hoc signed, so Gatekeeper blocks first launch. The README still told people to right-click → Open, which macOS 15 (Sequoia) removed. This replaces that with the current System Settings path.

## Changes

- Point the Apple Silicon packaging note at the install section instead of right-click → Open.
- Document first-launch steps under `INSTALLATION AND PACKAGING` → macOS: Done → System Settings → Privacy & Security → Open Anyway, plus Apple's support article.

## Validation

Opened the CD arm64 DMG on a Mac: the app runs after the Gatekeeper Open Anyway approval.