### PR TITLE
Fix C++17 and MySQL 8.0 build errors in mysql++

### DIFF
--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -66,6 +66,9 @@ set(MASTER_INCLUDES
 # Handle different compile of master if MySQL is found or minimal build is requested
 # Force
 if(MYSQL_FOUND AND NOT MASTER_MINIMAL)
+	set(MASTER_DEPS ${MASTER_DEPS} mysql++ PARENT_SCOPE)
+	set(MASTER_LIBS ${MASTER_LIBS} mysql++ ${MYSQL_LIBRARIES} PARENT_SCOPE)
+	set(MASTER_INCLUDES ${MASTER_INCLUDES} ../mysql++ ${MYSQL_INCLUDE_DIR} PARENT_SCOPE)
 	set(MASTER_DEPS ${MASTER_DEPS} mysql++)
 	set(MASTER_LIBS ${MASTER_LIBS} mysql++ ${MYSQL_LIBRARIES})
 	set(MASTER_INCLUDES ${MASTER_INCLUDES} ../mysql++ ${MYSQL_INCLUDE_DIR})

--- a/mysql++/beemutex.cpp
+++ b/mysql++/beemutex.cpp
@@ -61,7 +61,7 @@ namespace mysqlpp {
 #endif
 
 
-BeecryptMutex::BeecryptMutex() throw (MutexFailed)
+BeecryptMutex::BeecryptMutex()
 #if defined(ACTUALLY_DOES_SOMETHING)
 	: pmutex_(new bc_mutex_t)
 #endif
@@ -103,7 +103,7 @@ BeecryptMutex::~BeecryptMutex()
 
 
 void
-BeecryptMutex::lock() throw (MutexFailed)
+BeecryptMutex::lock()
 {
 #if defined(MYSQLPP_PLATFORM_WINDOWS)
 	if (WaitForSingleObject(impl_val(pmutex_), INFINITE) == WAIT_OBJECT_0)
@@ -125,7 +125,7 @@ BeecryptMutex::lock() throw (MutexFailed)
 
 
 bool
-BeecryptMutex::trylock() throw (MutexFailed)
+BeecryptMutex::trylock()
 {
 #if defined(ACTUALLY_DOES_SOMETHING)
 #	if defined(MYSQLPP_PLATFORM_WINDOWS)
@@ -160,7 +160,7 @@ BeecryptMutex::trylock() throw (MutexFailed)
 
 
 void
-BeecryptMutex::unlock() throw (MutexFailed)
+BeecryptMutex::unlock()
 {
 #if defined(MYSQLPP_PLATFORM_WINDOWS)
 	if (!ReleaseMutex(impl_val(pmutex_)))

--- a/mysql++/beemutex.h
+++ b/mysql++/beemutex.h
@@ -61,7 +61,7 @@ public:
 	///
 	/// Throws a MutexFailed exception if we can't acquire the lock for
 	/// some reason.  The exception contains a message saying why.
-	BeecryptMutex() throw (MutexFailed);
+	BeecryptMutex();
 
 	/// \brief Destroy the mutex
 	///
@@ -70,14 +70,14 @@ public:
 
 	/// \brief Acquire the mutex, blocking if it can't be acquired
 	/// immediately.
-	void lock() throw (MutexFailed);
+	void lock();
 
 	/// \brief Acquire the mutex immediately and return true, or return
 	/// false if it would have to block to acquire the mutex.
-	bool trylock() throw (MutexFailed);
+	bool trylock();
 
 	/// \brief Release the mutex
-	void unlock() throw (MutexFailed);
+	void unlock();
 
 private:
 	void* pmutex_;

--- a/mysql++/options.cpp
+++ b/mysql++/options.cpp
@@ -67,7 +67,7 @@ FoundRowsOption::set(DBDriver* dbd)
 Option::Error
 GuessConnectionOption::set(DBDriver* dbd)
 {
-#if MYSQL_VERSION_ID >= 40101
+#if MYSQL_VERSION_ID >= 40101 && defined(MYSQL_OPT_GUESS_CONNECTION)
 	return dbd->connected() ? Option::err_connected :
 			dbd->set_option(MYSQL_OPT_GUESS_CONNECTION) ?
 				Option::err_NONE : Option::err_api_reject;
@@ -259,7 +259,7 @@ ReportDataTruncationOption::set(DBDriver* dbd)
 Option::Error
 SecureAuthOption::set(DBDriver* dbd)
 {
-#if MYSQL_VERSION_ID >= 40101
+#if MYSQL_VERSION_ID >= 40101 && defined(MYSQL_SECURE_AUTH)
 	return dbd->connected() ? Option::err_connected :
 			dbd->set_option(MYSQL_SECURE_AUTH, &arg_) ?
 				Option::err_NONE : Option::err_api_reject;
@@ -290,7 +290,7 @@ SetCharsetNameOption::set(DBDriver* dbd)
 Option::Error
 SetClientIpOption::set(DBDriver* dbd)
 {
-#if MYSQL_VERSION_ID >= 40101
+#if MYSQL_VERSION_ID >= 40101 && defined(MYSQL_SET_CLIENT_IP)
 	return dbd->connected() ? Option::err_connected :
 			dbd->set_option(MYSQL_SET_CLIENT_IP, arg_.c_str()) ?
 				Option::err_NONE : Option::err_api_reject;
@@ -335,7 +335,7 @@ SslOption::set(DBDriver* dbd)
 Option::Error
 UseEmbeddedConnectionOption::set(DBDriver* dbd)
 {
-#if MYSQL_VERSION_ID >= 40101
+#if MYSQL_VERSION_ID >= 40101 && defined(MYSQL_OPT_USE_EMBEDDED_CONNECTION)
 	return dbd->connected() ? Option::err_connected :
 			dbd->set_option(MYSQL_OPT_USE_EMBEDDED_CONNECTION) ?
 				Option::err_NONE : Option::err_api_reject;
@@ -348,7 +348,7 @@ UseEmbeddedConnectionOption::set(DBDriver* dbd)
 Option::Error
 UseRemoteConnectionOption::set(DBDriver* dbd)
 {
-#if MYSQL_VERSION_ID >= 40101
+#if MYSQL_VERSION_ID >= 40101 && defined(MYSQL_OPT_USE_REMOTE_CONNECTION)
 	return dbd->connected() ? Option::err_connected :
 			dbd->set_option(MYSQL_OPT_USE_REMOTE_CONNECTION) ?
 				Option::err_NONE : Option::err_api_reject;

--- a/mysql++/stadapter.cpp
+++ b/mysql++/stadapter.cpp
@@ -416,7 +416,7 @@ SQLTypeAdapter::assign(const null_type&)
 }
 
 char
-SQLTypeAdapter::at(size_type i) const throw(std::out_of_range)
+SQLTypeAdapter::at(size_type i) const
 {
 	if (buffer_) {
 		if (i <= length()) {

--- a/mysql++/stadapter.h
+++ b/mysql++/stadapter.h
@@ -221,7 +221,7 @@ public:
 	/// WARNING: The throw-spec is incorrect, but it can't be changed
 	/// until v4, where we can break the ABI.  Throw-specs shouldn't be
 	/// relied on anyway.
-	char at(size_type i) const throw(std::out_of_range);
+	char at(size_type i) const;
 
 	/// \brief Compare the internal buffer to the given string
 	///

--- a/zap/bitfighter_test.cmake
+++ b/zap/bitfighter_test.cmake
@@ -82,6 +82,7 @@ endif()
 target_link_libraries(bitfighter_test
 	${CLIENT_LIBS}
 	${SHARED_LIBS}
+	${MASTER_LIBS}
 	GTest::gtest
 )
 
@@ -89,6 +90,7 @@ add_dependencies(bitfighter_test
 	bitfighter_client
 	master_lib
 	gtest
+	${MASTER_DEPS}
 )
 
 # Help CLion associate this target with gtest for gutter-run icon detection.


### PR DESCRIPTION
Fixed C++17 compilation errors in `mysql++` caused by dynamic exception specifications (`throw(...)`) and updated option setters to guard against removed MySQL 8.0 C API constants.

---
*PR created automatically by Jules for task [6544611972146475989](https://jules.google.com/task/6544611972146475989) started by @eykamp*