### PR TITLE
Build bitfighterd and tnlping in Linux CI

### DIFF
--- a/.github/workflows/BuildPackages.yml
+++ b/.github/workflows/BuildPackages.yml
@@ -11,7 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update && sudo apt-get install -y cmake libphysfs-dev libsdl2-dev libopenal-dev libvorbis-dev libmodplug-dev libspeex-dev libpng-dev
-      - run: cd build && cmake .. && make
+      - run: |
+          cd build
+          cmake ..
+          make
+          # bitfighterd and tnlping are EXCLUDE_FROM_ALL; default make skips them
+          make bitfighterd tnlping
       - run: cp -R resource/* exe/
       - uses: actions/upload-artifact@v4.6.2
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,8 @@ jobs:
           cd build
           cmake ..
           make
+          # bitfighterd and tnlping are EXCLUDE_FROM_ALL; default make skips them
+          make bitfighterd tnlping
       - name: Copy resources
         run: cp -R resource/* exe/
 

--- a/bitfighter_test/TestGeomUtilsSafety.cpp
+++ b/bitfighter_test/TestGeomUtilsSafety.cpp
@@ -33,9 +33,8 @@ TEST(GeomUtilsSafetyTest, polygonCircleIntersectEmpty)
    Point vertices[1];
    Point outPoint;
    EXPECT_FALSE(polygonCircleIntersect(vertices, 0, Point(0, 0), 10.0f, outPoint));
-  
+
    Vector<Point> empty;
-   Point outPoint;
    EXPECT_FALSE(polygonCircleIntersect(empty.address(), empty.size(), Point(0, 0), 10.0f, outPoint));
 }
 


### PR DESCRIPTION
Depends on #840 (merge that first). GitHub will not retarget this PR onto the fix branch: stacked PRs are not enabled on this repo, and `fix/geom-utils-safety-redecl` exists only on the fork.

Incremental diff vs #840: https://github.com/bitfighter/bitfighter/compare/tomholford:fix/geom-utils-safety-redecl...tomholford:feat/bitfighterd-ci

## Summary

`bitfighterd` and `tnlping` are `EXCLUDE_FROM_ALL`, so Linux `make` in CI never compiled them. The dedicated server is the next packaging target (Docker/GHCR stack); this PR makes the Linux jobs actually build those binaries first.

## Changes

- `validate.yml` Linux job: `make bitfighterd tnlping` after the default `make`.
- `BuildPackages.yml` Linux job: same, so the uploaded `exe/` artifact includes the dedicated server and ping helper.

## Validation

TODO: Linux CI on this PR — both jobs should compile `exe/bitfighterd` and `exe/tnlping`. Blocked until #840 makes default `make` succeed.

## Post-Merge

- Next stack layer: dedicated-server Dockerfile, then compose example, then `ghcr.io/bitfighter/bitfighterd` publish.