### PR TITLE
Fix GeomUtilsSafetyTest outPoint redecl

### DIFF
--- a/bitfighter_test/TestGeomUtilsSafety.cpp
+++ b/bitfighter_test/TestGeomUtilsSafety.cpp
@@ -33,9 +33,8 @@ TEST(GeomUtilsSafetyTest, polygonCircleIntersectEmpty)
    Point vertices[1];
    Point outPoint;
    EXPECT_FALSE(polygonCircleIntersect(vertices, 0, Point(0, 0), 10.0f, outPoint));
-  
+
    Vector<Point> empty;
-   Point outPoint;
    EXPECT_FALSE(polygonCircleIntersect(empty.address(), empty.size(), Point(0, 0), 10.0f, outPoint));
 }
 


### PR DESCRIPTION
polygonCircleIntersectEmpty declared `Point outPoint` twice. That fails to compile (`redeclaration` / `redefinition`) and has kept master CI red since #786.

Reuse the first `outPoint` for both empty-polygon calls. No behavior change.

## Validation

Local:

```
cmake --build build --target bitfighter_test
cd exe && ./bitfighter_test --gtest_filter=GeomUtilsSafetyTest.*
```

9/9 passed.

CI: all four jobs green — Validate Code and Build Packages on Linux and macOS-arm64.